### PR TITLE
Fix compatibility on optional key on array dim fetch to be Mixed on phpstan patch 2.1.x-dev

### DIFF
--- a/src/NodeTypeResolver/NodeTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver.php
@@ -415,7 +415,7 @@ final class NodeTypeResolver
                 continue;
             }
 
-            return $originalNativeType;
+            return new MixedType();
         }
 
         return $type;


### PR DESCRIPTION
@VincentLanglet this should fixes https://github.com/rectorphp/rector/issues/9770

```diff
1) Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\AddMethodCallBasedStrictParamTypeRectorTest::test#20 with data ('/home/runner/work/phpstan/php...hp.inc')
Failed on fixture file "skip_native_optional_array_shape.php.inc"
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
         $this->doBar($shape['dirname']); // dirname is only conditionally returned
     }
 
-    private function doBar($param) {
+    private function doBar(string $param) {
 
     }
 }
```

The other notice is only union order so I think we can just update the fixture once next phpstan released.

```diff
-    public static function extension($filename): array|string
+    public static function extension($filename): string|array
```

step to reproduce:

1.  Temporary change composer.json phpstan/phpstan require to 2.1.x-dev
2.  Run unit test

