### PR TITLE
[sets] kick of named args set

### DIFF
--- a/config/set/named-args.php
+++ b/config/set/named-args.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Attribute\SortAttributeNamedArgsRector;
+use Rector\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector;
+use Rector\CodeQuality\Rector\CallLike\AddNameToNullArgumentRector;
+use Rector\CodeQuality\Rector\FuncCall\SortCallLikeNamedArgsRector;
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
+use Rector\NetteUtils\Rector\StaticCall\UtilsJsonStaticCallNamedArgRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        AddNameToNullArgumentRector::class,
+        AddNameToBooleanArgumentRector::class,
+        RemoveNullArgOnNullDefaultParamRector::class,
+        SortCallLikeNamedArgsRector::class,
+        SortAttributeNamedArgsRector::class,
+        UtilsJsonStaticCallNamedArgRector::class,
+    ]);
+};

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -773,6 +773,7 @@ final class RectorConfigBuilder
         bool $typeDeclarationDocblocks = false,
         bool $privatization = false,
         bool $naming = false,
+        bool $namedArgs = false,
         bool $instanceOf = false,
         bool $earlyReturn = false,
         /** @deprecated */
@@ -801,6 +802,7 @@ final class RectorConfigBuilder
             SetList::TYPE_DECLARATION_DOCBLOCKS => $typeDeclarationDocblocks,
             SetList::PRIVATIZATION => $privatization,
             SetList::NAMING => $naming,
+            SetList::NAMED_ARGS => $namedArgs,
             SetList::INSTANCEOF => $instanceOf,
             SetList::EARLY_RETURN => $earlyReturn,
             SetList::CARBON => $carbon,

--- a/src/Set/ValueObject/SetList.php
+++ b/src/Set/ValueObject/SetList.php
@@ -29,6 +29,8 @@ final class SetList
 
     public const string NAMING = __DIR__ . '/../../../config/set/naming.php';
 
+    public const string NAMED_ARGS = __DIR__ . '/../../../config/set/named-args.php';
+
     /**
      * Opinionated rules that match rector coding standard
      */


### PR DESCRIPTION
Here is kick of from https://github.com/rectorphp/rector/issues/9771

Any rule to add here?
Would it be enough to fix https://github.com/rectorphp/rector/issues/9771?