### PR TITLE
Add support for adding the `#[Override]` attribute to methods implementing interfaces

### DIFF
--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/AddToInterfaceMethodsTest.php
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/AddToInterfaceMethodsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddToInterfaceMethodsTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureAddToInterfaceMethods');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/add_to_interface_methods_configured_rule.php';
+    }
+}

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_countable.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_countable.php.inc
@@ -2,10 +2,12 @@
 
 namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
 
-final class SkipOnInterface implements \Stringable
+use Countable;
+
+final class SkipCountable implements Countable
 {
-    public function __toString(): string
+    public function count(): int
     {
-        return 'implements only';
+        return 0;
     }
 }

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_interface.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_interface.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromInterface;
+
+final class SkipInterface implements ExampleFromInterface
+{
+    public function foo()
+    {
+        return 'implements only';
+    }
+}

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_interface_mixed_usage.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_interface_mixed_usage.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromAnotherInterface;
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleParentClass;
+
+final class SkipInterfaceMixedUsage extends ExampleParentClass implements ExampleFromAnotherInterface
+{
+    public function foo()
+    {
+        return 'overrides method';
+    }
+
+    public function baz()
+    {
+        return 'implements only';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromAnotherInterface;
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleParentClass;
+
+final class SkipInterfaceMixedUsage extends ExampleParentClass implements ExampleFromAnotherInterface
+{
+    #[\Override]
+    public function foo()
+    {
+        return 'overrides method';
+    }
+
+    public function baz()
+    {
+        return 'implements only';
+    }
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_on_stringable_interface.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Fixture/skip_on_stringable_interface.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
+
+final class SkipOnStringableInterface implements \Stringable
+{
+    public function __toString(): string
+    {
+        return 'implements only';
+    }
+}

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/extends_abstract_parent.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/extends_abstract_parent.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\AbstractParentWithInterface;
+
+final class ExtendsAbstractParent extends AbstractParentWithInterface
+{
+    public function foo()
+    {
+        return true;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\AbstractParentWithInterface;
+
+final class ExtendsAbstractParent extends AbstractParentWithInterface
+{
+    #[\Override]
+    public function foo()
+    {
+        return true;
+    }
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/implement_built_in.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/implement_built_in.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Countable;
+
+final class ImplementBuiltIn implements Countable
+{
+    public function count(): int
+    {
+        return 0;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Countable;
+
+final class ImplementBuiltIn implements Countable
+{
+    #[\Override]
+    public function count(): int
+    {
+        return 0;
+    }
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/indirect_totring_override.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/indirect_totring_override.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\SomeClassImplementsToString;
+
+final class IndirectToStringOverride extends SomeClassImplementsToString
+{
+    public function __toString(): string
+    {
+        return 'hello';
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\SomeClassImplementsToString;
+
+final class IndirectToStringOverride extends SomeClassImplementsToString
+{
+    #[\Override]
+    public function __toString(): string
+    {
+        return 'hello';
+    }
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/interface_implement.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/interface_implement.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromInterface;
+
+final class InterfaceImplement implements ExampleFromInterface
+{
+    public function foo()
+    {
+        return true;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromInterface;
+
+final class InterfaceImplement implements ExampleFromInterface
+{
+    #[\Override]
+    public function foo()
+    {
+        return true;
+    }
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/interface_implement_multiple.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/interface_implement_multiple.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromAnotherInterface;
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromInterface;
+
+final class InterfaceImplementMultiple implements ExampleFromInterface, ExampleFromAnotherInterface
+{
+    public function foo()
+    {
+        return true;
+    }
+
+    public function baz()
+    {
+        return true;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromAnotherInterface;
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromInterface;
+
+final class InterfaceImplementMultiple implements ExampleFromInterface, ExampleFromAnotherInterface
+{
+    #[\Override]
+    public function foo()
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function baz()
+    {
+        return true;
+    }
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/normal_extends.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/normal_extends.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleParentClass;
+
+final class NormalExtends extends ExampleParentClass
+{
+    public function foo()
+    {
+        return true;
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleParentClass;
+
+final class NormalExtends extends ExampleParentClass
+{
+    #[\Override]
+    public function foo()
+    {
+        return true;
+    }
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/totring_override.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureAddToInterfaceMethods/totring_override.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Stringable;
+
+final class ToStringOverride implements Stringable
+{
+    public function __toString(): string
+    {
+        return 'hello';
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureAddToInterfaceMethods;
+
+use Stringable;
+
+final class ToStringOverride implements Stringable
+{
+    #[\Override]
+    public function __toString(): string
+    {
+        return 'hello';
+    }
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureOverrideEmptyMethod/skip_countable.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureOverrideEmptyMethod/skip_countable.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Fixture;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromInterface;
+use Countable;
+
+final class SkipCountable implements Countable
+{
+    public function count(): int
+    {
+        return 0;
+    }
+}

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureOverrideEmptyMethod/skip_countable_override_stringable.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureOverrideEmptyMethod/skip_countable_override_stringable.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureOverrideEmptyMethod;
+
+use Countable;
+use Stringable;
+
+final class SkipCountableOverrideStringable implements Countable, Stringable
+{
+    public function count(): int
+    {
+        return 0;
+    }
+
+    public function __toString()
+    {
+        return 'hello';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureOverrideEmptyMethod;
+
+use Countable;
+use Stringable;
+
+final class SkipCountableOverrideStringable implements Countable, Stringable
+{
+    public function count(): int
+    {
+        return 0;
+    }
+
+    #[\Override]
+    public function __toString()
+    {
+        return 'hello';
+    }
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureOverrideEmptyMethod/skip_implement_interface.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureOverrideEmptyMethod/skip_implement_interface.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureOverrideEmptyMethod;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromInterface;
+
+final class SkipImplementInterface implements ExampleFromInterface
+{
+    public function foo()
+    {
+        return true;
+    }
+}

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureOverrideEmptyMethod/totring_override_with_interface.php.inc
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/FixtureOverrideEmptyMethod/totring_override_with_interface.php.inc
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureOverrideEmptyMethod;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromInterface;
+use Stringable;
+
+final class ToStringOverrideWithInterface implements Stringable, ExampleFromInterface
+{
+    public function __toString(): string
+    {
+        return 'hello';
+    }
+
+    public function foo()
+    {
+        return 'implements only';
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\FixtureOverrideEmptyMethod;
+
+use Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source\ExampleFromInterface;
+use Stringable;
+
+final class ToStringOverrideWithInterface implements Stringable, ExampleFromInterface
+{
+    #[\Override]
+    public function __toString(): string
+    {
+        return 'hello';
+    }
+
+    public function foo()
+    {
+        return 'implements only';
+    }
+}
+
+?>

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/AbstractParentWithInterface.php
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/AbstractParentWithInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source;
+
+abstract class AbstractParentWithInterface implements ExampleFromInterface
+{
+
+}

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/ExampleFromAnotherInterface.php
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/Source/ExampleFromAnotherInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\Source;
+
+interface ExampleFromAnotherInterface
+{
+    public function baz();
+}

--- a/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/config/add_to_interface_methods_configured_rule.php
+++ b/rules-tests/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector/config/add_to_interface_methods_configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(AddOverrideAttributeToOverriddenMethodsRector::class, [
+        AddOverrideAttributeToOverriddenMethodsRector::ADD_TO_INTERFACE_METHODS => true,
+    ]);
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_83);
+};

--- a/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
+++ b/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
@@ -44,9 +44,16 @@ final class AddOverrideAttributeToOverriddenMethodsRector extends AbstractRector
      */
     public const string ALLOW_OVERRIDE_EMPTY_METHOD = 'allow_override_empty_method';
 
+    /**
+     * @api
+     */
+    public const string ADD_TO_INTERFACE_METHODS = 'add_to_interface_methods';
+
     private const string OVERRIDE_CLASS = 'Override';
 
     private bool $allowOverrideEmptyMethod = false;
+
+    private bool $addToInterfaceMethods = false;
 
     private bool $hasChanged = false;
 
@@ -107,6 +114,42 @@ CODE_SAMPLE
                         self::ALLOW_OVERRIDE_EMPTY_METHOD => false,
                     ]
                 ),
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+interface ParentInterface
+{
+    public function foo();
+}
+
+final class ChildClass implements ParentInterface
+{
+    public function foo()
+    {
+        echo 'implements interface';
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+interface ParentInterface
+{
+    public function foo();
+}
+
+final class ChildClass implements ParentInterface
+{
+    #[\Override]
+    public function foo()
+    {
+        echo 'implements interface';
+    }
+}
+CODE_SAMPLE
+                    ,
+                    [
+                        self::ADD_TO_INTERFACE_METHODS => true,
+                    ]
+                ),
             ]
         );
     }
@@ -125,6 +168,7 @@ CODE_SAMPLE
     public function configure(array $configuration): void
     {
         $this->allowOverrideEmptyMethod = $configuration[self::ALLOW_OVERRIDE_EMPTY_METHOD] ?? false;
+        $this->addToInterfaceMethods = $configuration[self::ADD_TO_INTERFACE_METHODS] ?? false;
     }
 
     /**
@@ -138,8 +182,7 @@ CODE_SAMPLE
             return null;
         }
 
-        // skip if no parents, nor traits, nor strinables are involved
-        if ($node->extends === null && $node->getTraitUses() === [] && ! $this->implementsStringable($node)) {
+        if ($this->shouldSkipNode($node)) {
             return null;
         }
 
@@ -151,15 +194,15 @@ CODE_SAMPLE
         $classReflection = $this->reflectionProvider->getClass($className);
         $parentClassReflections = $classReflection->getParents();
 
-        if ($this->allowOverrideEmptyMethod) {
-            $parentClassReflections = array_merge(
-                $parentClassReflections,
-                $classReflection->getInterfaces(),
+        // interfaces are added for Stringable
+        if ($this->addToInterfaceMethods || $this->allowOverrideEmptyMethod) {
+            $parentClassReflections = array_merge($parentClassReflections, $classReflection->getInterfaces());
+        }
 
-                // place on last to ensure verify method exists on parent early
-                // for non abstract method from trait
-                $classReflection->getTraits(),
-            );
+        if ($this->allowOverrideEmptyMethod) {
+            // place on last to ensure verify method exists on parent early
+            // for non abstract method from trait
+            $parentClassReflections = array_merge($parentClassReflections, $classReflection->getTraits());
         }
 
         if ($parentClassReflections === []) {
@@ -253,8 +296,14 @@ CODE_SAMPLE
 
     private function shouldSkipParentClassMethod(ClassReflection $parentClassReflection, ClassMethod $classMethod): bool
     {
-        if ($this->allowOverrideEmptyMethod && $parentClassReflection->isBuiltIn()) {
+        // special case for Stringable interface
+        if ($this->allowOverrideEmptyMethod && $parentClassReflection->getName() === 'Stringable') {
             return false;
+        }
+
+        // if the method is on interface, skip based on the config flag
+        if ($parentClassReflection->isInterface()) {
+            return ! $this->addToInterfaceMethods;
         }
 
         // parse parent method, if it has some contents or not
@@ -324,14 +373,30 @@ CODE_SAMPLE
         return null;
     }
 
-    private function implementsStringable(Class_ $class): bool
+    // early return for the class if it does not extend anything
+    private function shouldSkipNode(Class_ $class): bool
     {
-        foreach ($class->implements as $implement) {
-            if ($this->isName($implement, 'Stringable')) {
-                return true;
+        if ($class->extends !== null) {
+            return false;
+        }
+
+        if ($class->getTraitUses() !== []) {
+            return false;
+        }
+
+        if ($this->addToInterfaceMethods && $class->implements !== []) {
+            return false;
+        }
+
+        // add override to Stringable if flag is set
+        if ($this->allowOverrideEmptyMethod) {
+            foreach ($class->implements as $implement) {
+                if ($this->isName($implement, 'Stringable')) {
+                    return false;
+                }
             }
         }
 
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
This pull request adds an opt-in configuration flag to `AddOverrideAttributeToOverriddenMethodsRector` to also add `#[\Override]` on methods implementing interface methods.

The default behavior is unchanged. The existing special handling of `Stringable` in combination with `allow_override_empty_method` is preserved.

It also fixes an edge case where the presence of Stringable caused `#[\Override]` to be added to unrelated interface methods ([example 1](https://getrector.com/demo/ddbca850-e50f-4d3f-ae14-12f6f515ffb4), [example 2](https://getrector.com/demo/a8097999-9003-413c-b9a4-ff37a7bb4027)). Tests were added to prevent regressions.

Motivation:

- PHP accepts `#[\Override]` for both parent methods and implemented interface methods
- Some tooling expects or suggests the same behavior

This allows projects to opt in without affecting existing users.

New config:

```php
use Rector\Config\RectorConfig;
use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;

return RectorConfig::configure()
    ->withConfiguredRule(AddOverrideAttributeToOverriddenMethodsRector::class, [
        AddOverrideAttributeToOverriddenMethodsRector::ADD_TO_INTERFACE_METHODS => true,
    ]);
```

Fixes https://github.com/rectorphp/rector/issues/9699