### PR TITLE
Bump composer/pcre to ^3.4.0 and phpstan/phpstan to ^2.2.2

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.1.56"
+        "phpstan/phpstan": "^2.2.2"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^8.3",
         "clue/ndjson-react": "^1.3",
-        "composer/pcre": "^3.3.2",
+        "composer/pcre": "^3.4.0",
         "composer/semver": "^3.4",
         "composer/xdebug-handler": "^3.0.5",
         "doctrine/inflector": "^2.1",
@@ -23,7 +23,7 @@
         "nikic/php-parser": "^5.7",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",
-        "phpstan/phpstan": "^2.1.56",
+        "phpstan/phpstan": "^2.2.2",
         "react/event-loop": "^1.6",
         "react/promise": "^3.3",
         "react/socket": "^1.17",


### PR DESCRIPTION
This is needed per-conflict composer.json definition on latest build 

https://github.com/rectorphp/rector/commit/3d28220a28e316ea8d1b9a907286ad493d3d39ee#diff-57c08f336d81028573ac231bbc3c9b30040e58a567113a86e4204d60da702560

to avoid incompatible signature when user uses phpstan 2.1.x