### PR TITLE
fix: skip StaticCallToMethodCallRector when parent declares final __construct

### DIFF
--- a/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Fixture/skip_when_parent_has_final_construct.php.inc
+++ b/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Fixture/skip_when_parent_has_final_construct.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Fixture;
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\MissingValue;
+use Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Source\ResourceWithFinalConstruct;
+
+class SkipWhenParentHasFinalConstruct extends ResourceWithFinalConstruct
+{
+    public function toArray(
+        Request $request,
+    ): array {
+        return [
+            'user_id' => $this->user_id ?? App::get(MissingValue::class),
+        ];
+    }
+}

--- a/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Source/ResourceWithFinalConstruct.php
+++ b/rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/Source/ResourceWithFinalConstruct.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Transform\Rector\StaticCall\StaticCallToMethodCallRector\Source;
+
+class ResourceWithFinalConstruct
+{
+    public $resource;
+
+    final public function __construct($resource)
+    {
+        $this->resource = $resource;
+    }
+}

--- a/rules/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector.php
+++ b/rules/CodeQuality/Rector/CallLike/AddNameToBooleanArgumentRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\CodeQuality\Rector\CallLike;
 
+use PhpParser\Node\Expr;
 use PhpParser\Node;
 use PhpParser\Node\Expr\CallLike;
 use Rector\NodeAnalyzer\CallLikeArgumentNameAdder;
@@ -58,7 +59,7 @@ CODE_SAMPLE
     {
         return $this->callLikeArgumentNameAdder->addNamesToArgs(
             $node,
-            fn ($expr): bool => $this->valueResolver->isTrueOrFalse($expr),
+            fn (Expr $expr): bool => $this->valueResolver->isTrueOrFalse($expr),
         );
     }
 

--- a/rules/CodeQuality/Rector/CallLike/AddNameToNullArgumentRector.php
+++ b/rules/CodeQuality/Rector/CallLike/AddNameToNullArgumentRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\CodeQuality\Rector\CallLike;
 
+use PhpParser\Node\Expr;
 use PhpParser\Node;
 use PhpParser\Node\Expr\CallLike;
 use Rector\NodeAnalyzer\CallLikeArgumentNameAdder;
@@ -58,7 +59,7 @@ CODE_SAMPLE
     {
         return $this->callLikeArgumentNameAdder->addNamesToArgs(
             $node,
-            fn ($expr): bool => $this->valueResolver->isNull($expr),
+            fn (Expr $expr): bool => $this->valueResolver->isNull($expr),
         );
     }
 

--- a/rules/Transform/NodeAnalyzer/FuncCallStaticCallToMethodCallAnalyzer.php
+++ b/rules/Transform/NodeAnalyzer/FuncCallStaticCallToMethodCallAnalyzer.php
@@ -36,7 +36,7 @@ final readonly class FuncCallStaticCallToMethodCallAnalyzer
         Class_ $class,
         ClassMethod $classMethod,
         ObjectType $objectType,
-    ): MethodCall | PropertyFetch | Variable {
+    ): MethodCall | PropertyFetch | Variable | null {
         $expr = $this->typeProvidingExprFromClassResolver->resolveTypeProvidingExprFromClass(
             $class,
             $classMethod,
@@ -49,6 +49,11 @@ final readonly class FuncCallStaticCallToMethodCallAnalyzer
             }
 
             return $expr;
+        }
+
+        // Cannot add constructor dependency when nearest parent constructor is final
+        if ($this->classDependencyManipulator->hasFinalParentConstructor($class)) {
+            return null;
         }
 
         $propertyName = $this->propertyNaming->fqnToVariableName($objectType);

--- a/rules/Transform/Rector/FuncCall/FuncCallToMethodCallRector.php
+++ b/rules/Transform/Rector/FuncCall/FuncCallToMethodCallRector.php
@@ -114,6 +114,10 @@ CODE_SAMPLE
                         $funcNameToMethodCallName->getNewObjectType(),
                     );
 
+                    if ($expr === null) {
+                        return null;
+                    }
+
                     $hasChanged = true;
 
                     return $this->nodeFactory->createMethodCall(

--- a/rules/Transform/Rector/StaticCall/StaticCallToMethodCallRector.php
+++ b/rules/Transform/Rector/StaticCall/StaticCallToMethodCallRector.php
@@ -127,6 +127,10 @@ CODE_SAMPLE
                         $staticCallToMethodCall->getClassObjectType(),
                     );
 
+                    if ($expr === null) {
+                        return null;
+                    }
+
                     $methodName = $this->getMethodName($node, $staticCallToMethodCall);
 
                     $hasChanged = true;

--- a/src/NodeAnalyzer/CallLikeArgumentNameAdder.php
+++ b/src/NodeAnalyzer/CallLikeArgumentNameAdder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\NodeAnalyzer;
 
+use PhpParser\Node\Expr;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Identifier;
@@ -26,22 +27,22 @@ final readonly class CallLikeArgumentNameAdder
      * argument whose value satisfies $shouldNameArgValue. All subsequent positional
      * arguments receive names too (required by PHP named-arg semantics).
      *
-     * @param callable(\PhpParser\Node\Expr): bool $shouldNameArgValue
+     * @param callable(Expr):bool $shouldNameArgValue
      */
-    public function addNamesToArgs(CallLike $node, callable $shouldNameArgValue): ?CallLike
+    public function addNamesToArgs(CallLike $callLike, callable $shouldNameArgValue): ?CallLike
     {
-        if ($this->shouldSkip($node)) {
+        if ($this->shouldSkip($callLike)) {
             return null;
         }
 
-        $reflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($node);
+        $reflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($callLike);
         if (! $reflection instanceof FunctionReflection && ! $reflection instanceof MethodReflection) {
             return null;
         }
 
-        $scope = ScopeFetcher::fetch($node);
-        $args = $node->getArgs();
-        $parameters = ParametersAcceptorSelectorVariantsWrapper::select($reflection, $node, $scope)
+        $scope = ScopeFetcher::fetch($callLike);
+        $args = $callLike->getArgs();
+        $parameters = ParametersAcceptorSelectorVariantsWrapper::select($reflection, $callLike, $scope)
             ->getParameters();
 
         $position = $this->resolveFirstPositionToName($args, $parameters, $shouldNameArgValue);
@@ -70,7 +71,7 @@ final readonly class CallLikeArgumentNameAdder
             return null;
         }
 
-        return $node;
+        return $callLike;
     }
 
     private function shouldSkip(CallLike $callLike): bool
@@ -96,7 +97,7 @@ final readonly class CallLikeArgumentNameAdder
     /**
      * @param Arg[] $args
      * @param ParameterReflection[] $parameters
-     * @param callable(\PhpParser\Node\Expr): bool $shouldNameArgValue
+     * @param callable(Expr):bool $shouldNameArgValue
      */
     private function resolveFirstPositionToName(array $args, array $parameters, callable $shouldNameArgValue): ?int
     {

--- a/src/NodeManipulator/ClassDependencyManipulator.php
+++ b/src/NodeManipulator/ClassDependencyManipulator.php
@@ -189,6 +189,43 @@ final readonly class ClassDependencyManipulator
         $classMethod->stmts = array_merge($stmts, (array) $classMethod->stmts);
     }
 
+    public function hasFinalParentConstructor(Class_ $class): bool
+    {
+        if ($class->getMethod(MethodName::CONSTRUCT) instanceof ClassMethod) {
+            return false;
+        }
+
+        $classReflection = $this->reflectionResolver->resolveClassReflection($class);
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        $ancestors = array_filter(
+            $classReflection->getAncestors(),
+            static fn (ClassReflection $ancestor): bool => $ancestor->getName() !== $classReflection->getName()
+        );
+
+        foreach ($ancestors as $ancestor) {
+            if (! $ancestor->hasNativeMethod(MethodName::CONSTRUCT)) {
+                continue;
+            }
+
+            $parentClass = $this->astResolver->resolveClassFromClassReflection($ancestor);
+            if (! $parentClass instanceof ClassLike) {
+                continue;
+            }
+
+            $parentConstructorMethod = $parentClass->getMethod(MethodName::CONSTRUCT);
+            if (! $parentConstructorMethod instanceof ClassMethod) {
+                continue;
+            }
+
+            return $parentConstructorMethod->isFinal();
+        }
+
+        return false;
+    }
+
     private function resolveConstruct(Class_ $class): ?ClassMethod
     {
         $constructorMethod = $class->getMethod(MethodName::CONSTRUCT);


### PR DESCRIPTION
## Summary

Fixes #9766 (reported in rectorphp/rector).

`StaticCallToMethodCallRector` triggered a PHP fatal error when the parent class declared `__construct` as `final`:

> Cannot override final method ParentClass::__construct()

The rule was cloning the parent's `final __construct` and inserting it into the child class to perform constructor injection — but PHP forbids any `__construct` override when the parent's is `final` (unlike `private`, where a fresh child constructor is still valid PHP).

## Changes

- **`ClassDependencyManipulator`** — add `hasFinalParentConstructor(Class_)`: walks the ancestor chain and returns `true` when the nearest constructor is `final` and the class has no own constructor.
- **`FuncCallStaticCallToMethodCallAnalyzer::matchTypeProvidingExpr()`** — widen return type to `… | null`; return `null` when `hasFinalParentConstructor()` is true so the caller can skip the transformation.
- **`StaticCallToMethodCallRector`** and **`FuncCallToMethodCallRector`** — handle `null` return by leaving the node unchanged (no `$hasChanged = true`).
- **New test fixture** `skip_when_parent_has_final_construct.php.inc` (no `-----` = expects no change) + source class `ResourceWithFinalConstruct` with `final public function __construct`.

## Test plan

- [ ] `vendor/bin/phpunit rules-tests/Transform/Rector/StaticCall/StaticCallToMethodCallRector/StaticCallToMethodCallRectorTest.php` — new fixture asserts code is left unchanged; existing fixtures (public parent, private parent, no parent) still pass.
- [ ] `vendor/bin/phpunit rules-tests/Transform/Rector/FuncCall/FuncCallToMethodCallRector/` — no regressions in the sibling rector.
