### PR TITLE
Implement TODO: handle multiple type nodes in AddReturnDocblockForDimFetchArrayFromAssignsRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForDimFetchArrayFromAssignsRector/Fixture/union_from_if_else_assign.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForDimFetchArrayFromAssignsRector/Fixture/union_from_if_else_assign.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForDimFetchArrayFromAssignsRector\Fixture;
+
+final class UnionFromIfElseAssign
+{
+    public function toArray(): array
+    {
+        $items = [];
+
+        if (mt_rand(0, 1)) {
+            $items = ['id' => 1];
+        } else {
+            $items = ['name' => 'test'];
+        }
+
+        return $items;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForDimFetchArrayFromAssignsRector\Fixture;
+
+final class UnionFromIfElseAssign
+{
+    /**
+     * @return array<string, int>|array<string, string>
+     */
+    public function toArray(): array
+    {
+        $items = [];
+
+        if (mt_rand(0, 1)) {
+            $items = ['id' => 1];
+        } else {
+            $items = ['name' => 'test'];
+        }
+
+        return $items;
+    }
+}
+
+?>

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForDimFetchArrayFromAssignsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForDimFetchArrayFromAssignsRector.php
@@ -16,6 +16,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclarationDocblocks\NodeFinder\ReturnNodeFinder;
 use Rector\TypeDeclarationDocblocks\TagNodeAnalyzer\UsefulArrayTagNodeAnalyzer;
@@ -166,8 +167,15 @@ CODE_SAMPLE
             return $node;
         }
 
-        // @todo handle multiple type nodes
-        $this->phpDocTypeChanger->changeReturnTypeNode($node, $phpDocInfo, $genericUnionedTypeNodes[0]);
+        if ($genericUnionedTypeNodes === []) {
+            return null;
+        }
+
+        $typeNode = count($genericUnionedTypeNodes) === 1
+            ? $genericUnionedTypeNodes[0]
+            : new BracketsAwareUnionTypeNode($genericUnionedTypeNodes);
+
+        $this->phpDocTypeChanger->changeReturnTypeNode($node, $phpDocInfo, $typeNode);
 
         return $node;
     }

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForDimFetchArrayFromAssignsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForDimFetchArrayFromAssignsRector.php
@@ -171,6 +171,9 @@ CODE_SAMPLE
             return null;
         }
 
+        // sort for deterministic output across PHP versions
+        usort($genericUnionedTypeNodes, static fn ($a, $b): int => (string) $a <=> (string) $b);
+
         $typeNode = count($genericUnionedTypeNodes) === 1
             ? $genericUnionedTypeNodes[0]
             : new BracketsAwareUnionTypeNode($genericUnionedTypeNodes);

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForDimFetchArrayFromAssignsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForDimFetchArrayFromAssignsRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
@@ -172,7 +173,7 @@ CODE_SAMPLE
         }
 
         // sort for deterministic output across PHP versions
-        usort($genericUnionedTypeNodes, static fn ($a, $b): int => (string) $a <=> (string) $b);
+        usort($genericUnionedTypeNodes, static fn (TypeNode $a, TypeNode $b): int => (string) $a <=> (string) $b);
 
         $typeNode = count($genericUnionedTypeNodes) === 1
             ? $genericUnionedTypeNodes[0]


### PR DESCRIPTION
When a method returns a variable whose PHPStan-inferred type is a union
of multiple distinct ConstantArrayTypes, the rector previously only used
the first generalized type node and discarded the rest. Now it correctly
creates a BracketsAwareUnionTypeNode from all non-empty type nodes,
producing a union @return docblock (e.g. array<string, int>|array<string, string>).

Also adds a guard for the case where all union members are empty arrays
(would previously crash with an undefined index on $genericUnionedTypeNodes[0]).

https://claude.ai/code/session_01L2wfcmkihik6MVWq5qwEfw