### PR TITLE
Fix RemoveDeadIfBlockRector dropping else block when merging empty if with elseif

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveDeadIfBlockRector/Fixture/empty_if_with_elseif_and_else.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveDeadIfBlockRector/Fixture/empty_if_with_elseif_and_else.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveDeadIfBlockRector\Fixture;
+
+class EmptyIfWithElseIfAndElse
+{
+    public function calculatePrice($qty, $cond, $price1, $price2)
+    {
+        if ($qty < 1) {
+        } elseif (!$cond) {
+            $total = $qty * $price1;
+        } else {
+            $total = $qty * $price2;
+        }
+
+        return $total;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveDeadIfBlockRector\Fixture;
+
+class EmptyIfWithElseIfAndElse
+{
+    public function calculatePrice($qty, $cond, $price1, $price2)
+    {
+        if ($qty >= 1 && !$cond) {
+            $total = $qty * $price1;
+        } else {
+            $total = $qty * $price2;
+        }
+
+        return $total;
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/If_/RemoveDeadIfBlockRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveDeadIfBlockRector.php
@@ -143,6 +143,8 @@ CODE_SAMPLE
                 $if->elseifs = \array_slice($node->elseifs, 1);
             }
 
+            $if->else = $node->else;
+
             return $this->refactor($if) ?? $if;
         }
 


### PR DESCRIPTION
Fixes rectorphp/rector#9776

## Problem

When an `if` block has an empty body but is followed by an `elseif` (with statements) **and** an `else` block, `RemoveDeadIfBlockRector` merges the negated `if` condition into the first `elseif`, but silently drops the `else` block.

### Input
```php
if ($qty < 1) {
} elseif (!$cond) {
    $total = $qty * $price1;
} else {
    $total = $qty * $price2;
}
```

### Actual (buggy)
```php
if ($qty >= 1 && !$cond) {
    $total = $qty * $price1;
}
```

### Expected
```php
if ($qty >= 1 && !$cond) {
    $total = $qty * $price1;
} else {
    $total = $qty * $price2;
}
```

## Fix

When constructing the new merged `If_` node, carry over the original `else` block (alongside the already-handled remaining `elseifs`).

A fixture covering the issue's reproduction has been added.