### PR TITLE
[Php70] Allow is_null() conversion on TernaryToNullCoalescingRector with parentheses handling

### DIFF
--- a/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/is_null_function.php.inc
+++ b/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/is_null_function.php.inc
@@ -31,4 +31,3 @@ function ternaryWithIsNull()
 }
 
 ?>
-

--- a/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/is_null_function.php.inc
+++ b/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/is_null_function.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\Ternary\TernaryToNullCoalescingRector\Fixture;
+
+function ternaryWithIsNull()
+{
+    $x = is_null($value) ? 10 : $value;
+
+    $y = is_null($a) ? $b : $a;
+
+    $z = !is_null($value) ? $value : 10;
+
+    $w = !is_null($c) ? $c : $d;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php70\Rector\Ternary\TernaryToNullCoalescingRector\Fixture;
+
+function ternaryWithIsNull()
+{
+    $x = $value ?? 10;
+
+    $y = $a ?? $b;
+
+    $z = $value ?? 10;
+
+    $w = $c ?? $d;
+}
+
+?>
+

--- a/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/is_null_function.php.inc
+++ b/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/is_null_function.php.inc
@@ -9,8 +9,6 @@ function ternaryWithIsNull()
     $y = is_null($a) ? $b : $a;
 
     $z = !is_null($value) ? $value : 10;
-
-    $w = !is_null($c) ? $c : $d;
 }
 
 ?>
@@ -26,8 +24,6 @@ function ternaryWithIsNull()
     $y = $a ?? $b;
 
     $z = $value ?? 10;
-
-    $w = $c ?? $d;
 }
 
 ?>

--- a/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/is_null_with_parentheses.php.inc
+++ b/rules-tests/Php70/Rector/Ternary/TernaryToNullCoalescingRector/Fixture/is_null_with_parentheses.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\Ternary\TernaryToNullCoalescingRector\Fixture;
+
+function isNullWithParentheses()
+{
+    $w = !is_null($c = $x) ? ($c = $x) : $d;
+    $w = is_null($c = $x) ? $d : ($c = $x);
+    $w = !is_null($c) ? $c : ($a + $b);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php70\Rector\Ternary\TernaryToNullCoalescingRector\Fixture;
+
+function isNullWithParentheses()
+{
+    $w = ($c = $x) ?? $d;
+    $w = ($c = $x) ?? $d;
+    $w = $c ?? ($a + $b);
+}
+
+?>

--- a/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
+++ b/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
@@ -6,6 +6,7 @@ namespace Rector\Php70\Rector\Ternary;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\BinaryOp\Identical;
@@ -94,11 +95,11 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
 
         $ternaryCompareNode = $node->cond;
         if ($this->isNullMatch($ternaryCompareNode->left, $ternaryCompareNode->right, $checkedNode)) {
-            return new Coalesce($checkedNode, $fallbackNode);
+            return $this->createCoalesce($checkedNode, $fallbackNode);
         }
 
         if ($this->isNullMatch($ternaryCompareNode->right, $ternaryCompareNode->left, $checkedNode)) {
-            return new Coalesce($checkedNode, $fallbackNode);
+            return $this->createCoalesce($checkedNode, $fallbackNode);
         }
 
         return null;
@@ -131,7 +132,9 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
                 return null;
             }
 
-            return new Coalesce($ternary->if, $ternary->else);
+            $this->preserveWrappedFallback($ternary->else);
+
+            return $this->createCoalesce($ternary->if, $ternary->else);
         }
 
         if (! $this->nodeComparator->areNodesEqual($ternary->else, $checkedExpr)) {
@@ -142,7 +145,9 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
             return null;
         }
 
-        return new Coalesce($ternary->else, $ternary->if);
+        $this->preserveWrappedFallback($ternary->if);
+
+        return $this->createCoalesce($ternary->else, $ternary->if);
     }
 
     private function processTernaryWithIsset(Ternary $ternary, Isset_ $isset): ?Coalesce
@@ -172,7 +177,7 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
             $ternary->else->setAttribute(AttributeKey::WRAPPED_IN_PARENTHESES, true);
         }
 
-        return new Coalesce($ternary->if, $ternary->else);
+        return $this->createCoalesce($ternary->if, $ternary->else);
     }
 
     private function isTernaryParenthesized(File $file, Expr $expr, Ternary $ternary): bool
@@ -212,5 +217,46 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
         }
 
         return $this->nodeComparator->areNodesEqual($firstNode, $secondNode);
+    }
+
+    private function createCoalesce(Expr $checkedExpr, Expr $fallbackExpr): Coalesce
+    {
+        if ($this->isExprParenthesized($this->getFile(), $checkedExpr)) {
+            $checkedExpr->setAttribute(AttributeKey::WRAPPED_IN_PARENTHESES, true);
+        }
+
+        return new Coalesce($checkedExpr, $fallbackExpr);
+    }
+
+    private function preserveWrappedFallback(Expr $expr): void
+    {
+        if (! ($expr instanceof BinaryOp || $expr instanceof Ternary)) {
+            return;
+        }
+
+        if (! $this->isExprParenthesized($this->getFile(), $expr)) {
+            return;
+        }
+
+        $expr->setAttribute(AttributeKey::WRAPPED_IN_PARENTHESES, true);
+    }
+
+    private function isExprParenthesized(File $file, Expr $expr): bool
+    {
+        $oldTokens = $file->getOldTokens();
+        $startTokenPos = $expr->getStartTokenPos();
+        $endTokenPos = $expr->getEndTokenPos();
+
+        while (isset($oldTokens[$startTokenPos - 1]) && trim((string) $oldTokens[$startTokenPos - 1]) === '') {
+            --$startTokenPos;
+        }
+
+        while (isset($oldTokens[$endTokenPos + 1]) && trim((string) $oldTokens[$endTokenPos + 1]) === '') {
+            ++$endTokenPos;
+        }
+
+        return isset($oldTokens[$startTokenPos - 1], $oldTokens[$endTokenPos + 1])
+            && (string) $oldTokens[$startTokenPos - 1] === '('
+            && (string) $oldTokens[$endTokenPos + 1] === ')';
     }
 }

--- a/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
+++ b/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\Php70\Rector\Ternary;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\BinaryOp\Identical;
@@ -117,7 +117,7 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
         }
 
         $firstArg = $isNullFuncCall->args[0];
-        if (! $firstArg instanceof Node\Arg) {
+        if (! $firstArg instanceof Arg) {
             return null;
         }
 
@@ -230,7 +230,7 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
 
     private function preserveWrappedFallback(Expr $expr): void
     {
-        if (! ($expr instanceof BinaryOp || $expr instanceof Ternary)) {
+        if (! $expr instanceof BinaryOp && ! $expr instanceof Ternary) {
             return;
         }
 

--- a/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
+++ b/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
@@ -10,6 +10,8 @@ use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\Ternary;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -38,6 +40,7 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
             [
                 new CodeSample('$value === null ? 10 : $value;', '$value ?? 10;'),
                 new CodeSample('isset($value) ? $value : 10;', '$value ?? 10;'),
+                new CodeSample('is_null($value) ? 10 : $value;', '$value ?? 10;'),
             ]
         );
     }
@@ -57,6 +60,17 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
     {
         if ($node->cond instanceof Isset_) {
             return $this->processTernaryWithIsset($node, $node->cond);
+        }
+
+        if ($node->cond instanceof FuncCall && $this->isName($node->cond, 'is_null')) {
+            return $this->processTernaryWithIsNull($node, $node->cond, false);
+        }
+
+        if (
+            $node->cond instanceof BooleanNot && $node->cond->expr instanceof FuncCall
+            && $this->isName($node->cond->expr, 'is_null')
+        ) {
+            return $this->processTernaryWithIsNull($node, $node->cond->expr, true);
         }
 
         if ($node->cond instanceof Identical) {
@@ -93,6 +107,33 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::NULL_COALESCE;
+    }
+
+    private function processTernaryWithIsNull(Ternary $ternary, FuncCall $isNullFuncCall, bool $isNegated): ?Coalesce
+    {
+        if (count($isNullFuncCall->args) !== 1) {
+            return null;
+        }
+
+        $checkedExpr = $isNullFuncCall->args[0]->value;
+
+        if ($isNegated) {
+            if (! $ternary->if instanceof Expr) {
+                return null;
+            }
+
+            if (! $this->nodeComparator->areNodesEqual($ternary->if, $checkedExpr)) {
+                return null;
+            }
+
+            return new Coalesce($ternary->if, $ternary->else);
+        }
+
+        if (! $this->nodeComparator->areNodesEqual($ternary->else, $checkedExpr)) {
+            return null;
+        }
+
+        return new Coalesce($ternary->else, $ternary->if);
     }
 
     private function processTernaryWithIsset(Ternary $ternary, Isset_ $isset): ?Coalesce

--- a/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
+++ b/rules/Php70/Rector/Ternary/TernaryToNullCoalescingRector.php
@@ -115,7 +115,12 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
             return null;
         }
 
-        $checkedExpr = $isNullFuncCall->args[0]->value;
+        $firstArg = $isNullFuncCall->args[0];
+        if (! $firstArg instanceof Node\Arg) {
+            return null;
+        }
+
+        $checkedExpr = $firstArg->value;
 
         if ($isNegated) {
             if (! $ternary->if instanceof Expr) {
@@ -130,6 +135,10 @@ final class TernaryToNullCoalescingRector extends AbstractRector implements MinP
         }
 
         if (! $this->nodeComparator->areNodesEqual($ternary->else, $checkedExpr)) {
+            return null;
+        }
+
+        if (! $ternary->if instanceof Expr) {
             return null;
         }
 


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-src/pull/7890
Closes https://github.com/rectorphp/rector/issues/9648

Continue of https://github.com/rectorphp/rector-src/pull/7890