### PR TITLE
Bump webmozart/assert to ^2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/process": "^7.4",
         "symplify/easy-parallel": "^11.2.2",
         "symplify/rule-doc-generator-contracts": "^11.2",
-        "webmozart/assert": "^2.4.0"
+        "webmozart/assert": "^2.4"
     },
     "require-dev": {
         "boundwize/structarmed": "^0.6",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/process": "^7.4",
         "symplify/easy-parallel": "^11.2.2",
         "symplify/rule-doc-generator-contracts": "^11.2",
-        "webmozart/assert": "2.3.0"
+        "webmozart/assert": "^2.4.0"
     },
     "require-dev": {
         "boundwize/structarmed": "^0.6",


### PR DESCRIPTION
`webmozart/assert` to 2.4.0 was cause downgrade issue:

https://github.com/rectorphp/rector-src/actions/runs/26181495364/job/77025550737

The temporary solution was pin to `webmozart/assert` 2.3.0.

- https://github.com/rectorphp/rector-src/pull/7998

After some investigation, the issue seems on rector-downgrade-php, which solved at PR:

- https://github.com/rectorphp/rector-downgrade-php/pull/374

This PR bump `webmozart/assert` to ^2.4