### PR TITLE
Fix StaticCallOnNonStaticToInstanceCallRector emitting $this in static methods

### DIFF
--- a/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/skip_static_closure_scope.php.inc
+++ b/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/skip_static_closure_scope.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Fixture;
+
+class SkipStaticClosureScope
+{
+    public function where(string $column, $value)
+    {
+        return $this;
+    }
+
+    public static function boot(): callable
+    {
+        return static function () {
+            return SkipStaticClosureScope::where('active', true);
+        };
+    }
+}

--- a/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/skip_static_method_scope.php.inc
+++ b/rules-tests/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/skip_static_method_scope.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Fixture;
+
+class SkipStaticMethodScope
+{
+    public function create(array $data)
+    {
+        return $this;
+    }
+
+    public static function make(array $data)
+    {
+        return SkipStaticMethodScope::create($data);
+    }
+}

--- a/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
+++ b/rules/Php70/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
@@ -126,6 +126,11 @@ CODE_SAMPLE
 
         $classReflection = $scope->getClassReflection();
         if ($classReflection instanceof ClassReflection && $classReflection->getName() === $className) {
+            // no $this in static scope (method/closure/arrow fn)
+            if (! $scope->hasVariableType('this')->yes()) {
+                return null;
+            }
+
             return new MethodCall(new Variable('this'), $node->name, $node->args);
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9647

`StaticCallOnNonStaticToInstanceCallRector` should no longer refactor static calls to `$this` inside of static methods.

Issue outline: https://github.com/nikspyratos/rector-static-call-repro

Swap rector-src for this fork + branch in the reproduction project to see it work as well