### PR TITLE
[DeadCode] Skip with assign to call with target has #[NoDiscard] attribute on RemoveUnusedVariableAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_assign_no_discard_function_call.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_assign_no_discard_function_call.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+class SkipAssignNoDiscardFunctionCall
+{
+    public function run()
+    {
+        $value = $this->some_call();
+    }
+
+    #[\NoDiscard]
+    private function some_call()
+    {
+
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_assign_no_discard_function_call.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_assign_no_discard_function_call.php.inc
@@ -15,5 +15,3 @@ class SkipAssignNoDiscardFunctionCall
 
     }
 }
-
-?>

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_assign_no_discard_method_call.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_assign_no_discard_method_call.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
 
-class SkipAssignNoDiscardFunctionCall
+class SkipAssignNoDiscardMethodCall
 {
     public function run()
     {

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -8,11 +8,14 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignRef;
-use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Cast;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Include_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
@@ -270,7 +273,11 @@ CODE_SAMPLE
                 continue;
             }
 
-            if ($assign->expr instanceof CallLike) {
+            if ($assign->expr instanceof FuncCall
+                || $assign->expr instanceof StaticCall
+                || $assign->expr instanceof MethodCall
+                || $assign->expr instanceof New_
+                || $assign->expr instanceof NullsafeMethodCall) {
                 $targetCall = $this->astResolver->resolveClassMethodOrFunctionFromCall($assign->expr);
                 if (($targetCall instanceof ClassMethod || $targetCall instanceof Function_)
                     && $this->phpAttributeAnalyzer->hasPhpAttribute($targetCall, 'NoDiscard')) {

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignRef;
+use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Cast;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
@@ -25,6 +26,8 @@ use Rector\DeadCode\SideEffect\SideEffectNodeDetector;
 use Rector\NodeAnalyzer\VariableAnalyzer;
 use Rector\NodeManipulator\StmtsManipulator;
 use Rector\Php\ReservedKeywordAnalyzer;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\PhpParser\AstResolver;
 use Rector\PhpParser\Enum\NodeGroup;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
@@ -42,7 +45,9 @@ final class RemoveUnusedVariableAssignRector extends AbstractRector
         private readonly SideEffectNodeDetector $sideEffectNodeDetector,
         private readonly VariableAnalyzer $variableAnalyzer,
         private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly StmtsManipulator $stmtsManipulator
+        private readonly StmtsManipulator $stmtsManipulator,
+        private readonly AstResolver $astResolver,
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer
     ) {
     }
 
@@ -263,6 +268,14 @@ CODE_SAMPLE
 
             if ($this->shouldSkipVariable($assign->var, $variableName, $refVariableNames)) {
                 continue;
+            }
+
+            if ($assign->expr instanceof CallLike) {
+                $targetCall = $this->astResolver->resolveClassMethodOrFunctionFromCall($assign->expr);
+                if (($targetCall instanceof ClassMethod || $targetCall instanceof Function_)
+                    && $this->phpAttributeAnalyzer->hasPhpAttribute($targetCall, 'NoDiscard')) {
+                    continue;
+                }
             }
 
             $assignedVariableNamesByStmtPosition[$key] = $variableName;

--- a/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Property;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\PhpAttribute\Enum\DocTagNodeState;
@@ -23,7 +24,7 @@ final readonly class PhpAttributeAnalyzer
     ) {
     }
 
-    public function hasPhpAttribute(Property | ClassLike | ClassMethod | Param $node, string $attributeClass): bool
+    public function hasPhpAttribute(Property | ClassLike | ClassMethod | Param | Function_ $node, string $attributeClass): bool
     {
         foreach ($node->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $attribute) {

--- a/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/PhpAttributeAnalyzer.php
@@ -24,7 +24,7 @@ final readonly class PhpAttributeAnalyzer
     ) {
     }
 
-    public function hasPhpAttribute(Property | ClassLike | ClassMethod | Param | Function_ $node, string $attributeClass): bool
+    public function hasPhpAttribute(Property | ClassLike | ClassMethod | Function_ | Param  $node, string $attributeClass): bool
     {
         foreach ($node->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $attribute) {
@@ -42,7 +42,7 @@ final readonly class PhpAttributeAnalyzer
     /**
      * @param string[] $attributeClasses
      */
-    public function hasPhpAttributes(Property | ClassLike | ClassMethod | Param $node, array $attributeClasses): bool
+    public function hasPhpAttributes(Property | ClassLike | ClassMethod | Function_ | Param $node, array $attributeClasses): bool
     {
         foreach ($attributeClasses as $attributeClass) {
             if ($this->hasPhpAttribute($node, $attributeClass)) {

--- a/src/PhpParser/AstResolver.php
+++ b/src/PhpParser/AstResolver.php
@@ -112,7 +112,7 @@ final class AstResolver
     }
 
     public function resolveClassMethodOrFunctionFromCall(
-        FuncCall | StaticCall | MethodCall | New_ $call
+        FuncCall | StaticCall | MethodCall | New_ | NullsafeMethodCall $call
     ): ClassMethod | Function_ | null {
         if ($call instanceof FuncCall) {
             return $this->resolveFunctionFromFuncCall($call);


### PR DESCRIPTION
Ref https://3v4l.org/YXB9c#v8.5.3 vs https://3v4l.org/RudO3#v8.5.3