### PR TITLE
Extract AutoloadFileParameterResolver from bin, add tests

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -3,10 +3,10 @@
 declare(strict_types=1);
 
 use Nette\Utils\Json;
+use Rector\Bootstrap\AutoloadFileParameterResolver;
 use Rector\Bootstrap\RectorConfigsResolver;
 use Rector\ChangesReporting\Output\JsonOutputFormatter;
 use Rector\Configuration\Option;
-use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Console\Style\SymfonyStyleFactory;
 use Rector\DependencyInjection\LazyContainerFactory;
 use Rector\DependencyInjection\RectorContainerFactory;
@@ -128,13 +128,7 @@ $autoloadIncluder->autoloadProjectAutoloaderFile();
 $autoloadIncluder->autoloadRectorInstalledAsGlobalDependency();
 $autoloadIncluder->autoloadFromCommandLine();
 
-// a different extra autoload changes what PHPStan can resolve, so cached results
-// must not survive it: register it before the configuration hash is computed.
-// ArgvInput handles both "--autoload-file path" and "--autoload-file=path"
-$autoloadFileOption = (new ArgvInput())->getParameterOption(['--autoload-file', '-a'], null);
-if (is_string($autoloadFileOption) && $autoloadFileOption !== '') {
-    SimpleParameterProvider::setParameter(Option::AUTOLOAD_FILE, realpath($autoloadFileOption) ?: $autoloadFileOption);
-}
+AutoloadFileParameterResolver::resolveFromArgv($_SERVER['argv']);
 
 $rectorConfigsResolver = new RectorConfigsResolver();
 

--- a/src/Bootstrap/AutoloadFileParameterResolver.php
+++ b/src/Bootstrap/AutoloadFileParameterResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Bootstrap;
+
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Symfony\Component\Console\Input\ArgvInput;
+
+/**
+ * A different extra autoload changes what PHPStan can resolve, so cached results
+ * must not survive it. Registering the file as a parameter folds it into the
+ * configuration hash, which invalidates the cache like any other config change.
+ *
+ * Called from bin/rector.php before the configuration hash is computed.
+ *
+ * @see \Rector\Tests\Bootstrap\AutoloadFileParameterResolverTest
+ */
+final class AutoloadFileParameterResolver
+{
+    /**
+     * @param array<int, mixed> $argv
+     */
+    public static function resolveFromArgv(array $argv): void
+    {
+        // handles "--autoload-file path", "--autoload-file=path" and "-a path";
+        // parallel workers receive the space-separated form, so all spellings must
+        // normalize to the same value or main process and workers would disagree
+        $autoloadFile = (new ArgvInput($argv))->getParameterOption(['--autoload-file', '-a'], null);
+        if (! is_string($autoloadFile) || $autoloadFile === '') {
+            return;
+        }
+
+        SimpleParameterProvider::setParameter(Option::AUTOLOAD_FILE, realpath($autoloadFile) ?: $autoloadFile);
+    }
+}

--- a/tests/Bootstrap/AutoloadFileParameterResolverTest.php
+++ b/tests/Bootstrap/AutoloadFileParameterResolverTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Bootstrap;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Rector\Bootstrap\AutoloadFileParameterResolver;
+use Rector\Caching\Config\FileHashComputer;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
+
+final class AutoloadFileParameterResolverTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        SimpleParameterProvider::setParameter(Option::AUTOLOAD_FILE, '');
+    }
+
+    /**
+     * all spellings must resolve to the same value, or the main process and
+     * parallel workers, which receive the space-separated form, would compute
+     * different configuration hashes
+     *
+     * @param array<int, string> $argv
+     */
+    #[DataProvider('provideArgvSpellings')]
+    public function testEverySpellingResolvesToSameRealPath(array $argv): void
+    {
+        AutoloadFileParameterResolver::resolveFromArgv($argv);
+
+        $this->assertSame(
+            (string) realpath(__FILE__),
+            SimpleParameterProvider::provideStringParameter(Option::AUTOLOAD_FILE)
+        );
+    }
+
+    /**
+     * @return iterable<string, array{array<int, string>}>
+     */
+    public static function provideArgvSpellings(): iterable
+    {
+        $relativePath = 'tests/Bootstrap/' . basename(__FILE__);
+
+        yield 'long with space' => [['bin/rector', 'process', '--autoload-file', __FILE__]];
+        yield 'long with equals' => [['bin/rector', 'process', '--autoload-file=' . __FILE__]];
+        yield 'short with space' => [['bin/rector', 'process', '-a', __FILE__]];
+        yield 'relative path is normalized' => [['bin/rector', 'process', '-a', $relativePath]];
+    }
+
+    public function testWithoutOptionParameterStaysUntouched(): void
+    {
+        AutoloadFileParameterResolver::resolveFromArgv(['bin/rector', 'process', '--dry-run']);
+
+        $this->assertSame('', SimpleParameterProvider::provideStringParameter(Option::AUTOLOAD_FILE));
+    }
+
+    public function testResolvedAutoloadFileChangesConfigurationHash(): void
+    {
+        $fileHashComputer = new FileHashComputer();
+        $configFilePath = __DIR__ . '/config/some_config.php';
+
+        $hashWithout = $fileHashComputer->compute($configFilePath);
+
+        AutoloadFileParameterResolver::resolveFromArgv(['bin/rector', 'process', '-a', __FILE__]);
+
+        $this->assertNotSame($hashWithout, $fileHashComputer->compute($configFilePath));
+    }
+}

--- a/tests/Bootstrap/config/some_config.php
+++ b/tests/Bootstrap/config/some_config.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+};


### PR DESCRIPTION
The last revision of #8034 missed the merge by two minutes — this is it.

Moves the parameter registration from inline bin code into a small class, no behavior change, and adds tests: all three CLI spellings (`--autoload-file path`, `--autoload-file=path`, `-a path`) resolve to the same value, no flag leaves the parameter untouched, and registering it changes the configuration hash.