### PR TITLE
 [CodeQuality] Skip in html for ForRepeatedCountToOwnVariableRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector/Fixture/skip_in_html.php.inc
+++ b/rules-tests/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector/Fixture/skip_in_html.php.inc
@@ -1,0 +1,5 @@
+<div>
+    <?php for ($i = 5; $i <= count($items); $i++) : ?>
+        <p>Item <?php echo $i; ?></p>
+    <?php endfor; ?>
+</div>

--- a/rules/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector.php
+++ b/rules/CodeQuality/Rector/For_/ForRepeatedCountToOwnVariableRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\For_;
+use Rector\Contract\Rector\HTMLAverseRectorInterface;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -22,7 +23,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see \Rector\Tests\CodeQuality\Rector\For_\ForRepeatedCountToOwnVariableRector\ForRepeatedCountToOwnVariableRectorTest
  */
-final class ForRepeatedCountToOwnVariableRector extends AbstractRector
+final class ForRepeatedCountToOwnVariableRector extends AbstractRector implements HTMLAverseRectorInterface
 {
     private const string COUNTER_NAME = 'counter';
 


### PR DESCRIPTION
due to cause invalid prepend code that cause fatal error, see https://getrector.com/demo/7c14f496-a648-48d5-9b44-d9f1bfb80533