### PR TITLE
[patch-3] Create void-return-functions-with-side-effects.php.inc

### DIFF
--- a/rules-tests/DeadCode/Rector/Expression/RemoveDeadStmtRector/Fixture/void-return-functions-with-side-effects.php.inc
+++ b/rules-tests/DeadCode/Rector/Expression/RemoveDeadStmtRector/Fixture/void-return-functions-with-side-effects.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Expression\RemoveDeadStmtRector\Fixture;
+
+is_string('foo')
+    |> assert(...);
+
+sprintf('echo "%s"', 'foo')
+    |> passthru(...);
+
+?>


### PR DESCRIPTION
the examples assert and passthru are void return functions with side effects and should not be removed.

Test fixture for https://github.com/rectorphp/rector/issues/9707