### PR TITLE
 [CodeQuality] Skip union type on UseIdenticalOverEqualWithSameTypeRector 

### DIFF
--- a/rules-tests/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector/Fixture/skip_union.php.inc
+++ b/rules-tests/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector/Fixture/skip_union.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+final class SkipUnion
+{
+    public function run(int|string|float $firstValue, int|string|float $secondValue)
+    {
+        return $firstValue == $secondValue;
+    }
+}

--- a/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
+++ b/rules/CodeQuality/Rector/Equal/UseIdenticalOverEqualWithSameTypeRector.php
@@ -18,6 +18,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
+use PHPStan\Type\UnionType;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -93,6 +94,10 @@ CODE_SAMPLE
         $normalizedRightType = $this->normalizeScalarType($rightStaticType);
 
         if (! $normalizedLeftType->equals($normalizedRightType)) {
+            return null;
+        }
+
+        if ($normalizedLeftType instanceof UnionType) {
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9746