### PR TITLE
Create spread_operator_stays.php.inc

### DIFF
--- a/rules-tests/Php85/Rector/Expression/NestedFuncCallsToPipeOperatorRector/Fixture/spread_operator_stays.php.inc
+++ b/rules-tests/Php85/Rector/Expression/NestedFuncCallsToPipeOperatorRector/Fixture/spread_operator_stays.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+$arrayOfArrays = [['a'], ['a'], ['b']];
+$merged = array_unique(array_merge(...$arrayOfArrays));
+
+?>
+-----
+<?php
+
+$merged = array_merge(...$arrayOfArrays)
+ |> array_unique(...);
+
+?>


### PR DESCRIPTION
The spread operator should not be removed when changing to pipe operator.

Fixture for [#9710](https://github.com/rectorphp/rector/issues/9710)