### PR TITLE
Bump to nette/utils ^4.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "composer/xdebug-handler": "^3.0.5",
         "doctrine/inflector": "^2.1",
         "illuminate/container": "12.39.*",
-        "nette/utils": "4.1.3",
+        "nette/utils": "^4.1.4",
         "nikic/php-parser": "^5.7",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",


### PR DESCRIPTION
nette/utils 4.1.4 was cause downgrade issue:

https://github.com/rectorphp/rector-src/actions/runs/25715044232/job/75502988819#step:14:75

The temporary solution was pin to nette/utils 4.1.3.

- https://github.com/rectorphp/rector-src/pull/7986

After some investigation, the issue seems on rector-downgrade-php, which solved at PR:

- https://github.com/rectorphp/rector-downgrade-php/pull/373

This PR bump nette/utils to ^4.1.4