### PR TITLE
Fix example CS in AddReturnDocblockFromMethodCallDocblockRector

### DIFF
--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockFromMethodCallDocblockRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockFromMethodCallDocblockRector.php
@@ -61,15 +61,14 @@ final class Repository
         // ...
     }
 }
-}
 CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
 final class SomeController
 {
     /**
-        * @return SomeEntity[]
-        */
+     * @return SomeEntity[]
+     */
     public function getAll(): array
     {
         return $this->repository->findAll();


### PR DESCRIPTION
There were some unwanted whitespace problems, and a stray `}`.

Easy to see at https://getrector.com/rule-detail/add-return-docblock-from-method-call-docblock-rector