### PR TITLE
feat(php86): add min/max to clamp rector

### DIFF
--- a/config/set/level/up-to-php86.php
+++ b/config/set/level/up-to-php86.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([SetList::PHP_86, LevelSetList::UP_TO_PHP_85]);
+};

--- a/config/set/php86.php
+++ b/config/set/php86.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+    ]);
+};

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -152,7 +152,7 @@ parameters:
         - '#Callable callable\(PHPStan\\Type\\Type\)\: PHPStan\\Type\\Type invoked with 2 parameters, 1 required#'
 
         # known value
-        - '#Method (.*?) should return 50200\|50300\|50400\|50500\|50600\|70000\|70100\|70200\|70300\|70400\|80000\|80100\|80200\|80300\|80400\|80500\|100000 but returns int#'
+        - '#Method (.*?) should return 50200\|50300\|50400\|50500\|50600\|70000\|70100\|70200\|70300\|70400\|80000\|80100\|80200\|80300\|80400\|80500\|80600\|100000 but returns int#'
 
         -
             message: '#Function "class_exists\(\)" cannot be used/left in the code#'
@@ -325,7 +325,7 @@ parameters:
             message: '#PHPDoc tag @var with type int is not subtype of native type array\|PHPStan\\PhpDocParser\\Ast\\ConstExpr\\ConstExprNode\|Rector\\BetterPhpDocParser\\PhpDoc\\DoctrineAnnotationTagValueNode\|Rector\\BetterPhpDocParser\\PhpDoc\\StringNode\|Rector\\BetterPhpDocParser\\ValueObject\\PhpDoc\\DoctrineAnnotation\\CurlyListNode\|string#'
             path: src/BetterPhpDocParser/PhpDocParser/StaticDoctrineAnnotationParser.php
 
-        - '#Parameter \#1 \$phpVersion of method Rector\\Config\\RectorConfig\:\:phpVersion\(\) expects 50200\|50300\|50400\|50500\|50600\|70000\|70100\|70200\|70300\|70400\|80000\|80100\|80200\|80300\|80400\|80500\|100000, 79999 given#'
+        - '#Parameter \#1 \$phpVersion of method Rector\\Config\\RectorConfig\:\:phpVersion\(\) expects 50200\|50300\|50400\|50500\|50600\|70000\|70100\|70200\|70300\|70400\|80000\|80100\|80200\|80300\|80400\|80500\|80600\|100000, 79999 given#'
 
         # node vs stmts mix
         - '#expects array<PhpParser\\Node\\Stmt>, array<PhpParser\\Node> given#'

--- a/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/Fixture/fixture.php.inc
+++ b/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/Fixture/fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Php86\Rector\FuncCall\MinMaxToClampRector\Fixture;
+
+$value = random_int(0, 100);
+
+max(0, min(100, $value));
+max(0, min($value, 100));
+max(min($value, 100), 0);
+max(min(100, $value), 0);
+
+min(100, max(0, $value));
+min(100, max($value, 0));
+min(max($value, 0), 100);
+min(max(0, $value), 100);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php86\Rector\FuncCall\MinMaxToClampRector\Fixture;
+
+$value = random_int(0, 100);
+
+clamp($value, 0, 100);
+clamp($value, 0, 100);
+clamp($value, 0, 100);
+clamp($value, 0, 100);
+
+clamp($value, 0, 100);
+clamp($value, 0, 100);
+clamp($value, 0, 100);
+clamp($value, 0, 100);
+
+?>

--- a/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/Fixture/known_variable_and_constant_bounds.php.inc
+++ b/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/Fixture/known_variable_and_constant_bounds.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Php86\Rector\FuncCall\MinMaxToClampRector\Fixture;
+
+$limit = 100;
+
+fn (int $value) => max(0, min(100, $value));
+fn (int $value) => max(0, min($limit, $value));
+fn (int $value) => max(0, min($value, $limit));
+fn (int $value) => max(PHP_INT_MIN, min(PHP_INT_MAX, $value));
+fn (string $value) => max('a', min('z', $value));
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php86\Rector\FuncCall\MinMaxToClampRector\Fixture;
+
+$limit = 100;
+
+fn (int $value) => clamp($value, 0, 100);
+fn (int $value) => clamp($value, 0, $limit);
+fn (int $value) => clamp($value, 0, $limit);
+fn (int $value) => clamp($value, PHP_INT_MIN, PHP_INT_MAX);
+fn (string $value) => clamp($value, 'a', 'z');
+
+?>

--- a/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/Fixture/outer_variable_inner_literal.php.inc
+++ b/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/Fixture/outer_variable_inner_literal.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php86\Rector\FuncCall\MinMaxToClampRector\Fixture;
+
+fn (int $value, int $min) => max($min, min(100, $value));
+fn (int $value, int $max) => min($max, max(0, $value));
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php86\Rector\FuncCall\MinMaxToClampRector\Fixture;
+
+fn (int $value, int $min) => clamp($value, $min, 100);
+fn (int $value, int $max) => clamp($value, 0, $max);
+
+?>

--- a/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/Fixture/skip_ambiguous_inner_order.php.inc
+++ b/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/Fixture/skip_ambiguous_inner_order.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+namespace Rector\Tests\Php86\Rector\FuncCall\MinMaxToClampRector\Fixture;
+
+fn (int $value, int $min, int $max) => max($min, min($value, $max));

--- a/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/Fixture/skip_same_function.php.inc
+++ b/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/Fixture/skip_same_function.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+namespace Rector\Tests\Php86\Rector\FuncCall\MinMaxToClampRector\Fixture;
+
+fn (int $value, int $min, int $max) => max($min, max($max, $value));
+fn (int $value, int $min, int $max) => min($min, min($max, $value));

--- a/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/MinMaxToClampRectorTest.php
+++ b/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/MinMaxToClampRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php86\Rector\FuncCall\MinMaxToClampRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class MinMaxToClampRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/config/configured_rule.php
+++ b/rules-tests/Php86/Rector/FuncCall/MinMaxToClampRector/config/configured_rule.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php86\Rector\FuncCall\MinMaxToClampRector;
+use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rules([MinMaxToClampRector::class]);
+    $rectorConfig->rule(MinMaxToClampRector::class);
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_86);
 };

--- a/rules/Php86/Rector/FuncCall/MinMaxToClampRector.php
+++ b/rules/Php86/Rector/FuncCall/MinMaxToClampRector.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php86\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\Php86\Rector\FuncCall\MinMaxToClampRector\MinMaxToClampRectorTest
+ */
+final class MinMaxToClampRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Convert nested min()/max() calls to clamp()', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+$result = max(0, min(100, $value));
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+$result = clamp($value, 0, 100);
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if ($this->isName($node, 'max')) {
+            return $this->matchClampFuncCall($node, 'min');
+        }
+
+        if ($this->isName($node, 'min')) {
+            return $this->matchClampFuncCall($node, 'max');
+        }
+
+        return null;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::CLAMP;
+    }
+
+    private function matchClampFuncCall(FuncCall $outerFuncCall, string $expectedInnerFuncName): ?FuncCall
+    {
+        $args = $outerFuncCall->getArgs();
+
+        if (count($args) !== 2) {
+            return null;
+        }
+
+        if (! $this->isSupportedArg($args[0]) || ! $this->isSupportedArg($args[1])) {
+            return null;
+        }
+
+        $leftValue = $args[0]->value;
+        $rightValue = $args[1]->value;
+
+        if ($leftValue instanceof FuncCall) {
+            return $this->createClampFuncCall($outerFuncCall, $leftValue, $rightValue, $expectedInnerFuncName);
+        }
+
+        if ($rightValue instanceof FuncCall) {
+            return $this->createClampFuncCall($outerFuncCall, $rightValue, $leftValue, $expectedInnerFuncName);
+        }
+
+        return null;
+    }
+
+    private function createClampFuncCall(
+        FuncCall $outerFuncCall,
+        FuncCall $innerFuncCall,
+        Expr $outerBoundExpr,
+        string $expectedInnerFuncName
+    ): ?FuncCall {
+        if ($innerFuncCall->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (! $this->isName($innerFuncCall, $expectedInnerFuncName)) {
+            return null;
+        }
+
+        $args = $innerFuncCall->getArgs();
+        if (count($args) !== 2) {
+            return null;
+        }
+
+        if (! $this->isSupportedArg($args[0]) || ! $this->isSupportedArg($args[1])) {
+            return null;
+        }
+
+        $valueAndBound = $this->matchValueAndKnownBound($args[0]->value, $args[1]->value);
+        if ($valueAndBound === null) {
+            return null;
+        }
+
+        [$valueExpr, $innerBoundExpr] = $valueAndBound;
+
+        if ($this->isName($outerFuncCall, 'max')) {
+            return $this->nodeFactory->createFuncCall('clamp', [$valueExpr, $outerBoundExpr, $innerBoundExpr]);
+        }
+
+        return $this->nodeFactory->createFuncCall('clamp', [$valueExpr, $innerBoundExpr, $outerBoundExpr]);
+    }
+
+    private function isSupportedArg(Arg $arg): bool
+    {
+        return ! $arg->unpack && $arg->name === null;
+    }
+
+    /**
+     * @return array{Expr, Expr}|null
+     */
+    private function matchValueAndKnownBound(Expr $firstExpr, Expr $secondExpr): ?array
+    {
+        $isFirstKnownBound = $this->isKnownBound($firstExpr);
+        $isSecondKnownBound = $this->isKnownBound($secondExpr);
+
+        if ($isFirstKnownBound === $isSecondKnownBound) {
+            return null;
+        }
+
+        if ($isFirstKnownBound) {
+            return [$secondExpr, $firstExpr];
+        }
+
+        return [$firstExpr, $secondExpr];
+    }
+
+    private function isKnownBound(Expr $expr): bool
+    {
+        return $this->getNativeType($expr)
+            ->isConstantScalarValue()
+            ->yes();
+    }
+}

--- a/src/Config/Level/CodingStyleLevel.php
+++ b/src/Config/Level/CodingStyleLevel.php
@@ -32,6 +32,7 @@ use Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector;
 use Rector\CodingStyle\Rector\Use_\SeparateMultiUseImportsRector;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php86\Rector\FuncCall\MinMaxToClampRector;
 use Rector\Transform\Rector\FuncCall\FuncCallToConstFetchRector;
 use Rector\Visibility\Rector\ClassMethod\ExplicitPublicClassMethodRector;
 
@@ -83,6 +84,7 @@ final class CodingStyleLevel
         ExplicitPublicClassMethodRector::class,
         RemoveUselessAliasInUseStatementRector::class,
         BinaryOpStandaloneAssignsToDirectRector::class,
+        MinMaxToClampRector::class,
     ];
 
     /**

--- a/src/Configuration/PhpLevelSetResolver.php
+++ b/src/Configuration/PhpLevelSetResolver.php
@@ -35,6 +35,7 @@ final class PhpLevelSetResolver
         PhpVersion::PHP_83 => SetList::PHP_83,
         PhpVersion::PHP_84 => SetList::PHP_84,
         PhpVersion::PHP_85 => SetList::PHP_85,
+        PhpVersion::PHP_86 => SetList::PHP_86,
     ];
 
     /**

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -574,6 +574,7 @@ final class RectorConfigBuilder
         // place on later as BC break when used in php 7.x without named arg
         bool $php84 = false,
         bool $php85 = false,
+        bool $php86 = false,
     ): self {
         if ($this->isWithPhpSetsUsed === true) {
             throw new InvalidConfigurationException(sprintf(
@@ -665,6 +666,8 @@ final class RectorConfigBuilder
             $targetPhpVersion = PhpVersion::PHP_84;
         } elseif ($php85) {
             $targetPhpVersion = PhpVersion::PHP_85;
+        } elseif ($php86) {
+            $targetPhpVersion = PhpVersion::PHP_86;
         } else {
             throw new InvalidConfigurationException('Invalid PHP version set');
         }

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Rector;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\Node\PropertyItem;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -218,6 +219,14 @@ CODE_SAMPLE;
     protected function getType(Node $node): Type
     {
         return $this->nodeTypeResolver->getType($node);
+    }
+
+    /**
+     * Use this method for getting native expr type
+     */
+    protected function getNativeType(Expr $node): Type
+    {
+        return $this->nodeTypeResolver->getNativeType($node);
     }
 
     /**

--- a/src/Set/ValueObject/LevelSetList.php
+++ b/src/Set/ValueObject/LevelSetList.php
@@ -9,6 +9,8 @@ namespace Rector\Set\ValueObject;
  */
 final class LevelSetList
 {
+    public const string UP_TO_PHP_86 = __DIR__ . '/../../../config/set/level/up-to-php86.php';
+
     public const string UP_TO_PHP_85 = __DIR__ . '/../../../config/set/level/up-to-php85.php';
 
     public const string UP_TO_PHP_84 = __DIR__ . '/../../../config/set/level/up-to-php84.php';

--- a/src/Set/ValueObject/SetList.php
+++ b/src/Set/ValueObject/SetList.php
@@ -66,6 +66,8 @@ final class SetList
 
     public const string PHP_85 = __DIR__ . '/../../../config/set/php85.php';
 
+    public const string PHP_86 = __DIR__ . '/../../../config/set/php86.php';
+
     public const string PRIVATIZATION = __DIR__ . '/../../../config/set/privatization.php';
 
     public const string TYPE_DECLARATION = __DIR__ . '/../../../config/set/type-declaration.php';

--- a/src/ValueObject/PhpVersion.php
+++ b/src/ValueObject/PhpVersion.php
@@ -41,5 +41,7 @@ final class PhpVersion
 
     public const int PHP_85 = 80500;
 
+    public const int PHP_86 = 80600;
+
     public const int PHP_10 = 100000;
 }

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -500,4 +500,9 @@ final class PhpVersionFeature
      * @see https://wiki.php.net/rfc/override_properties
      */
     public const int OVERRIDE_ATTRIBUTE_ON_PROPERTIES = PhpVersion::PHP_85;
+
+    /**
+     * @see https://wiki.php.net/rfc/clamp_v2
+     */
+    public const int CLAMP = PhpVersion::PHP_86;
 }


### PR DESCRIPTION
Hello!

This adds support for the new PHP 8.6 [`clamp()`](https://wiki.php.net/rfc/clamp_v2) function!

```diff
-min(100, max(0, $value));
+clamp($value, 0, 100);
```

Thanks!