### PR TITLE
[Php81] Skip NullToStrictStringFuncCallArgRector for magic __get() property access

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_magic_get_property_in_if_truthy_check.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_magic_get_property_in_if_truthy_check.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+class EntityWithMagicGet
+{
+    protected array $_fields = [];
+
+    public function __get(string $field)
+    {
+        $value = null;
+        if (isset($this->_fields[$field])) {
+            $value = &$this->_fields[$field];
+        }
+
+        return $value;
+    }
+}
+
+$entity = new EntityWithMagicGet();
+if ($entity->someProp) {
+    preg_replace('/\r\n|\n|\r/', '', $entity->someProp);
+}

--- a/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
+++ b/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\Cast\Int_ as CastInt_;
 use PhpParser\Node\Expr\Cast\String_ as CastString_;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\Int_;
@@ -19,9 +20,11 @@ use PHPStan\Analyser\Fiber\FiberScope;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\Native\ExtendedNativeParameterReflection;
 use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
@@ -35,6 +38,7 @@ final readonly class NullToStrictStringIntConverter
         private ValueResolver $valueResolver,
         private NodeTypeResolver $nodeTypeResolver,
         private PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private ReflectionProvider $reflectionProvider,
     ) {
     }
 
@@ -116,6 +120,10 @@ final readonly class NullToStrictStringIntConverter
 
     private function shouldSkipValue(Expr $expr, Scope $scope, bool $isTrait, string $targetType): bool
     {
+        if ($this->isPropertyFetchOnClassWithMagicGet($expr)) {
+            return true;
+        }
+
         $type = $this->nodeTypeResolver->getType($expr);
         if ($type->isString()->yes() && $targetType === 'string') {
             return true;
@@ -151,6 +159,24 @@ final readonly class NullToStrictStringIntConverter
         }
 
         return $this->shouldSkipTrait($expr, $type, $isTrait);
+    }
+
+    private function isPropertyFetchOnClassWithMagicGet(Expr $expr): bool
+    {
+        if (! $expr instanceof PropertyFetch) {
+            return false;
+        }
+
+        $varType = $this->nodeTypeResolver->getType($expr->var);
+        if (! $varType instanceof ObjectType) {
+            return false;
+        }
+
+        if (! $this->reflectionProvider->hasClass($varType->getClassName())) {
+            return false;
+        }
+
+        return $this->reflectionProvider->getClass($varType->getClassName())->hasMethod('__get');
     }
 
     private function isValidUnionType(Type $type): bool


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9762

## Problem

`NullToStrictStringFuncCallArgRector` incorrectly wraps a magic property access in a `(string)` cast even when the value is already guarded by a truthy `if` check:

```php
class Entity
{
    protected array $_fields = [];

    public function __get(string $field)
    {
        $value = null;
        if (isset($this->_fields[$field])) {
            $value = &$this->_fields[$field];
        }
        return $value;
    }
}

$entity = new Entity();
if ($entity->someProp) {
    // incorrectly became: preg_replace('/\r\n|\n|\r/', '', (string) $entity->someProp);
    preg_replace('/\r\n|\n|\r/', '', $entity->someProp);
}
```

## Root Cause

When `__get()` has no return type hint, PHPStan resolves any magic property access to `ErrorType` (shown as `*ERROR*` in `dumpType`). Since `ErrorType extends MixedType`, the existing `shouldSkipType()` check treats it as a plain `MixedType` and does not skip. The `isAnErrorType()` guard also misses it because it inspects the *native* type (plain `MixedType`) and its parent-scope fallback only fires inside closures/functions — at the top level `getParentScope()` returns `null`.

## Fix

In `shouldSkipValue()`, check upfront whether the argument is a `PropertyFetch` on a class that declares `__get()`. If so, the type is unresolvable via static analysis and the cast would be wrong.

```php
private function isPropertyFetchOnClassWithMagicGet(Expr $expr): bool
{
    if (! $expr instanceof PropertyFetch) {
        return false;
    }

    $varType = $this->nodeTypeResolver->getType($expr->var);
    if (! $varType instanceof ObjectType) {
        return false;
    }

    if (! $this->reflectionProvider->hasClass($varType->getClassName())) {
        return false;
    }

    return $this->reflectionProvider->getClass($varType->getClassName())->hasMethod('__get');
}
```

`hasMethod('__get')` resolves through the full inheritance chain, so it also covers classes that inherit `__get()` from a parent (e.g. CakePHP's `EntityTrait`).

## Test

Added `skip_magic_get_property_in_if_truthy_check.php.inc` fixture reproducing the exact scenario from the issue.