### PR TITLE
feat: create rector to add names to boolean arguments

### DIFF
--- a/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/AddNameToBooleanArgumentRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/AddNameToBooleanArgumentRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddNameToBooleanArgumentRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return AddNameToBooleanArgumentRectorTest::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/Fixture/fixture.php.inc
+++ b/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector\Source\Service;
+
+in_array($value, $array, true);
+
+function (Service $service, string $value): void
+{
+    $service->configure($value, true);
+    Service::create($value, true);
+    new Service($value, true);
+};
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector\Source\Service;
+
+in_array($value, $array, strict: true);
+
+function (Service $service, string $value): void
+{
+    $service->configure($value, strict: true);
+    Service::create($value, strict: true);
+    new Service($value, strict: true);
+};
+
+?>

--- a/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/Fixture/name_following_arguments.php.inc
+++ b/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/Fixture/name_following_arguments.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector\Fixture;
+
+json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector\Fixture;
+
+json_decode($json, associative: true, depth: 512, flags: JSON_THROW_ON_ERROR);
+
+?>

--- a/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/Fixture/skip_already_named.php.inc
+++ b/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/Fixture/skip_already_named.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector\Fixture;
+
+in_array($value, $array, strict: true);

--- a/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/Fixture/skip_first_class_callable.php.inc
+++ b/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector\Fixture;
+
+in_array(...);

--- a/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/Fixture/skip_unpack.php.inc
+++ b/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/Fixture/skip_unpack.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector\Source\Service;
+
+function (array $rest): void
+{
+    Service::create('value', true, ...$rest);
+};

--- a/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/Source/Service.php
+++ b/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/Source/Service.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector\Source;
+
+final class Service
+{
+    public function __construct(string $value, bool $strict, ?string $fallback = null)
+    {
+    }
+
+    public function configure(string $value, bool $strict, ?string $fallback = null): void
+    {
+    }
+
+    public static function create(string $value, bool $strict, ?string $fallback = null): self
+    {
+        return new self($value, $strict, $fallback);
+    }
+}

--- a/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([AddNameToBooleanArgumentRector::class]);

--- a/rules/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector.php
+++ b/rules/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\CallLike;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Identifier;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector\AddNameToBooleanArgumentRectorTest
+ */
+final class AddNameToBooleanArgumentRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly ValueResolver $valueResolver,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add parameter names to boolean arguments.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+in_array($value, $array, true);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+in_array($value, $array, strict: true);
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [CallLike::class];
+    }
+
+    /**
+     * @param CallLike $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->shouldSkip($node)) {
+            return null;
+        }
+
+        $reflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($node);
+        if (! $reflection instanceof FunctionReflection && ! $reflection instanceof MethodReflection) {
+            return null;
+        }
+
+        $scope = ScopeFetcher::fetch($node);
+        $args = $node->getArgs();
+        $parameters = ParametersAcceptorSelectorVariantsWrapper::select($reflection, $node, $scope)
+            ->getParameters();
+
+        $position = $this->resolveFirstPositionToName($args, $parameters);
+        if ($position === null) {
+            return null;
+        }
+
+        $wasChanged = false;
+        for ($i = $position; $i < count($args); ++$i) {
+            $arg = $args[$i];
+            if ($arg->name instanceof Identifier) {
+                continue;
+            }
+
+            $parameterReflection = $this->resolveParameterReflection($arg, $i, $parameters);
+            if (! $parameterReflection instanceof ParameterReflection) {
+                return null;
+            }
+
+            $arg->name = new Identifier($parameterReflection->getName());
+            $wasChanged = true;
+        }
+
+        if (! $wasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    private function shouldSkip(CallLike $callLike): bool
+    {
+        if ($callLike->isFirstClassCallable()) {
+            return true;
+        }
+
+        $args = $callLike->getArgs();
+        if ($args === []) {
+            return true;
+        }
+
+        foreach ($args as $arg) {
+            if ($arg->unpack) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Arg[] $args
+     * @param ParameterReflection[] $parameters
+     */
+    private function resolveFirstPositionToName(array $args, array $parameters): ?int
+    {
+        foreach ($args as $position => $arg) {
+            if ($arg->name instanceof Identifier) {
+                continue;
+            }
+
+            if (! $this->valueResolver->isTrueOrFalse($arg->value)) {
+                continue;
+            }
+
+            if ($this->canNameArgsFromPosition($args, $parameters, $position)) {
+                return $position;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param Arg[] $args
+     * @param ParameterReflection[] $parameters
+     */
+    private function canNameArgsFromPosition(array $args, array $parameters, int $position): bool
+    {
+        $count = count($args);
+        for ($i = $position; $i < $count; ++$i) {
+            $arg = $args[$i];
+            if ($arg->name instanceof Identifier) {
+                continue;
+            }
+
+            $parameterReflection = $this->resolveParameterReflection($arg, $i, $parameters);
+            if (! $parameterReflection instanceof ParameterReflection) {
+                return false;
+            }
+
+            if ($parameterReflection->isVariadic()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param ParameterReflection[] $parameters
+     */
+    private function resolveParameterReflection(Arg $arg, int $position, array $parameters): ?ParameterReflection
+    {
+        if ($arg->name instanceof Identifier) {
+            foreach ($parameters as $parameter) {
+                if ($parameter->getName() === $arg->name->toString()) {
+                    return $parameter;
+                }
+            }
+
+            return null;
+        }
+
+        $parameter = $parameters[$position] ?? null;
+        if ($parameter instanceof ParameterReflection) {
+            return $parameter;
+        }
+
+        $lastParameter = end($parameters);
+        if ($lastParameter instanceof ParameterReflection && $lastParameter->isVariadic()) {
+            return $lastParameter;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Hello!

Please see https://x.com/VotrubaT/status/2037867835469238412 for context.

This adds names to boolean call-site arguments---this increases code quality by making it clear what the value being passed is for:

```diff
-in_array($value, $array, true);
+in_array($value, $array, strict: true);
```

Thanks!