### PR TITLE
[PostRector] Do not keep an unused import matched only by a partial docblock name's tail

### DIFF
--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -249,7 +249,10 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
 
     private function isSubNamespace(string $name, string $comparedName, string $namespacedPrefix): bool
     {
-        if (str_ends_with($comparedName, '\\' . $name)) {
+        // a partially qualified name like "Foo\Bar" resolves through the import of its first
+        // segment, never through an import whose tail it happens to match, so only a single
+        // segment name (the imported short name) may be matched against the import's tail here
+        if (! str_contains($name, '\\') && str_ends_with($comparedName, '\\' . $name)) {
             return true;
         }
 

--- a/tests/Issues/NamespacedUse/Fixture/partial_docblock_name_keeps_namespace_not_class_import.php.inc
+++ b/tests/Issues/NamespacedUse/Fixture/partial_docblock_name_keeps_namespace_not_class_import.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace App;
+
+use App\Animal;
+use App\Animal\Dog;
+
+/**
+ * @see Animal\Dog
+ */
+final class PartialDocblockNameKeepsNamespaceNotClassImport
+{
+}
+
+?>
+-----
+<?php
+
+namespace App;
+
+use App\Animal;
+
+/**
+ * @see Animal\Dog
+ */
+final class PartialDocblockNameKeepsNamespaceNotClassImport
+{
+}
+
+?>


### PR DESCRIPTION
`isSubNamespace()` treats an import as used when a referenced name equals the tail of the import's fully qualified name. That tail match is the primary mechanism for the normal case of importing a class and referencing its short name: `use App\Bar\Baz;` referenced as `Baz` matches because `App\Bar\Baz` ends with `\Baz`.

The match also fired for multi-segment, partially qualified names. A name like `Foo\Bar\Baz` never resolves to an import through its tail; in PHP a partially qualified name resolves through the import of its *first* segment. So `use App\Animal\Dog;` was wrongly kept alive by an unrelated `@see Animal\Dog`, which actually resolves through `use App\Animal;`. With `removeUnusedImports()` enabled the genuinely unused class import survived, and when two imported classes shared a short name this left two `use` statements with the same alias - invalid PHP.

Restrict the tail match to single segment names, which are the only names that can resolve to an import through its tail.