### PR TITLE
[TypeDeclarationDocblocks] Skip overridden methods in DocblockReturnArrayFromDirectArrayInstanceRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/skip_overridden_method.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/skip_overridden_method.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockReturnArrayFromDirectArrayInstanceRector\Fixture;
+
+interface SomeOverriddenInterface
+{
+    /**
+     * @return int[]
+     */
+    public function getCodes(): iterable;
+}
+
+abstract class SomeOverriddenBase
+{
+    /**
+     * @return string[]
+     */
+    abstract public function getMethods(): iterable;
+}
+
+final class SomeOverriddenChild extends SomeOverriddenBase implements SomeOverriddenInterface
+{
+    public function getCodes(): iterable
+    {
+        return [
+            200,
+            201,
+        ];
+    }
+
+    public function getMethods(): iterable
+    {
+        return [
+            'GET',
+            'POST',
+        ];
+    }
+}

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
@@ -19,6 +19,7 @@ use Rector\Rector\AbstractRector;
 use Rector\TypeDeclarationDocblocks\NodeFinder\ReturnNodeFinder;
 use Rector\TypeDeclarationDocblocks\TagNodeAnalyzer\UsefulArrayTagNodeAnalyzer;
 use Rector\TypeDeclarationDocblocks\TypeResolver\ConstantArrayTypeGeneralizer;
+use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -32,7 +33,8 @@ final class DocblockReturnArrayFromDirectArrayInstanceRector extends AbstractRec
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
         private readonly ConstantArrayTypeGeneralizer $constantArrayTypeGeneralizer,
         private readonly ReturnNodeFinder $returnNodeFinder,
-        private readonly UsefulArrayTagNodeAnalyzer $usefulArrayTagNodeAnalyzer
+        private readonly UsefulArrayTagNodeAnalyzer $usefulArrayTagNodeAnalyzer,
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard
     ) {
     }
 
@@ -85,6 +87,11 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         if ($node->stmts === null) {
+            return null;
+        }
+
+        // skip overridden methods to not conflict with parent/interface @return docblock
+        if ($node instanceof ClassMethod && $this->parentClassMethodTypeOverrideGuard->hasParentClassMethod($node)) {
             return null;
         }
 


### PR DESCRIPTION
## Summary
- Skip `@return` docblock generation in `DocblockReturnArrayFromDirectArrayInstanceRector` when the `ClassMethod` overrides a parent class or interface method
- Follows the existing pattern used by `AddParamArrayDocblockFromDimFetchAccessRector` (same guard, same call-site shape)
- Adds `skip_overridden_method.php.inc` fixture covering the interface + abstract-parent repro from the issue

Fixes rectorphp/rector#9599

## Test plan
- [x] `vendor/bin/phpunit rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/` — 24 tests pass
- [x] Verified the new fixture fails when the guard is removed (proves it exercises the new code path)