### PR TITLE
feat: add drupal to RectorConfigBuilder::withComposerBased

### DIFF
--- a/.github/workflows/rector_drupal_rector_dev.yaml
+++ b/.github/workflows/rector_drupal_rector_dev.yaml
@@ -1,0 +1,30 @@
+name: Rector Drupal with dev-main
+
+on:
+    push:
+        branches:
+            - main
+    pull_request: null
+
+env:
+    # see https://github.com/composer/composer/issues/9368#issuecomment-718112361
+    COMPOSER_ROOT_VERSION: "dev-main"
+
+jobs:
+    rector_drupal_rector_dev:
+        runs-on: ubuntu-latest
+
+        steps:
+            -
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 8.3
+                    coverage: none
+
+                # fixes https://github.com/rectorphp/rector/pull/4559/checks?check_run_id=1359814403, see https://github.com/shivammathur/setup-php#composer-github-oauth
+                env:
+                    COMPOSER_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+
+            -   run: git clone https://github.com/palantirnet/drupal-rector.git
+            -   run: composer require rector/rector:dev-main --working-dir drupal-rector
+            -   run: cd drupal-rector && vendor/bin/phpunit

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -829,6 +829,7 @@ final class RectorConfigBuilder
         bool $symfony = false,
         bool $netteUtils = false,
         bool $laravel = false,
+        bool $drupal = false,
     ): self {
         $setMap = [
             SetGroup::TWIG => $twig,
@@ -837,6 +838,7 @@ final class RectorConfigBuilder
             SetGroup::SYMFONY => $symfony,
             SetGroup::NETTE_UTILS => $netteUtils,
             SetGroup::LARAVEL => $laravel,
+            SetGroup::DRUPAL => $drupal,
         ];
 
         foreach ($setMap as $setPath => $isEnabled) {

--- a/src/Set/Enum/SetGroup.php
+++ b/src/Set/Enum/SetGroup.php
@@ -43,5 +43,10 @@ final class SetGroup
      */
     public const string LARAVEL = 'laravel';
 
+    /**
+     * Version-based set provider
+     */
+    public const string DRUPAL = 'drupal';
+
     public const string ATTRIBUTES = 'attributes';
 }


### PR DESCRIPTION
## What

Adds a `drupal` toggle to `withComposerBased()` and the matching `SetGroup::DRUPAL` constant, so a Drupal `SetProviderInterface` can expose composer-triggered sets keyed on `drupal/core`:

```php
return RectorConfig::configure()
    ->withSetProviders(\DrupalRector\Set\DrupalSetProvider::class)
    ->withComposerBased(drupal: true);
```

This mirrors the existing ecosystem toggles (`twig`, `symfony`, `laravel`, …) exactly — one extra parameter wired into the same `$setMap`, plus the group constant. The set provider itself lives in the external `palantirnet/drupal-rector` package, same as `laravel`'s provider lives in `rector-laravel`.

## Why

Companion to palantirnet/drupal-rector#370, which ships `DrupalSetProvider` exposing the per-minor Drupal deprecation/breaking configs as `ComposerTriggeredSet`s in the `drupal` group. Those sets stay dormant until core exposes the `drupal:` toggle to opt into the group — this PR is that toggle. And ofcourse the original https://github.com/rectorphp/rector/issues/9778

## Verification

- `tests/Set/SetManager/SetManagerTest.php` green.
- Confirmed `withComposerBased(drupal: true)` registers the `drupal` set group.