### PR TITLE
Fix ReplaceArgumentDefaultValueRector generating invalid self:: constant in unrelated classes

### DIFF
--- a/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Fixture/replace_self_constant_in_subclass.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Fixture/replace_self_constant_in_subclass.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Source\SomeSortableObject;
+
+class ReplaceSelfConstantInSubclass extends SomeSortableObject
+{
+    public function run()
+    {
+        $this->sortBy(self::SORT_ORDER_ASC);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Source\SomeSortableObject;
+
+class ReplaceSelfConstantInSubclass extends SomeSortableObject
+{
+    public function run()
+    {
+        $this->sortBy(self::SORT_ORDER_DESC);
+    }
+}
+
+?>

--- a/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Fixture/skip_self_constant_in_unrelated_class.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Fixture/skip_self_constant_in_unrelated_class.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Source\SomeSortableObject;
+
+class SkipSelfConstantInUnrelatedClass
+{
+    public function run()
+    {
+        $object = new SomeSortableObject();
+        $object->sortBy(SomeSortableObject::SORT_ORDER_ASC);
+    }
+}

--- a/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Source/SomeSortableObject.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Source/SomeSortableObject.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Source;
+
+class SomeSortableObject
+{
+    public const SORT_ORDER_ASC = 'ASC';
+
+    public const SORT_ORDER_DESC = 'DESC';
+
+    public function sortBy(string $dir)
+    {
+    }
+}

--- a/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/config/configured_rule.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/config/configured_rule.php
@@ -7,6 +7,7 @@ use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
 use Rector\Config\RectorConfig;
 use Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Fixture\ReplaceInConstructor;
 use Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Fixture\ReplaceMethodArgumentWithConstant;
+use Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Source\SomeSortableObject;
 use Rector\ValueObject\MethodName;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -84,6 +85,14 @@ return static function (RectorConfig $rectorConfig): void {
                 0,
                 'path',
                 'Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Fixture\SomeBase::PATH'
+            ),
+
+            new ReplaceArgumentDefaultValue(
+                SomeSortableObject::class,
+                'sortBy',
+                0,
+                'ASC',
+                'self::SORT_ORDER_DESC'
             ),
         ]);
 };

--- a/rules/Arguments/ArgumentDefaultValueReplacer.php
+++ b/rules/Arguments/ArgumentDefaultValueReplacer.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Reflection\ClassReflection;
 use Rector\Arguments\Contract\ReplaceArgumentDefaultValueInterface;
 use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
 use Rector\NodeAnalyzer\ArgsAnalyzer;
@@ -23,6 +24,7 @@ use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpParser\AstResolver;
 use Rector\PhpParser\Node\NodeFactory;
 use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
 final readonly class ArgumentDefaultValueReplacer
@@ -32,7 +34,8 @@ final readonly class ArgumentDefaultValueReplacer
         private ValueResolver $valueResolver,
         private ArgsAnalyzer $argsAnalyzer,
         private AstResolver $astResolver,
-        private NodeTypeResolver $nodeTypeResolver
+        private NodeTypeResolver $nodeTypeResolver,
+        private ReflectionResolver $reflectionResolver
     ) {
     }
 
@@ -171,6 +174,23 @@ final readonly class ArgumentDefaultValueReplacer
                     && $type->getClassName() === $targetClass
                     && $particularArg->value->name instanceof Identifier
                     && $particularArg->value->name->toString() === $targetConstant) {
+                    return null;
+                }
+            }
+
+            // when the replacement value is a self::/static::/parent:: constant, it only
+            // resolves correctly if the class around the call actually has that constant;
+            // otherwise the produced code would reference a non-existing constant
+            if ($normalizedValueAfter instanceof ClassConstFetch
+                && $normalizedValueAfter->class instanceof Name
+                && $normalizedValueAfter->class->isSpecialClassName()
+                && $normalizedValueAfter->name instanceof Identifier) {
+                $classReflection = $this->reflectionResolver->resolveClassReflection($expr);
+                if (! $classReflection instanceof ClassReflection) {
+                    return null;
+                }
+
+                if (! $classReflection->hasConstant($normalizedValueAfter->name->toString())) {
                     return null;
                 }
             }


### PR DESCRIPTION
Fixes rectorphp/rector#9737

## Problem

When `ReplaceArgumentDefaultValueRector` is configured with a `self::SOME_CONSTANT` replacement value, the rule inserted it blindly into every matching call, regardless of the class surrounding that call.

If the surrounding class does not have the constant (e.g. it does not extend the class that declares it), the produced code references a non-existing constant and crashes at runtime:

```php
class Test4 // does NOT extend Super
{
    public function testSelf()
    {
        $test = new Test3(); // Test3 extends Super
        // before: $test->replaceSelf(Super::SORT_ORDER_ASC);
        // after (broken): $test->replaceSelf(self::SORT_ORDER_DESC); // self = Test4, no such const!
    }
}
```

## Fix

Before applying a `self::`/`static::`/`parent::` constant replacement, verify the class around the call actually has that constant (including inherited ones). If it does not, the replacement is skipped so no broken code is generated.

Calls inside subclasses that legitimately inherit the constant keep being refactored as before.

## Tests

Added two fixtures to the existing rule test set:
- `replace_self_constant_in_subclass.php.inc` — subclass inherits the constant, replacement applied.
- `skip_self_constant_in_unrelated_class.php.inc` — unrelated class lacks the constant, replacement skipped.