### PR TITLE
[deprecation] Add RenameDeprecatedMethodCallRector inferring rename from @deprecated docblock

### DIFF
--- a/rules-tests/Renaming/NodeAnalyzer/DeprecatedMethodCallReplacementResolverTest.php
+++ b/rules-tests/Renaming/NodeAnalyzer/DeprecatedMethodCallReplacementResolverTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Renaming\NodeAnalyzer;
+
+use Iterator;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Renaming\NodeAnalyzer\DeprecatedMethodCallReplacementResolver;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\Tests\Renaming\NodeAnalyzer\Source\DeprecatedMethodsClient;
+
+final class DeprecatedMethodCallReplacementResolverTest extends AbstractLazyTestCase
+{
+    private DeprecatedMethodCallReplacementResolver $deprecatedMethodCallReplacementResolver;
+
+    private ReflectionProvider $reflectionProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->deprecatedMethodCallReplacementResolver = $this->make(DeprecatedMethodCallReplacementResolver::class);
+        $this->reflectionProvider = $this->make(ReflectionProvider::class);
+    }
+
+    #[DataProvider('provideData')]
+    public function test(string $methodName, ?string $expectedReplacement): void
+    {
+        $classReflection = $this->reflectionProvider->getClass(DeprecatedMethodsClient::class);
+        $extendedMethodReflection = $classReflection->getNativeMethod($methodName);
+
+        $resolvedReplacement = $this->deprecatedMethodCallReplacementResolver->resolve($extendedMethodReflection);
+        $this->assertSame($expectedReplacement, $resolvedReplacement);
+    }
+
+    /**
+     * @return Iterator<string, array{string, (string | null)}>
+     */
+    public static function provideData(): Iterator
+    {
+        yield 'use ...() instead' => ['getData', 'fetchData'];
+        yield 'replaced by ...()' => ['loadData', 'fetchData'];
+        yield '{@see ...()}' => ['readData', 'fetchData'];
+        yield 'static use ...() instead' => ['makeOld', 'make'];
+        yield 'deprecated without method suggestion' => ['legacyData', null];
+        yield 'suggested method does not exist' => ['vanishedData', null];
+        yield 'suggested method is itself deprecated' => ['deadEndData', null];
+        yield 'not deprecated at all' => ['fetchData', null];
+    }
+}

--- a/rules-tests/Renaming/NodeAnalyzer/Source/DeprecatedMethodsClient.php
+++ b/rules-tests/Renaming/NodeAnalyzer/Source/DeprecatedMethodsClient.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Renaming\NodeAnalyzer\Source;
+
+final class DeprecatedMethodsClient
+{
+    /**
+     * @deprecated since 2.0, use fetchData() instead
+     */
+    public function getData(): array
+    {
+        return $this->fetchData();
+    }
+
+    /**
+     * @deprecated replaced by fetchData()
+     */
+    public function loadData(): array
+    {
+        return $this->fetchData();
+    }
+
+    /**
+     * @deprecated {@see fetchData()}
+     */
+    public function readData(): array
+    {
+        return $this->fetchData();
+    }
+
+    /**
+     * @deprecated since 2.0, use the repository layer instead
+     */
+    public function legacyData(): array
+    {
+        return $this->fetchData();
+    }
+
+    /**
+     * @deprecated use missingMethod() instead
+     */
+    public function vanishedData(): array
+    {
+        return $this->fetchData();
+    }
+
+    /**
+     * @deprecated use loadData() instead
+     */
+    public function deadEndData(): array
+    {
+        return $this->fetchData();
+    }
+
+    public function fetchData(): array
+    {
+        return [];
+    }
+
+    /**
+     * @deprecated use make() instead
+     */
+    public static function makeOld(): self
+    {
+        return new self();
+    }
+
+    public static function make(): self
+    {
+        return new self();
+    }
+}

--- a/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/rename_replaced_by.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/rename_replaced_by.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source\SomeApiClient;
+
+function renameReplacedBy(SomeApiClient $apiClient)
+{
+    return $apiClient->loadData();
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source\SomeApiClient;
+
+function renameReplacedBy(SomeApiClient $apiClient)
+{
+    return $apiClient->fetchData();
+}
+
+?>

--- a/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/rename_see_tag.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/rename_see_tag.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source\SomeApiClient;
+
+function renameSeeTag(SomeApiClient $apiClient)
+{
+    return $apiClient->readData();
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source\SomeApiClient;
+
+function renameSeeTag(SomeApiClient $apiClient)
+{
+    return $apiClient->fetchData();
+}
+
+?>

--- a/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/rename_static_call.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/rename_static_call.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source\SomeApiClient;
+
+function renameStaticCall()
+{
+    return SomeApiClient::makeOld();
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source\SomeApiClient;
+
+function renameStaticCall()
+{
+    return SomeApiClient::make();
+}
+
+?>

--- a/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/rename_use_instead.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/rename_use_instead.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source\SomeApiClient;
+
+function renameUseInstead(SomeApiClient $apiClient)
+{
+    return $apiClient->getData();
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source\SomeApiClient;
+
+function renameUseInstead(SomeApiClient $apiClient)
+{
+    return $apiClient->fetchData();
+}
+
+?>

--- a/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/skip_magic_method_suggestion.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/skip_magic_method_suggestion.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source\MagicMethodApiClient;
+
+function skipMagicMethodSuggestion(MagicMethodApiClient $apiClient)
+{
+    // suggested fetchData() exists only as a @method magic method, not a real native one
+    return $apiClient->getData();
+}

--- a/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/skip_no_suggestion.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/skip_no_suggestion.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source\SomeApiClient;
+
+function skipNoSuggestion(SomeApiClient $apiClient)
+{
+    // @deprecated description has no "use newMethod()" hint
+    return $apiClient->legacyData();
+}

--- a/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/skip_not_deprecated.php.inc
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Fixture/skip_not_deprecated.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Fixture;
+
+use Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source\SomeApiClient;
+
+function skipNotDeprecated(SomeApiClient $apiClient)
+{
+    return $apiClient->fetchData();
+}

--- a/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/RenameDeprecatedMethodCallRectorTest.php
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/RenameDeprecatedMethodCallRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RenameDeprecatedMethodCallRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Source/MagicMethodApiClient.php
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Source/MagicMethodApiClient.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source;
+
+/**
+ * @method array fetchData()
+ */
+final class MagicMethodApiClient
+{
+    /**
+     * @deprecated use fetchData() instead
+     */
+    public function getData(): array
+    {
+        return [];
+    }
+
+    public function __call(string $name, array $arguments): array
+    {
+        return [];
+    }
+}

--- a/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Source/SomeApiClient.php
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/Source/SomeApiClient.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\Source;
+
+final class SomeApiClient
+{
+    /**
+     * @deprecated since 2.0, use fetchData() instead
+     */
+    public function getData(): array
+    {
+        return $this->fetchData();
+    }
+
+    /**
+     * @deprecated replaced by fetchData()
+     */
+    public function loadData(): array
+    {
+        return $this->fetchData();
+    }
+
+    /**
+     * @deprecated {@see fetchData()}
+     */
+    public function readData(): array
+    {
+        return $this->fetchData();
+    }
+
+    /**
+     * @deprecated since 2.0, use the repository layer instead
+     */
+    public function legacyData(): array
+    {
+        return $this->fetchData();
+    }
+
+    public function fetchData(): array
+    {
+        return [];
+    }
+
+    /**
+     * @deprecated use make() instead
+     */
+    public static function makeOld(): self
+    {
+        return new self();
+    }
+
+    public static function make(): self
+    {
+        return new self();
+    }
+}

--- a/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/config/configured_rule.php
+++ b/rules-tests/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector;
+
+return RectorConfig::configure()
+    ->withRules([RenameDeprecatedMethodCallRector::class]);

--- a/rules/Renaming/NodeAnalyzer/DeprecatedMethodCallReplacementResolver.php
+++ b/rules/Renaming/NodeAnalyzer/DeprecatedMethodCallReplacementResolver.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Renaming\NodeAnalyzer;
+
+use Nette\Utils\Strings;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+
+/**
+ * @see \Rector\Tests\Renaming\NodeAnalyzer\DeprecatedMethodCallReplacementResolverTest
+ */
+final class DeprecatedMethodCallReplacementResolver
+{
+    /**
+     * Matches the new method name suggested inside a "@deprecated" description, e.g.:
+     *  - "use newMethod() instead"
+     *  - "replaced by newMethod()"
+     *  - "{@see newMethod()}"
+     *
+     * Cross-class suggestions ("Other::newMethod()") are intentionally skipped for now.
+     */
+    private const string RENAME_SUGGESTION_REGEX = '#(?:\buse\b|\breplaced by\b|\{@see)\s+(?<method>\w+)\(\)#i';
+
+    /**
+     * Resolves a non-deprecated replacement method name suggested by the "@deprecated" docblock
+     * of the given method, or null when there is no usable suggestion.
+     */
+    public function resolve(MethodReflection $methodReflection): ?string
+    {
+        if (! $methodReflection->isDeprecated()->yes()) {
+            return null;
+        }
+
+        $newMethodName = $this->matchNewMethodName($methodReflection->getDeprecatedDescription());
+        if ($newMethodName === null) {
+            return null;
+        }
+
+        // already the suggested name? nothing to do
+        if (strtolower($methodReflection->getName()) === strtolower($newMethodName)) {
+            return null;
+        }
+
+        if (! $this->isExistingNonDeprecatedMethod($methodReflection->getDeclaringClass(), $newMethodName)) {
+            return null;
+        }
+
+        return $newMethodName;
+    }
+
+    private function matchNewMethodName(?string $deprecatedDescription): ?string
+    {
+        if ($deprecatedDescription === null || $deprecatedDescription === '') {
+            return null;
+        }
+
+        $match = Strings::match($deprecatedDescription, self::RENAME_SUGGESTION_REGEX);
+        if ($match === null) {
+            return null;
+        }
+
+        return $match['method'];
+    }
+
+    private function isExistingNonDeprecatedMethod(ClassReflection $classReflection, string $newMethodName): bool
+    {
+        if (! $classReflection->hasNativeMethod($newMethodName)) {
+            return false;
+        }
+
+        // do not rename onto another deprecated method, to avoid suggesting a dead end
+        $extendedMethodReflection = $classReflection->getNativeMethod($newMethodName);
+        return ! $extendedMethodReflection->isDeprecated()
+            ->yes();
+    }
+}

--- a/rules/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector.php
+++ b/rules/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\Renaming\Rector\MethodCall;
 
-use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
+use Rector\Renaming\NodeAnalyzer\DeprecatedMethodCallReplacementResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,18 +20,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RenameDeprecatedMethodCallRector extends AbstractRector
 {
-    /**
-     * Matches the new method name suggested inside a "@deprecated" description, e.g.:
-     *  - "use newMethod() instead"
-     *  - "replaced by newMethod()"
-     *  - "{@see newMethod()}"
-     *
-     * Cross-class suggestions ("Other::newMethod()") are intentionally skipped for now.
-     */
-    private const string RENAME_SUGGESTION_REGEX = '#(?:\buse\b|\breplaced by\b|\{@see)\s+(?<method>\w+)\(\)#i';
-
     public function __construct(
-        private readonly ReflectionResolver $reflectionResolver
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly DeprecatedMethodCallReplacementResolver $deprecatedMethodCallReplacementResolver
     ) {
     }
 
@@ -71,65 +61,23 @@ CODE_SAMPLE
             return null;
         }
 
-        $callName = $this->getName($node->name);
-        if ($callName === null) {
+        if ($this->getName($node->name) === null) {
             return null;
         }
 
-        $methodReflection = $node instanceof MethodCall
-            ? $this->reflectionResolver->resolveMethodReflectionFromMethodCall($node)
-            : $this->reflectionResolver->resolveMethodReflectionFromStaticCall($node);
+        $methodReflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($node);
 
         if (! $methodReflection instanceof MethodReflection) {
             return null;
         }
 
-        if (! $methodReflection->isDeprecated()->yes()) {
-            return null;
-        }
-
-        $newMethodName = $this->matchNewMethodName($methodReflection->getDeprecatedDescription());
+        $newMethodName = $this->deprecatedMethodCallReplacementResolver->resolve($methodReflection);
         if ($newMethodName === null) {
-            return null;
-        }
-
-        // already the suggested name? nothing to do
-        if ($this->nodeNameResolver->isStringName($callName, $newMethodName)) {
-            return null;
-        }
-
-        if (! $this->isExistingNonDeprecatedMethod($methodReflection->getDeclaringClass(), $newMethodName)) {
             return null;
         }
 
         $node->name = new Identifier($newMethodName);
 
         return $node;
-    }
-
-    private function matchNewMethodName(?string $deprecatedDescription): ?string
-    {
-        if ($deprecatedDescription === null || $deprecatedDescription === '') {
-            return null;
-        }
-
-        $match = Strings::match($deprecatedDescription, self::RENAME_SUGGESTION_REGEX);
-        if ($match === null) {
-            return null;
-        }
-
-        return $match['method'];
-    }
-
-    private function isExistingNonDeprecatedMethod(ClassReflection $classReflection, string $newMethodName): bool
-    {
-        if (! $classReflection->hasMethod($newMethodName)) {
-            return false;
-        }
-
-        // do not rename onto another deprecated method, to avoid suggesting a dead end
-        $extendedMethodReflection = $classReflection->getNativeMethod($newMethodName);
-        return ! $extendedMethodReflection->isDeprecated()
-            ->yes();
     }
 }

--- a/rules/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector.php
+++ b/rules/Renaming/Rector/MethodCall/RenameDeprecatedMethodCallRector.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Renaming\Rector\MethodCall;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\Renaming\Rector\MethodCall\RenameDeprecatedMethodCallRector\RenameDeprecatedMethodCallRectorTest
+ */
+final class RenameDeprecatedMethodCallRector extends AbstractRector
+{
+    /**
+     * Matches the new method name suggested inside a "@deprecated" description, e.g.:
+     *  - "use newMethod() instead"
+     *  - "replaced by newMethod()"
+     *  - "{@see newMethod()}"
+     *
+     * Cross-class suggestions ("Other::newMethod()") are intentionally skipped for now.
+     */
+    private const string RENAME_SUGGESTION_REGEX = '#(?:\buse\b|\breplaced by\b|\{@see)\s+(?<method>\w+)\(\)#i';
+
+    public function __construct(
+        private readonly ReflectionResolver $reflectionResolver
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Rename method calls whose target method is "@deprecated" and suggests a replacement method on the same class',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$someObject->oldMethod();
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$someObject->newMethod();
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        $callName = $this->getName($node->name);
+        if ($callName === null) {
+            return null;
+        }
+
+        $methodReflection = $node instanceof MethodCall
+            ? $this->reflectionResolver->resolveMethodReflectionFromMethodCall($node)
+            : $this->reflectionResolver->resolveMethodReflectionFromStaticCall($node);
+
+        if (! $methodReflection instanceof MethodReflection) {
+            return null;
+        }
+
+        if (! $methodReflection->isDeprecated()->yes()) {
+            return null;
+        }
+
+        $newMethodName = $this->matchNewMethodName($methodReflection->getDeprecatedDescription());
+        if ($newMethodName === null) {
+            return null;
+        }
+
+        // already the suggested name? nothing to do
+        if ($this->nodeNameResolver->isStringName($callName, $newMethodName)) {
+            return null;
+        }
+
+        if (! $this->isExistingNonDeprecatedMethod($methodReflection->getDeclaringClass(), $newMethodName)) {
+            return null;
+        }
+
+        $node->name = new Identifier($newMethodName);
+
+        return $node;
+    }
+
+    private function matchNewMethodName(?string $deprecatedDescription): ?string
+    {
+        if ($deprecatedDescription === null || $deprecatedDescription === '') {
+            return null;
+        }
+
+        $match = Strings::match($deprecatedDescription, self::RENAME_SUGGESTION_REGEX);
+        if ($match === null) {
+            return null;
+        }
+
+        return $match['method'];
+    }
+
+    private function isExistingNonDeprecatedMethod(ClassReflection $classReflection, string $newMethodName): bool
+    {
+        if (! $classReflection->hasMethod($newMethodName)) {
+            return false;
+        }
+
+        // do not rename onto another deprecated method, to avoid suggesting a dead end
+        $extendedMethodReflection = $classReflection->getNativeMethod($newMethodName);
+        return ! $extendedMethodReflection->isDeprecated()
+            ->yes();
+    }
+}


### PR DESCRIPTION
## Description

New core rule `RenameDeprecatedMethodCallRector`. It looks for method calls (`MethodCall`, `StaticCall`) where the **called** method carries a `@deprecated` annotation, infers a simple replacement method name from the docblock, and renames the call.

### Example

Given a class whose method is `@deprecated` with a replacement hint:

```php
final class SomeApiClient
{
    /**
     * @deprecated since 2.0, use fetchData() instead
     */
    public function getData(): array
    {
        return $this->fetchData();
    }

    public function fetchData(): array
    {
        return [];
    }
}
```

the rule rewrites calls to the deprecated method:

```diff
-$someApiClient->getData();
+$someApiClient->fetchData();
```

The same applies to static calls and the `replaced by newMethod()` / `{@see newMethod()}` docblock forms.

### How it works
1. Resolves the called method's reflection via `ReflectionResolver`.
2. Hands the reflection to `DeprecatedMethodCallReplacementResolver`, which:
   - skips unless `isDeprecated()->yes()`;
   - parses `getDeprecatedDescription()` for a replacement name in three common forms:
     - `use newMethod() instead`
     - `replaced by newMethod()`
     - `{@see newMethod()}`
   - **Safety guard:** only returns a name if the suggested method actually exists on the same declaring class, and is not itself deprecated (avoids dead-end renames).
3. If a replacement name comes back, the call's method name is swapped.

### Scope / limitations (intentional for this first cut)
- Same-class method rename only; cross-class `Other::newMethod()` suggestions are skipped.
- `NullsafeMethodCall` not handled (not yet supported by `ReflectionResolver`).
- A standalone sibling `@see` tag (outside the `@deprecated` text) is not read; only inline `{@see ...}`.
- Registered in the rule's test config only, not wired into any set.

### Tests
6 rule fixtures (use-instead / replaced-by / {@see} / static call + 2 skips) backed by a `Source/SomeApiClient` fixture, plus a dedicated unit test for `DeprecatedMethodCallReplacementResolver` covering each docblock form and every bail-out path. ECS, PHPStan level 8, and Rector all pass on the new code.
