### PR TITLE
Temporary pin webmozart/assert to 2.3.0 to make downgrade working

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/process": "^7.4",
         "symplify/easy-parallel": "^11.2.2",
         "symplify/rule-doc-generator-contracts": "^11.2",
-        "webmozart/assert": "^2.3"
+        "webmozart/assert": "2.3.0"
     },
     "require-dev": {
         "boundwize/structarmed": "^0.6",


### PR DESCRIPTION
The latest webmozart assert 2.4.0

https://github.com/webmozarts/assert/releases/tag/2.4.0

cause downgrade notice:

https://github.com/rectorphp/rector-src/actions/runs/26181495364/job/77025550737#step:14:77

This PR temporary pin to 2.3.0 to fix it.

I already created issue to track it to make real fix next:

- https://github.com/rectorphp/rector/issues/9764