### PR TITLE
[BetterPhpDocParser] Don't wrap first-position `@method` param union in extra parens

### DIFF
--- a/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/import_method_with_first_param_union.php.inc
+++ b/rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/import_method_with_first_param_union.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\Fixture;
+
+/**
+ * @method static \Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\NormalParamClass disable(string|array ...$classes)
+ */
+class ImportMethodWithFirstParamUnion
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\Fixture;
+
+use Rector\Tests\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\NormalParamClass;
+
+/**
+ * @method static NormalParamClass disable(string|array ...$classes)
+ */
+class ImportMethodWithFirstParamUnion
+{
+}
+
+?>

--- a/src/BetterPhpDocParser/PhpDocNodeVisitor/UnionTypeNodePhpDocNodeVisitor.php
+++ b/src/BetterPhpDocParser/PhpDocNodeVisitor/UnionTypeNodePhpDocNodeVisitor.php
@@ -58,13 +58,13 @@ final class UnionTypeNodePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor imp
     private function isWrappedInCurlyBrackets(BetterTokenIterator $betterTokenProvider, StartAndEnd $startAndEnd): bool
     {
         $previousPosition = $startAndEnd->getStart() - 1;
+        $nextPosition = $startAndEnd->getEnd() + 1;
 
-        if ($betterTokenProvider->isTokenTypeOnPosition(Lexer::TOKEN_OPEN_PARENTHESES, $previousPosition)) {
-            return true;
-        }
-
-        // there is no + 1, as end is right at the next token
-        return $betterTokenProvider->isTokenTypeOnPosition(Lexer::TOKEN_CLOSE_PARENTHESES, $startAndEnd->getEnd());
+        // A union is wrapped only when BOTH parens flank it. Either alone may be unrelated —
+        // e.g. an `@method`'s parameter-list `(` before a first-position union, or the matching
+        // `)` after a last-position union — neither belongs to the union type itself.
+        return $betterTokenProvider->isTokenTypeOnPosition(Lexer::TOKEN_OPEN_PARENTHESES, $previousPosition)
+            && $betterTokenProvider->isTokenTypeOnPosition(Lexer::TOKEN_CLOSE_PARENTHESES, $nextPosition);
     }
 
     private function resolveStartAndEnd(UnionTypeNode $unionTypeNode): ?StartAndEnd


### PR DESCRIPTION
Ran into this using rector's `withImportNames` on a project that generates `@method` docblocks for Laravel facades via [laravel/facade-documenter](https://github.com/laravel/facade-documenter).

## Setup

facade-documenter writes `@method` lines with fully-qualified class names. A facade that imports its proxy ends up like:

```php
use App\Services\ConfigConventionRegistry;

/**
 * @method static \App\Services\ConfigConventionRegistry disable(string|array ...$classes)
 */
class ConfigConvention extends Facade { /* ... */ }
```

Then `vendor/bin/rector process` runs. With `withImportNames` enabled, rector shortens the FQCN to its imported alias, which forces it to reprint the entire `@method` line.

## What it produces

```php
/**
 * @method static ConfigConventionRegistry disable((string|array) ...$classes)
 */
```

Extra parens injected around the first parameter's union.

## What it should produce

```php
/**
 * @method static ConfigConventionRegistry disable(string|array ...$classes)
 */
```

FQCN shortened, union left alone.

## Cause

`UnionTypeNodePhpDocNodeVisitor::isWrappedInCurlyBrackets()` returns true if there's either a `(` immediately before the union or a `)` immediately after. For a union that's the first parameter of an `@method`, the `(` belongs to the method's parameter list, not a type wrap. But the check fires anyway, marks `isWrappedInBrackets = true`, and the reprinter wraps the union.

The close-paren half of that check was also broken. It looked at `getEnd()`, which is the position *of* the union's last token (e.g. `array`), not one past it. The comment `// there is no + 1, as end is right at the next token` assumed `getEnd()` returns one past the union, but `endIndexOfLastRelevantToken()` returns the index of the last token. So the close check never actually matched anything, and the OR was effectively just running the open-paren check.

## Fix

Require both flanking parens, and correct the close offset to `getEnd() + 1`:

```php
$previousPosition = $startAndEnd->getStart() - 1;
$nextPosition = $startAndEnd->getEnd() + 1;

return $betterTokenProvider->isTokenTypeOnPosition(Lexer::TOKEN_OPEN_PARENTHESES, $previousPosition)
    && $betterTokenProvider->isTokenTypeOnPosition(Lexer::TOKEN_CLOSE_PARENTHESES, $nextPosition);
```

A union is wrapped only when both parens really do flank it.

## Test

Added a fixture under `rules-tests/CodingStyle/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/` reproducing the case via name-importing on a class with an `@method` whose first parameter is a union. Fails on `main`, passes here. Full `--testsuite=main` (5201 tests) stays green.