### PR TITLE
Fix compatibility with latest phpstan patch 2.1.x-dev

### DIFF
--- a/rules/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\ArrowFunction;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\ArrowFunction;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
@@ -58,7 +59,10 @@ CODE_SAMPLE
             return null;
         }
 
-        $type = $this->nodeTypeResolver->getNativeType($node->expr);
+        // to allow array shape
+        $type = $node->expr instanceof ArrayDimFetch
+            ? $this->getType($node->expr)
+            : $this->nodeTypeResolver->getNativeType($node->expr);
 
         // not valid to add explicit type in PHP
         if ($type->isVoid()->yes()) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9763

step to reproduce:

1. Temporary change composer.json phpstan/phpstan require to 2.1.x-dev
2. Run unit test

```diff
There was 1 failure:

1) Rector\Tests\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector\AddArrowFunctionReturnTypeRectorTest::test#2 with data ('/Users/samsonasik/www/rector-...hp.inc')
Failed on fixture file "return_by_array_shape_type.php.inc"
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
      */
     private function foo(array $values): void
     {
-        $bars = array_map(fn($value): int => $value['bar'], $values);
+        $bars = array_map(fn($value) => $value['bar'], $values);
     }
 }
 
-?>
```

This PR apply the patch to keep working as expected so array shape is keep followed.