### PR TITLE
Temporary pin nette/utils version to 4.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "composer/xdebug-handler": "^3.0.5",
         "doctrine/inflector": "^2.1",
         "illuminate/container": "12.39.*",
-        "nette/utils": "^4.1.3",
+        "nette/utils": "4.1.3",
         "nikic/php-parser": "^5.7",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",


### PR DESCRIPTION
Updated nette/utils version constraint to 4.1.3.

Fix broken build https://github.com/rectorphp/rector-src/actions/runs/25715044232/job/75502988819#step:14:75
Fixes https://github.com/rectorphp/rector/issues/9758

It maybe a nette/utils issue itself on latest 4.1.4

https://github.com/nette/utils/releases/tag/v4.1.4

or the scoper that needs tweak. 

Temporary pin nette/utils version to 4.1.3 for now.