### PR TITLE
chore: add SafeDeclareStrictTypesRector to code quality set

### DIFF
--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -84,6 +84,7 @@ use Rector\Php52\Rector\Property\VarToPublicPropertyRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 
 /**
  * Key 0 = level 0
@@ -183,7 +184,7 @@ final class CodeQualityLevel
         SortCallLikeNamedArgsRector::class,
         SortAttributeNamedArgsRector::class,
         RemoveReadonlyPropertyVisibilityOnReadonlyClassRector::class,
-        // SafeDeclareStrictTypesRector::class,
+        SafeDeclareStrictTypesRector::class,
     ];
 
     /**


### PR DESCRIPTION
I've been using this in prod for several months now with no bad effects---time to enable it for everyone?

Thanks!