### PR TITLE
[DX] Fix run on custom rector config when no rector.php and no rules/sets registered

### DIFF
--- a/src/Configuration/ConfigInitializer.php
+++ b/src/Configuration/ConfigInitializer.php
@@ -20,6 +20,7 @@ final readonly class ConfigInitializer
         private array $rectors,
         private InitFilePathsResolver $initFilePathsResolver,
         private SymfonyStyle $symfonyStyle,
+        private RectorConfigsResolver $rectorConfigsResolver,
     ) {
     }
 
@@ -38,6 +39,14 @@ final readonly class ConfigInitializer
         if (file_exists($distRectorConfigPath)) {
             $this->symfonyStyle->warning(
                 'Register rules or sets in your "' . RectorConfigsResolver::DEFAULT_DIST_CONFIG_FILE . '" config'
+            );
+            return;
+        }
+
+        $mainConfigFile = $this->rectorConfigsResolver->provide()->getMainConfigFile();
+        if ($mainConfigFile !== null && file_exists($mainConfigFile)) {
+            $this->symfonyStyle->warning(
+                'Register rules or sets in your "' . basename($mainConfigFile) . '" config'
             );
             return;
         }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9757

When no rules/sets registered in custom rector config.

**Before**

```bash
  rector-src git:(main) ✗ bin/rector --config="custom-rector.php" --dry-run

 No "rector.php" config found. Should we generate it for you? [yes]:
 > no
```

**After**

```bash
bin/rector --config="custom-rector.php" --dry-run 
                                                                                                                        
 [WARNING] Register rules or sets in your "custom-rector.php" config     
```

Steps to reproduce:
----

- no rector.php
- create `custom-rector.php` without rule/sets registered
- run rector with `--config="custom-rector.php"`