### PR TITLE
Fix RemoveParentCallWithoutParentRector removing valid call when ancestor hierarchy is unresolvable

### DIFF
--- a/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/Fixture/skip_broken_hierarchy.php.inc
+++ b/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/Fixture/skip_broken_hierarchy.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\Source\SkipBrokenHierarchyParent;
+
+class SkipBrokenHierarchy extends SkipBrokenHierarchyParent
+{
+    public function run()
+    {
+        parent::run();
+    }
+}

--- a/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/Source/SkipBrokenHierarchyParent.php
+++ b/rules-tests/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector/Source/SkipBrokenHierarchyParent.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector\Source;
+
+// the grandparent class is not autoloadable, so the ancestor chain cannot be
+// fully resolved and the called method cannot be safely declared as missing
+abstract class SkipBrokenHierarchyParent extends NonAutoloadableGrandParent
+{
+}

--- a/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
+++ b/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
@@ -16,6 +16,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use Rector\Enum\ObjectReference;
 use Rector\NodeAnalyzer\ClassAnalyzer;
 use Rector\NodeManipulator\ClassMethodManipulator;
+use Rector\PhpParser\AstResolver;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -28,7 +29,8 @@ final class RemoveParentCallWithoutParentRector extends AbstractRector
     public function __construct(
         private readonly ClassMethodManipulator $classMethodManipulator,
         private readonly ClassAnalyzer $classAnalyzer,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly AstResolver $astResolver
     ) {
     }
 
@@ -160,6 +162,36 @@ CODE_SAMPLE
             return false;
         }
 
-        return $this->classMethodManipulator->hasParentMethodOrInterfaceMethod($class, $calledMethodName);
+        if ($this->classMethodManipulator->hasParentMethodOrInterfaceMethod($class, $calledMethodName)) {
+            return true;
+        }
+
+        // the called method may be defined in an ancestor that cannot be resolved
+        // (e.g. a grandparent class is not autoloadable); in that case we cannot
+        // safely tell the method does not exist, so the call must not be removed
+        return $this->hasUnresolvableAncestor($class->extends);
+    }
+
+    private function hasUnresolvableAncestor(Name $parentName): bool
+    {
+        $parentClassName = $this->getName($parentName);
+        if (! is_string($parentClassName)) {
+            return false;
+        }
+
+        if (! $this->reflectionProvider->hasClass($parentClassName)) {
+            return true;
+        }
+
+        $parentClass = $this->astResolver->resolveClassFromName($parentClassName);
+        if (! $parentClass instanceof Class_) {
+            return false;
+        }
+
+        if (! $parentClass->extends instanceof Name) {
+            return false;
+        }
+
+        return $this->hasUnresolvableAncestor($parentClass->extends);
     }
 }


### PR DESCRIPTION
Fixes rectorphp/rector#9700

## Problem

`RemoveParentCallWithoutParentRector` decides whether a `parent::method()` call is dead by walking `ClassReflection::getParents()` via `hasParentMethodOrInterfaceMethod()`. When an intermediate ancestor in the chain cannot be resolved (e.g. a grandparent class is not autoloadable), `getParents()` silently stops at the unresolvable class. The method actually defined further up the chain is therefore not found, and a valid `parent::method()` call gets removed.

## Fix

When the method is not found among the resolvable parents, walk the declared `extends` chain through the AST (`AstResolver`). If any declared ancestor cannot be resolved by the `ReflectionProvider`, we cannot safely conclude the method does not exist, so the call is kept.

## Test

Added `skip_broken_hierarchy.php.inc`: a class whose parent (`SkipBrokenHierarchyParent`) extends a non-autoloadable grandparent. The `parent::run()` call must be preserved. Verified the fixture fails before the fix and passes after.