### PR TITLE
Fix unchanged-files cache missing changes induced by changed dependencies

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -173,7 +173,11 @@ final class ApplicationFileProcessor
         if ($fileProcessResult->getSystemErrors() !== []) {
             $this->changedFilesDetector->invalidateFile($file->getFilePath());
         } elseif (! $configuration->isDryRun() || ! $fileProcessResult->getFileDiff() instanceof FileDiff) {
-            $this->changedFilesDetector->cacheFile($file->getFilePath());
+            // a file clean under a subset of rules is not necessarily clean under all rules,
+            // caching it would hide its pending changes from the next full run
+            if ($configuration->getOnlyRule() === null && $configuration->getOnlySuffix() === null) {
+                $this->changedFilesDetector->cacheFile($file->getFilePath());
+            }
         }
 
         return $fileProcessResult;

--- a/src/Caching/Detector/ChangedFilesDetector.php
+++ b/src/Caching/Detector/ChangedFilesDetector.php
@@ -7,6 +7,7 @@ namespace Rector\Caching\Detector;
 use Rector\Caching\Cache;
 use Rector\Caching\Config\FileHashComputer;
 use Rector\Caching\Enum\CacheKey;
+use Rector\Caching\FileDependencyCollector;
 use Rector\Util\FileHasher;
 
 /**
@@ -24,7 +25,8 @@ final class ChangedFilesDetector
     public function __construct(
         private readonly FileHashComputer $fileHashComputer,
         private readonly Cache $cache,
-        private readonly FileHasher $fileHasher
+        private readonly FileHasher $fileHasher,
+        private readonly FileDependencyCollector $fileDependencyCollector
     ) {
     }
 
@@ -36,9 +38,26 @@ final class ChangedFilesDetector
             return;
         }
 
-        $hash = $this->hashFile($filePath);
+        // a failed capture means a possibly incomplete set, skip caching so the file is reprocessed
+        $dependencyHashes = $this->fileDependencyCollector->getDependencyFileHashes($filePath);
+        if ($dependencyHashes === null) {
+            return;
+        }
 
-        $this->cache->save($filePathCacheKey, CacheKey::FILE_HASH_KEY, $hash);
+        // the file may have just been written, recompute its hash fresh
+        // rather than trusting a memo entry from the pre-write filter pass
+        $this->fileDependencyCollector->forgetContentHash($filePath);
+        $ownHash = $this->fileDependencyCollector->contentHash($filePath);
+        if ($ownHash === null) {
+            return;
+        }
+
+        // store the own content hash plus one per dependency, so a dependency change
+        // invalidates this file even when its own content is unchanged
+        $this->cache->save($filePathCacheKey, CacheKey::FILE_HASH_KEY, [
+            'hash' => $ownHash,
+            'deps' => $dependencyHashes,
+        ]);
     }
 
     public function addCacheableFile(string $filePath): void
@@ -52,13 +71,27 @@ final class ChangedFilesDetector
         $fileInfoCacheKey = $this->getFilePathCacheKey($filePath);
         $cachedValue = $this->cache->load($fileInfoCacheKey, CacheKey::FILE_HASH_KEY);
 
-        if ($cachedValue !== null) {
-            $currentFileHash = $this->hashFile($filePath);
-            return $currentFileHash !== $cachedValue;
+        // no value to compare against → be defensive and assume changed
+        if ($cachedValue === null) {
+            return true;
         }
 
-        // we don't have a value to compare against. Be defensive and assume its changed
-        return true;
+        // legacy string entry → own-hash comparison only, rewritten in the new format on next cacheFile()
+        if (is_string($cachedValue)) {
+            return $this->fileDependencyCollector->contentHash($filePath) !== $cachedValue;
+        }
+
+        if (! is_array($cachedValue)) {
+            return true;
+        }
+
+        // own content changed
+        if (($cachedValue['hash'] ?? null) !== $this->fileDependencyCollector->contentHash($filePath)) {
+            return true;
+        }
+
+        // any recorded dependency changed
+        return $this->fileDependencyCollector->hasAnyChangedDependency($cachedValue['deps'] ?? []);
     }
 
     public function invalidateFile(string $filePath): void
@@ -96,11 +129,6 @@ final class ChangedFilesDetector
     private function getFilePathCacheKey(string $filePath): string
     {
         return $this->fileHasher->hash($this->resolvePath($filePath));
-    }
-
-    private function hashFile(string $filePath): string
-    {
-        return $this->fileHasher->hashFiles([$this->resolvePath($filePath)]);
     }
 
     private function storeConfigurationDataHash(string $filePath, string $configurationHash): void

--- a/src/Caching/FileDependencyCollector.php
+++ b/src/Caching/FileDependencyCollector.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Caching;
+
+use Rector\Contract\DependencyInjection\ResettableInterface;
+use Rector\Util\FileHasher;
+
+/**
+ * Collects the files each processed file depends on, as surfaced by PHPStan's
+ * DependencyResolver during scope resolution, and provides memoized content hashes
+ * for dependency validation by the unchanged-files cache.
+ */
+final class FileDependencyCollector implements ResettableInterface
+{
+    /**
+     * @var array<string, array<string, true>>
+     */
+    private array $dependenciesByFile = [];
+
+    /**
+     * files whose capture threw, their possibly partial set must never be cached
+     *
+     * @var array<string, true>
+     */
+    private array $failedFiles = [];
+
+    /**
+     * keyed by the given path, so memo hits skip realpath() as well
+     *
+     * @var array<string, string|null>
+     */
+    private array $contentHashMemo = [];
+
+    /**
+     * a function's signature dependencies are identical at every call site
+     *
+     * @var array<string, string[]>
+     */
+    private array $functionDependencyFilesMemo = [];
+
+    public function __construct(
+        private readonly FileHasher $fileHasher,
+    ) {
+    }
+
+    public function record(string $filePath, string $dependencyFilePath): void
+    {
+        if ($filePath === $dependencyFilePath) {
+            return;
+        }
+
+        $this->dependenciesByFile[$filePath][$dependencyFilePath] = true;
+    }
+
+    public function markFailed(string $filePath): void
+    {
+        $this->failedFiles[$filePath] = true;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getMemoizedFunctionDependencyFiles(string $functionKey): ?array
+    {
+        return $this->functionDependencyFilesMemo[$functionKey] ?? null;
+    }
+
+    /**
+     * @param string[] $dependencyFiles
+     */
+    public function memoizeFunctionDependencyFiles(string $functionKey, array $dependencyFiles): void
+    {
+        $this->functionDependencyFilesMemo[$functionKey] = $dependencyFiles;
+    }
+
+    /**
+     * @return array<string, string>|null null when capture failed and the set cannot be trusted
+     */
+    public function getDependencyFileHashes(string $filePath): ?array
+    {
+        if (isset($this->failedFiles[$filePath])) {
+            return null;
+        }
+
+        $dependencyHashes = [];
+        foreach (array_keys($this->dependenciesByFile[$filePath] ?? []) as $dependencyFile) {
+            $dependencyHash = $this->contentHash($dependencyFile);
+            if ($dependencyHash !== null) {
+                $dependencyHashes[$dependencyFile] = $dependencyHash;
+            }
+        }
+
+        return $dependencyHashes;
+    }
+
+    /**
+     * @param array<string, string> $recordedDependencyHashes
+     */
+    public function hasAnyChangedDependency(array $recordedDependencyHashes): bool
+    {
+        foreach ($recordedDependencyHashes as $dependencyFile => $recordedHash) {
+            if ($this->contentHash($dependencyFile) !== $recordedHash) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * null when the file does not exist, e.g. a deleted dependency, which callers treat as changed
+     */
+    public function contentHash(string $filePath): ?string
+    {
+        if (array_key_exists($filePath, $this->contentHashMemo)) {
+            return $this->contentHashMemo[$filePath];
+        }
+
+        $resolvedPath = $this->resolvePath($filePath);
+        if (! is_file($resolvedPath)) {
+            return $this->contentHashMemo[$filePath] = null;
+        }
+
+        return $this->contentHashMemo[$filePath] = $this->fileHasher->hashFiles([$resolvedPath]);
+    }
+
+    /**
+     * drop a memoized hash, e.g. after the file has been written mid-run
+     */
+    public function forgetContentHash(string $filePath): void
+    {
+        unset($this->contentHashMemo[$filePath]);
+    }
+
+    public function reset(): void
+    {
+        $this->dependenciesByFile = [];
+        $this->failedFiles = [];
+        $this->contentHashMemo = [];
+        $this->functionDependencyFilesMemo = [];
+    }
+
+    private function resolvePath(string $filePath): string
+    {
+        $realPath = realpath($filePath);
+        if ($realPath === false) {
+            return $filePath;
+        }
+
+        return $realPath;
+    }
+}

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -10,6 +10,7 @@ use Illuminate\Container\Container;
 use PhpParser\Lexer;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\ScopeFactory;
+use PHPStan\Dependency\DependencyResolver;
 use PHPStan\Parser\Parser;
 use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\PhpDocParser\ParserConfig;
@@ -38,6 +39,7 @@ use Rector\Caching\Cache;
 use Rector\Caching\CacheFactory;
 use Rector\Caching\Config\FileHashComputer;
 use Rector\Caching\Contract\CacheMetaExtensionInterface;
+use Rector\Caching\FileDependencyCollector;
 use Rector\ChangesReporting\Contract\Output\OutputFormatterInterface;
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
 use Rector\ChangesReporting\Output\GitHubOutputFormatter;
@@ -347,6 +349,7 @@ final class LazyContainerFactory
         TypeNodeResolver::class,
         NodeScopeResolver::class,
         ReflectionProvider::class,
+        DependencyResolver::class,
     ];
 
     /**
@@ -452,6 +455,7 @@ final class LazyContainerFactory
 
         $rectorConfig->singleton(FileProcessor::class);
         $rectorConfig->singleton(PostFileProcessor::class);
+        $rectorConfig->singleton(FileDependencyCollector::class);
 
         $rectorConfig->when(RectorNodeTraverser::class)
             ->needs('$rectors')
@@ -476,6 +480,7 @@ final class LazyContainerFactory
         // resettable
         $rectorConfig->tag(DynamicSourceLocatorProvider::class, ResettableInterface::class);
         $rectorConfig->tag(RenamedClassesDataCollector::class, ResettableInterface::class);
+        $rectorConfig->tag(FileDependencyCollector::class, ResettableInterface::class);
 
         // caching
         $rectorConfig->singleton(Cache::class, static function (Container $container): Cache {

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -89,6 +89,7 @@ use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Analyser\UndefinedVariableException;
+use PHPStan\Dependency\DependencyResolver;
 use PHPStan\Node\FunctionCallableNode;
 use PHPStan\Node\InstantiationCallableNode;
 use PHPStan\Node\MethodCallableNode;
@@ -102,12 +103,14 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
+use Rector\Caching\FileDependencyCollector;
 use Rector\Contract\PhpParser\DecoratingNodeVisitorInterface;
 use Rector\NodeAnalyzer\ClassAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\FileNode;
 use Rector\Util\Reflection\PrivatesAccessor;
+use Throwable;
 use Webmozart\Assert\Assert;
 
 /**
@@ -130,7 +133,9 @@ final readonly class PHPStanNodeScopeResolver
         private ScopeFactory $scopeFactory,
         private PrivatesAccessor $privatesAccessor,
         private NodeNameResolver $nodeNameResolver,
-        private ClassAnalyzer $classAnalyzer
+        private ClassAnalyzer $classAnalyzer,
+        private DependencyResolver $dependencyResolver,
+        private FileDependencyCollector $fileDependencyCollector
     ) {
         // @todo make use of immutable, to avoid tedious traversing
         $this->nodeTraverser = new NodeTraverser(...$decoratingNodeVisitors);
@@ -161,6 +166,10 @@ final readonly class PHPStanNodeScopeResolver
             if ($mutatingScope instanceof FiberScope) {
                 $mutatingScope = $mutatingScope->toMutatingScope();
             }
+
+            // capture the files this file depends on, so the unchanged-files cache
+            // invalidates when a dependency changes, see captureNodeDependencies()
+            $this->captureNodeDependencies($node, $mutatingScope, $filePath);
 
             // the class reflection is resolved AFTER entering to class node
             // so we need to get it from the first after this one
@@ -729,5 +738,54 @@ final readonly class PHPStanNodeScopeResolver
         $trait->setAttribute(AttributeKey::SCOPE, $traitScope);
         $this->nodeScopeResolverProcessNodes($trait->stmts, $traitScope, $nodeCallback);
         $this->decorateNodeAttrGroups($trait, $traitScope, $nodeCallback);
+    }
+
+    /**
+     * Record the dependency files PHPStan surfaces for this node, with a memo per
+     * function call as signature dependencies are identical at every call site.
+     * The memo key is the resolved function name, so two calls only share an entry
+     * when they resolve to the same function.
+     */
+    private function captureNodeDependencies(Node $node, MutatingScope $mutatingScope, string $filePath): void
+    {
+        $functionMemoKey = null;
+        if ($node instanceof FuncCall) {
+            $functionName = $this->nodeNameResolver->getName($node);
+            if (is_string($functionName)) {
+                $functionMemoKey = strtolower($functionName);
+            }
+        }
+
+        $memoizedFiles = $functionMemoKey !== null
+            ? $this->fileDependencyCollector->getMemoizedFunctionDependencyFiles($functionMemoKey)
+            : null;
+
+        if ($memoizedFiles !== null) {
+            foreach ($memoizedFiles as $memoizedFile) {
+                $this->fileDependencyCollector->record($filePath, $memoizedFile);
+            }
+
+            return;
+        }
+
+        try {
+            $nodeDependencies = $this->dependencyResolver->resolveDependencies($node, $mutatingScope);
+            $dependencyFiles = [];
+            foreach ($nodeDependencies->getReflections() as $dependencyReflection) {
+                $dependencyFile = $dependencyReflection->getFileName();
+                if ($dependencyFile !== null) {
+                    $dependencyFiles[] = $dependencyFile;
+                    $this->fileDependencyCollector->record($filePath, $dependencyFile);
+                }
+            }
+
+            if ($functionMemoKey !== null) {
+                $this->fileDependencyCollector->memoizeFunctionDependencyFiles($functionMemoKey, $dependencyFiles);
+            }
+        } catch (Throwable) {
+            // a failed capture leaves a possibly partial dependency set, mark the file
+            // so it is never cached with it and gets reprocessed on every run instead
+            $this->fileDependencyCollector->markFailed($filePath);
+        }
     }
 }

--- a/tests/Caching/Detector/ChangedFilesDetectorTest.php
+++ b/tests/Caching/Detector/ChangedFilesDetectorTest.php
@@ -5,17 +5,22 @@ declare(strict_types=1);
 namespace Rector\Tests\Caching\Detector;
 
 use Rector\Caching\Detector\ChangedFilesDetector;
+use Rector\Caching\FileDependencyCollector;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 
 final class ChangedFilesDetectorTest extends AbstractLazyTestCase
 {
     private ChangedFilesDetector $changedFilesDetector;
 
+    private FileDependencyCollector $fileDependencyCollector;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->changedFilesDetector = $this->make(ChangedFilesDetector::class);
+        $this->fileDependencyCollector = $this->make(FileDependencyCollector::class);
+        $this->fileDependencyCollector->reset();
     }
 
     protected function tearDown(): void
@@ -34,6 +39,44 @@ final class ChangedFilesDetectorTest extends AbstractLazyTestCase
         $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
         $this->changedFilesDetector->invalidateFile($filePath);
 
+        $this->assertTrue($this->changedFilesDetector->hasFileChanged($filePath));
+    }
+
+    public function testDependencyChangeInvalidatesFile(): void
+    {
+        $filePath = __DIR__ . '/Source/file.php';
+        $dependencyFilePath = sys_get_temp_dir() . '/rector_changed_files_detector_dependency_test.php';
+        file_put_contents($dependencyFilePath, "<?php\n\nclass DetectorDependencyFixture\n{\n}\n");
+
+        $this->fileDependencyCollector->record($filePath, $dependencyFilePath);
+        $this->changedFilesDetector->addCacheableFile($filePath);
+        $this->changedFilesDetector->cacheFile($filePath);
+
+        // simulate a fresh process run with unchanged files
+        $this->fileDependencyCollector->reset();
+        $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
+
+        // a dependency change must invalidate the file, even though its own content is unchanged
+        file_put_contents(
+            $dependencyFilePath,
+            "<?php\n\nclass DetectorDependencyFixture\n{\n    public function added(): int\n    {\n        return 1;\n    }\n}\n"
+        );
+        $this->fileDependencyCollector->reset();
+        $this->assertTrue($this->changedFilesDetector->hasFileChanged($filePath));
+
+        unlink($dependencyFilePath);
+    }
+
+    public function testFailedDependencyCapturePreventsCaching(): void
+    {
+        $filePath = __DIR__ . '/Source/file.php';
+
+        // a failed capture means the dependency set may be incomplete → never cache
+        $this->fileDependencyCollector->markFailed($filePath);
+        $this->changedFilesDetector->addCacheableFile($filePath);
+        $this->changedFilesDetector->cacheFile($filePath);
+
+        $this->fileDependencyCollector->reset();
         $this->assertTrue($this->changedFilesDetector->hasFileChanged($filePath));
     }
 


### PR DESCRIPTION
## Problem

The unchanged-files cache only checks each file's own content. A clean file stays skipped on warm runs even when one of its dependencies changed.

Repro on `main`: a parent class method gains `: int`, which lets a child file infer its own return type. A fresh run reports the new change in the child file, a warm run reports nothing until `--clear-cache`.

```php
// Dad.php — the only file that changes on disk
 class Dad
 {
-    public function getValue()
+    public function getValue(): int
     {
         return 1;
     }
 }

// Kid.php — unchanged on disk, but typeDeclarations can now add `: int` to value()
class Kid extends Dad
{
    public function value()
    {
        return $this->getValue();
    }
}
```

Reproducible with vanilla rector in ~30s: https://github.com/SanderMuller/rector-stale-cache-poc

## Fix

`PHPStanNodeScopeResolver` records which files each file depends on during scope resolution, using PHPStan's own `DependencyResolver` — the same engine behind PHPStan's result cache. No own logic about which nodes matter: every node goes through PHPStan's resolver and its branch chain decides.

```php
// PHPStanNodeScopeResolver, inside the node callback:
$nodeDependencies = $this->dependencyResolver->resolveDependencies($node, $mutatingScope);
foreach ($nodeDependencies->getFileDependencies() as $dependencyFile) {
    $this->fileDependencyCollector->record($filePath, $dependencyFile);
}
```

Cache entries store the file's own hash plus one hash per dependency, all re-validated on load:

```php
// before
'abc123'
// after
['hash' => 'abc123', 'deps' => ['/src/Dad.php' => 'def456']]
```

Old string entries still load and upgrade themselves on the next write. If capture fails for a file, the file is not cached at all rather than cached with a partial set. Function calls memoize their dependency files per resolved name. Selective runs (`--only`, `--only-suffix`) skip the cache write, same guard as #8029.

## Cost and scope

~7-8% on a cold run (interleaved A/B, 138-file corpus); warm runs unchanged within noise. Output byte-identical to a fresh run.

Per review feedback this is now the minimal single-logic version: 306 lines, 6 files, one commit, no node-type guards, no `get_defined_functions()`, no hardcoded node names — native functions are handled by PHPStan's reflection like everything else. The per-node guards that cut the cold cost to ~4% are split off and can come later as their own perf PR, where that trade-off can be discussed on its own.

Follow-ups: #8029 (open), #8033 (diff replay, the 9-170x warm win, stacked on this).