### PR TITLE
[DeadCode] Skip used by get_object_vars on RemoveUnusedPromotedPropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector/Fixture/skip_used_by_get_object_vars.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPromotedPropertyRector/Fixture/skip_used_by_get_object_vars.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector\Fixture;
+
+readonly class SkipUsedByGetObjectVars
+{
+  public function __construct(private string $foo)
+  {
+  }
+
+  public function toArray(): array
+  {
+    return get_object_vars($this);
+  }
+}

--- a/rules/DeadCode/NodeAnalyzer/PropertyWriteonlyAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/PropertyWriteonlyAnalyzer.php
@@ -30,15 +30,8 @@ final readonly class PropertyWriteonlyAnalyzer
 
     public function hasClassDynamicPropertyNames(Class_ $class): bool
     {
-        $isImplementsJsonSerializable = $this->nodeTypeResolver->isObjectType(
-            $class,
-            new ObjectType('JsonSerializable')
-        );
-
-        return (bool) $this->betterNodeFinder->findFirst($class, function (Node $node) use (
-            $isImplementsJsonSerializable
-        ): bool {
-            if ($isImplementsJsonSerializable && $node instanceof FuncCall && $this->nodeNameResolver->isName(
+        return (bool) $this->betterNodeFinder->findFirst($class, function (Node $node) : bool {
+            if ($node instanceof FuncCall && $this->nodeNameResolver->isName(
                 $node,
                 'get_object_vars'
             ) && ! $node->isFirstClassCallable()) {

--- a/rules/DeadCode/NodeAnalyzer/PropertyWriteonlyAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/PropertyWriteonlyAnalyzer.php
@@ -15,14 +15,12 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpParser\Node\BetterNodeFinder;
 
 final readonly class PropertyWriteonlyAnalyzer
 {
     public function __construct(
         private BetterNodeFinder $betterNodeFinder,
-        private NodeTypeResolver $nodeTypeResolver,
         private NodeNameResolver $nodeNameResolver
     ) {
     }

--- a/rules/DeadCode/NodeAnalyzer/PropertyWriteonlyAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/PropertyWriteonlyAnalyzer.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
-use PHPStan\Type\ObjectType;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9760