### PR TITLE
Create void-return-functions-with-side-effects.php.inc

### DIFF
--- a/rules-tests/DeadCode/Rector/Expression/RemoveDeadStmtRectorFixture/void-return-functions-with-side-effects.php.inc
+++ b/rules-tests/DeadCode/Rector/Expression/RemoveDeadStmtRectorFixture/void-return-functions-with-side-effects.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+is_string('foo')
+    |> assert(...);
+
+sprintf('echo "%s"', 'foo')
+    |> passthru(...);
+
+?>


### PR DESCRIPTION
the examples assert and passthru are void return functions with side effects and should not be removed.

Fixture for https://github.com/rectorphp/rector/issues/9707