### PR TITLE
Bump to PHPStan ^2.1.47

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.41"
+        "phpstan/phpstan": "^2.1.47"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nikic/php-parser": "^5.7",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",
-        "phpstan/phpstan": "^2.1.41",
+        "phpstan/phpstan": "^2.1.47",
         "react/event-loop": "^1.6",
         "react/promise": "^3.3",
         "react/socket": "^1.17",


### PR DESCRIPTION
PHPStan 2.1.47 released https://github.com/phpstan/phpstan/releases/tag/2.1.47

It checked on latest PR CI that cause unit test notice:

- https://github.com/rectorphp/rector-src/actions/runs/24381475596/job/71205726476?pr=7969#step:7:40

The unit test on rector-symfony package fixed at PR:

- https://github.com/rectorphp/rector-symfony/pull/931

This PR bump to PHPStan ^2.1.47, ensure compatible code release required.