### PR TITLE
      [CodingStyle] Skip by reference required params on call inside on ArrowFunctionDelegatingCallToFirstClassCallableRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/ArrowFunction/ArrowFunctionDelegatingCallToFirstClassCallableRector/Fixture/skip_with_reset.php.inc
+++ b/rules-tests/CodingStyle/Rector/ArrowFunction/ArrowFunctionDelegatingCallToFirstClassCallableRector/Fixture/skip_with_reset.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector\Fixture;
+
+final class SkipWithReset
+{
+    public function run()
+    {
+        $data = [['a']];
+        return array_map(reset(...), $data);
+    }
+}

--- a/rules-tests/CodingStyle/Rector/ArrowFunction/ArrowFunctionDelegatingCallToFirstClassCallableRector/Fixture/skip_with_reset.php.inc
+++ b/rules-tests/CodingStyle/Rector/ArrowFunction/ArrowFunctionDelegatingCallToFirstClassCallableRector/Fixture/skip_with_reset.php.inc
@@ -10,6 +10,6 @@ final class SkipWithReset
     public function run()
     {
         $data = [['a']];
-        return array_map(reset(...), $data);
+        return array_map(fn ($item) => reset($item), $data);
     }
 }

--- a/rules-tests/CodingStyle/Rector/ArrowFunction/ArrowFunctionDelegatingCallToFirstClassCallableRector/Fixture/skip_with_reset.php.inc
+++ b/rules-tests/CodingStyle/Rector/ArrowFunction/ArrowFunctionDelegatingCallToFirstClassCallableRector/Fixture/skip_with_reset.php.inc
@@ -2,6 +2,9 @@
 
 namespace Rector\Tests\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector\Fixture;
 
+/**
+ * @see https://3v4l.org/T4rPe#v8.5.3
+ */
 final class SkipWithReset
 {
     public function run()

--- a/rules/CodingStyle/Guard/ArrowFunctionAndClosureFirstClassCallableGuard.php
+++ b/rules/CodingStyle/Guard/ArrowFunctionAndClosureFirstClassCallableGuard.php
@@ -21,6 +21,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpParser\AstResolver;
 use Rector\PhpParser\Comparing\NodeComparator;
@@ -100,6 +101,14 @@ final readonly class ArrowFunctionAndClosureFirstClassCallableGuard
             $reflection->getName()
         )) {
             return true;
+        }
+
+        // check if args require by reference
+        $parameters = ParametersAcceptorSelectorVariantsWrapper::select($reflection, $callLike, $scope)->getParameters();
+        foreach ($parameters as $parameter) {
+            if ($parameter->passedByReference()->yes()) {
+                return true;
+            }
         }
 
         $functionLike = $this->astResolver->resolveClassMethodOrFunctionFromCall($callLike);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9720
Ref https://3v4l.org/T4rPe#v8.5.3