### PR TITLE
 [Php85] Do not convert to pipe on use directly of spread operator on NestedFuncCallsToPipeOperatorRector

### DIFF
--- a/rules-tests/Php85/Rector/Expression/NestedFuncCallsToPipeOperatorRector/Fixture/spread_operator_stays.php.inc
+++ b/rules-tests/Php85/Rector/Expression/NestedFuncCallsToPipeOperatorRector/Fixture/spread_operator_stays.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+$arrayOfArrays = [['a'], ['a'], ['b']];
+$merged = array_unique(array_merge(...$arrayOfArrays));
+
+?>
+-----
+<?php
+
+$merged = array_merge(...$arrayOfArrays)
+ |> array_unique(...);
+
+?>

--- a/rules-tests/Php85/Rector/Expression/NestedFuncCallsToPipeOperatorRector/Fixture/spread_operator_stays.php.inc
+++ b/rules-tests/Php85/Rector/Expression/NestedFuncCallsToPipeOperatorRector/Fixture/spread_operator_stays.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+namespace Rector\Tests\Php85\Rector\Expression\NestedFuncCallsToPipeOperatorRector\Fixture;
+
 $arrayOfArrays = [['a'], ['a'], ['b']];
 $merged = array_unique(array_merge(...$arrayOfArrays));
 
@@ -7,7 +9,10 @@ $merged = array_unique(array_merge(...$arrayOfArrays));
 -----
 <?php
 
+namespace Rector\Tests\Php85\Rector\Expression\NestedFuncCallsToPipeOperatorRector\Fixture;
+
+$arrayOfArrays = [['a'], ['a'], ['b']];
 $merged = array_merge(...$arrayOfArrays)
- |> array_unique(...);
+    |> array_unique(...);
 
 ?>

--- a/rules/Php85/Rector/Expression/NestedFuncCallsToPipeOperatorRector.php
+++ b/rules/Php85/Rector/Expression/NestedFuncCallsToPipeOperatorRector.php
@@ -147,7 +147,7 @@ CODE_SAMPLE
             if ($deep) {
                 // Spread argument can't be converted to pipe — keep the call as-is
                 if ($arg->unpack) {
-                    return $expr;
+                    return null;
                 }
 
                 // Return a pipe with the base expression on the left

--- a/rules/Php85/Rector/Expression/NestedFuncCallsToPipeOperatorRector.php
+++ b/rules/Php85/Rector/Expression/NestedFuncCallsToPipeOperatorRector.php
@@ -145,6 +145,11 @@ CODE_SAMPLE
 
             // If we're deep in recursion and hit a non-FuncCall, this is the base
             if ($deep) {
+                // Spread argument can't be converted to pipe — keep the call as-is
+                if ($arg->unpack) {
+                    return $expr;
+                }
+
                 // Return a pipe with the base expression on the left
                 return new Pipe($arg->value, $this->createPlaceholderCall($expr));
             }

--- a/src/ChangesReporting/Output/JUnitOutputFormatter.php
+++ b/src/ChangesReporting/Output/JUnitOutputFormatter.php
@@ -57,16 +57,16 @@ final readonly class JUnitOutputFormatter implements OutputFormatterInterface
 
         $domDocument = new DOMDocument('1.0', 'UTF-8');
 
-        $xmlTestSuite = $domDocument->createElement(self::XML_ELEMENT_TESTSUITE);
-        $xmlTestSuite->setAttribute(self::XML_ATTRIBUTE_NAME, 'rector');
+        $domElement = $domDocument->createElement(self::XML_ELEMENT_TESTSUITE);
+        $domElement->setAttribute(self::XML_ATTRIBUTE_NAME, 'rector');
 
         $xmlTestSuites = $domDocument->createElement(self::XML_ELEMENT_TESTSUITES);
-        $xmlTestSuites->appendChild($xmlTestSuite);
+        $xmlTestSuites->appendChild($domElement);
 
         $domDocument->appendChild($xmlTestSuites);
 
-        $this->appendSystemErrors($processResult, $configuration, $domDocument, $xmlTestSuite);
-        $this->appendFileDiffs($processResult, $configuration, $domDocument, $xmlTestSuite);
+        $this->appendSystemErrors($processResult, $configuration, $domDocument, $domElement);
+        $this->appendFileDiffs($processResult, $configuration, $domDocument, $domElement);
 
         echo $domDocument->saveXML() . PHP_EOL;
     }


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/7936
Fixes https://github.com/rectorphp/rector/issues/9710