### PR TITLE
[php 8.4] [type-declaration] Add AddArrayAnyAllClosureParamTypeRector and NarrowArrayAnyAllNullableParamTypeRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "symfony/console": "^6.4.24",
         "symfony/filesystem": "^7.4",
         "symfony/finder": "^6.4",
+        "symfony/polyfill-php84": "^1.38",
         "symfony/process": "^7.4",
         "symplify/easy-parallel": "^11.2.2",
         "symplify/rule-doc-generator-contracts": "^11.2",

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector/AddArrayAnyAllClosureParamTypeRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector/AddArrayAnyAllClosureParamTypeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\AddArrayAnyAllClosureParamTypeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddArrayAnyAllClosureParamTypeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector/Fixture/array_all_closure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector/Fixture/array_all_closure.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\AddArrayAnyAllClosureParamTypeRector\Fixture;
+
+function arrayAllClosure()
+{
+    /** @var int[] $numbers */
+    $numbers = doSomething();
+
+    return array_all($numbers, function ($number): bool {
+        return $number > 0;
+    });
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\AddArrayAnyAllClosureParamTypeRector\Fixture;
+
+function arrayAllClosure()
+{
+    /** @var int[] $numbers */
+    $numbers = doSomething();
+
+    return array_all($numbers, function (int $number): bool {
+        return $number > 0;
+    });
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector/Fixture/array_any_arrow_function.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector/Fixture/array_any_arrow_function.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\AddArrayAnyAllClosureParamTypeRector\Fixture;
+
+function arrayAnyArrowFunction()
+{
+    /** @var string[] $items */
+    $items = doSomething();
+
+    return array_any($items, fn ($item): bool => $item !== '');
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\AddArrayAnyAllClosureParamTypeRector\Fixture;
+
+function arrayAnyArrowFunction()
+{
+    /** @var string[] $items */
+    $items = doSomething();
+
+    return array_any($items, fn (string $item): bool => $item !== '');
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector/Fixture/skip_already_typed.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector/Fixture/skip_already_typed.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\AddArrayAnyAllClosureParamTypeRector\Fixture;
+
+function skipAlreadyTyped()
+{
+    /** @var string[] $items */
+    $items = doSomething();
+
+    return array_any($items, fn (string $item): bool => $item !== '');
+}

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector/Fixture/skip_mixed_array.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector/Fixture/skip_mixed_array.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\AddArrayAnyAllClosureParamTypeRector\Fixture;
+
+function skipMixedArray($items)
+{
+    return array_any($items, fn ($item): bool => $item !== '');
+}

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\FuncCall\AddArrayAnyAllClosureParamTypeRector;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddArrayAnyAllClosureParamTypeRector::class);
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_84);
+};

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/Fixture/array_all_closure.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/Fixture/array_all_closure.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector\Fixture;
+
+function arrayAllClosure(): bool
+{
+    /** @var int[] $numbers */
+    $numbers = [1, 2, 3];
+
+    return array_all($numbers, function (?int $number): bool {
+        return $number > 0;
+    });
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector\Fixture;
+
+function arrayAllClosure(): bool
+{
+    /** @var int[] $numbers */
+    $numbers = [1, 2, 3];
+
+    return array_all($numbers, function (int $number): bool {
+        return $number > 0;
+    });
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/Fixture/array_any_arrow_function.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/Fixture/array_any_arrow_function.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector\Fixture;
+
+function arrayAnyArrowFunction(): bool
+{
+    /** @var string[] $items */
+    $items = ['a', 'b'];
+
+    return array_any($items, fn (?string $item): bool => $item !== '');
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector\Fixture;
+
+function arrayAnyArrowFunction(): bool
+{
+    /** @var string[] $items */
+    $items = ['a', 'b'];
+
+    return array_any($items, fn (string $item): bool => $item !== '');
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/Fixture/array_find.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/Fixture/array_find.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector\Fixture;
+
+function arrayFind(): ?string
+{
+    /** @var string[] $items */
+    $items = ['a', 'b'];
+
+    return array_find($items, fn (?string $item): bool => $item !== '');
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector\Fixture;
+
+function arrayFind(): ?string
+{
+    /** @var string[] $items */
+    $items = ['a', 'b'];
+
+    return array_find($items, fn (string $item): bool => $item !== '');
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/Fixture/skip_already_non_nullable.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/Fixture/skip_already_non_nullable.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector\Fixture;
+
+function skipAlreadyNonNullable(): bool
+{
+    /** @var string[] $items */
+    $items = ['a', 'b'];
+
+    return array_any($items, fn (string $item): bool => $item !== '');
+}

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/Fixture/skip_array_filter.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/Fixture/skip_array_filter.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector\Fixture;
+
+function skipArrayFilter(): array
+{
+    /** @var string[] $items */
+    $items = ['a', 'b'];
+
+    return array_filter($items, fn (?string $item): bool => $item !== '');
+}

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/Fixture/skip_nullable_item_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/Fixture/skip_nullable_item_type.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector\Fixture;
+
+function skipNullableItemType(): bool
+{
+    /** @var array<string|null> $items */
+    $items = ['a', null];
+
+    return array_any($items, fn (?string $item): bool => $item !== '');
+}

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/NarrowArrayAnyAllNullableParamTypeRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/NarrowArrayAnyAllNullableParamTypeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class NarrowArrayAnyAllNullableParamTypeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(NarrowArrayAnyAllNullableParamTypeRector::class);
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_84);
+};

--- a/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
+++ b/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Catch_;
 use PhpParser\NodeVisitor;
+use PHPStan\Reflection\ExtendedParameterReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
@@ -233,25 +234,18 @@ CODE_SAMPLE
         $extendedParametersAcceptor = ParametersAcceptorSelector::combineAcceptors(
             $extendedMethodReflection->getVariants()
         );
-
-        foreach ($extendedParametersAcceptor->getParameters() as $extendedParameterReflection) {
-            if ($extendedParameterReflection->getName() === $parameterName) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $extendedParametersAcceptor->getParameters(),
+            fn (ExtendedParameterReflection $extendedParameterReflection): bool => $extendedParameterReflection->getName() === $parameterName
+        );
     }
 
     private function hasArgument(New_ $new, string $argumentName): bool
     {
-        foreach ($new->getArgs() as $arg) {
-            if ($arg->name instanceof Identifier && $arg->name->toString() === $argumentName) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $new->getArgs(),
+            fn (Arg $arg): bool => $arg->name instanceof Identifier && $arg->name->toString() === $argumentName
+        );
     }
 
     private function resolveExceptionArgumentPosition(Name $exceptionName): ?int

--- a/rules/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector.php
+++ b/rules/CodeQuality/Rector/FuncCall/ChangeArrayPushToArrayAssignRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\CodeQuality\Rector\FuncCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\FuncCall;
@@ -100,12 +101,6 @@ CODE_SAMPLE
 
     private function hasArraySpread(FuncCall $funcCall): bool
     {
-        foreach ($funcCall->getArgs() as $arg) {
-            if ($arg->unpack) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($funcCall->getArgs(), fn (Arg $arg): bool => $arg->unpack);
     }
 }

--- a/rules/CodingStyle/ClassNameImport/ValueObject/PendingImports.php
+++ b/rules/CodingStyle/ClassNameImport/ValueObject/PendingImports.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\CodingStyle\ClassNameImport\ValueObject;
 
+use PHPStan\Type\Type;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
 /**
@@ -98,13 +99,12 @@ final class PendingImports
             }
         }
 
-        foreach ($this->functionImports as $functionImport) {
-            if (strtolower($functionImport->getShortName()) === $shortName) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $this->functionImports,
+            fn (FullyQualifiedObjectType $fullyQualifiedObjectType): bool => strtolower(
+                $fullyQualifiedObjectType->getShortName()
+            ) === $shortName
+        );
     }
 
     public function isImportShortable(FullyQualifiedObjectType $fullyQualifiedObjectType): bool
@@ -121,12 +121,6 @@ final class PendingImports
             }
         }
 
-        foreach ($this->functionImports as $functionImport) {
-            if ($fullyQualifiedObjectType->equals($functionImport)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->functionImports, fn (Type $type): bool => $fullyQualifiedObjectType->equals($type));
     }
 }

--- a/rules/CodingStyle/Guard/ArrowFunctionAndClosureFirstClassCallableGuard.php
+++ b/rules/CodingStyle/Guard/ArrowFunctionAndClosureFirstClassCallableGuard.php
@@ -189,13 +189,7 @@ final readonly class ArrowFunctionAndClosureFirstClassCallableGuard
      */
     private function isUsingByRef(array $params): bool
     {
-        foreach ($params as $param) {
-            if ($param->byRef) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($params, fn (Param $param): bool => $param->byRef);
     }
 
     /**
@@ -203,13 +197,7 @@ final readonly class ArrowFunctionAndClosureFirstClassCallableGuard
      */
     private function isUsingNamedArgs(array $args): bool
     {
-        foreach ($args as $arg) {
-            if ($arg->name instanceof Identifier) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($args, fn (Arg $arg): bool => $arg->name instanceof Identifier);
     }
 
     private function isChainedCall(FuncCall|MethodCall|StaticCall $callLike): bool

--- a/rules/DeadCode/NodeAnalyzer/NoDiscardCallAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/NoDiscardCallAnalyzer.php
@@ -85,12 +85,9 @@ final readonly class NoDiscardCallAnalyzer
      */
     private function hasNoDiscardAttribute(array $attributes): bool
     {
-        foreach ($attributes as $attribute) {
-            if ($attribute->getName() === 'NoDiscard') {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $attributes,
+            fn (AttributeReflection $attributeReflection): bool => $attributeReflection->getName() === 'NoDiscard'
+        );
     }
 }

--- a/rules/DeadCode/PhpDoc/Guard/TemplateTypeRemovalGuard.php
+++ b/rules/DeadCode/PhpDoc/Guard/TemplateTypeRemovalGuard.php
@@ -21,13 +21,6 @@ final class TemplateTypeRemovalGuard
         $types = $docType instanceof UnionType
             ? $docType->getTypes()
             : [$docType];
-
-        foreach ($types as $type) {
-            if ($type instanceof TemplateType) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($types, fn (Type $type): bool => ! $type instanceof TemplateType);
     }
 }

--- a/rules/DeadCode/Rector/ClassConst/RemoveUnusedPrivateClassConstantRector.php
+++ b/rules/DeadCode/Rector/ClassConst/RemoveUnusedPrivateClassConstantRector.php
@@ -104,12 +104,9 @@ CODE_SAMPLE
 
     private function hasParentClassOfEnumSuffix(ClassReflection $classReflection): bool
     {
-        foreach ($classReflection->getParentClassesNames() as $parentClassesName) {
-            if (str_ends_with($parentClassesName, 'Enum')) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $classReflection->getParentClassesNames(),
+            fn (string $parentClassesName): bool => str_ends_with($parentClassesName, 'Enum')
+        );
     }
 }

--- a/rules/DeadCode/Rector/ClassLike/RemoveTypedPropertyNonMockDocblockRector.php
+++ b/rules/DeadCode/Rector/ClassLike/RemoveTypedPropertyNonMockDocblockRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -142,12 +143,9 @@ CODE_SAMPLE
             return false;
         }
 
-        foreach ($varTagType->getTypes() as $unionedType) {
-            if ($unionedType->isSuperTypeOf(new ObjectType(ClassName::MOCK_OBJECT))->yes()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $varTagType->getTypes(),
+            fn (Type $unionedType): bool => $unionedType->isSuperTypeOf(new ObjectType(ClassName::MOCK_OBJECT))->yes()
+        );
     }
 }

--- a/rules/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector.php
+++ b/rules/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\FunctionLike;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\ConstFetch;
@@ -238,13 +239,7 @@ CODE_SAMPLE
      */
     private function hasImplicitNullReturn(array $returnStatements): bool
     {
-        foreach ($returnStatements as $returnStatement) {
-            if ($returnStatement->expr === null) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($returnStatements, fn (Return_ $return): bool => ! $return->expr instanceof Expr);
     }
 
     /**

--- a/rules/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector.php
+++ b/rules/DeadCode/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\Switch_;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Case_;
 use PhpParser\Node\Stmt\Return_;
@@ -180,13 +181,10 @@ CODE_SAMPLE
             return false;
         }
 
-        foreach ($currentCase->stmts as $stmt) {
-            if ($stmt instanceof Break_ || $stmt instanceof Return_) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $currentCase->stmts,
+            fn (Stmt $stmt): bool => $stmt instanceof Break_ || $stmt instanceof Return_
+        );
     }
 
     private function areSwitchStmtsEqualsConsideringComments(Case_ $currentCase, Case_ $nextCase): bool

--- a/rules/DeadCode/TypeNodeAnalyzer/GenericTypeNodeAnalyzer.php
+++ b/rules/DeadCode/TypeNodeAnalyzer/GenericTypeNodeAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DeadCode\TypeNodeAnalyzer;
 
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use Rector\BetterPhpDocParser\ValueObject\Type\BracketsAwareUnionTypeNode;
 
 final class GenericTypeNodeAnalyzer
@@ -12,13 +13,6 @@ final class GenericTypeNodeAnalyzer
     public function hasGenericType(BracketsAwareUnionTypeNode $bracketsAwareUnionTypeNode): bool
     {
         $types = $bracketsAwareUnionTypeNode->types;
-
-        foreach ($types as $type) {
-            if ($type instanceof GenericTypeNode) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($types, fn (TypeNode $typeNode): bool => $typeNode instanceof GenericTypeNode);
     }
 }

--- a/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/EarlyReturn/Rector/If_/RemoveAlwaysElseRector.php
@@ -176,13 +176,10 @@ CODE_SAMPLE
                 return true;
             }
 
-            foreach ($lastStmt->elseifs as $elseIf) {
-                if ($this->doesNotLastStatementBreakFlow($elseIf)) {
-                    return true;
-                }
-            }
-
-            return false;
+            return array_any(
+                $lastStmt->elseifs,
+                fn (If_|ElseIf_|Else_ $elseIf): bool => $this->doesNotLastStatementBreakFlow($elseIf)
+            );
         }
 
         return ! ($lastStmt instanceof Return_

--- a/rules/Naming/VariableRenamer.php
+++ b/rules/Naming/VariableRenamer.php
@@ -125,13 +125,10 @@ final readonly class VariableRenamer
             return false;
         }
 
-        foreach ($functionLike->getParams() as $param) {
-            if ($this->nodeNameResolver->isName($param, $variableName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $functionLike->getParams(),
+            fn (Node|array $param): bool => $this->nodeNameResolver->isName($param, $variableName)
+        );
     }
 
     private function renameVariableIfMatchesName(

--- a/rules/Php71/Rector/List_/ListToArrayDestructRector.php
+++ b/rules/Php71/Rector/List_/ListToArrayDestructRector.php
@@ -115,12 +115,6 @@ CODE_SAMPLE
 
     private function hasPartialDestruct(List_ $list): bool
     {
-        foreach ($list->items as $listItem) {
-            if (! $listItem instanceof ArrayItem) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($list->items, fn (?ArrayItem $arrayItem): bool => ! $arrayItem instanceof ArrayItem);
     }
 }

--- a/rules/Php74/NodeAnalyzer/ClosureArrowFunctionAnalyzer.php
+++ b/rules/Php74/NodeAnalyzer/ClosureArrowFunctionAnalyzer.php
@@ -76,13 +76,10 @@ final readonly class ClosureArrowFunctionAnalyzer
                     return false;
                 }
 
-                foreach ($variables as $variable) {
-                    if ($this->compactFuncCallAnalyzer->isInCompact($node, $variable)) {
-                        return true;
-                    }
-                }
-
-                return false;
+                return array_any(
+                    $variables,
+                    fn (Variable $variable): bool => $this->compactFuncCallAnalyzer->isInCompact($node, $variable)
+                );
             }
         );
     }
@@ -111,17 +108,16 @@ final readonly class ClosureArrowFunctionAnalyzer
             return false;
         }
 
-        $isFoundInStmt = (bool) $this->betterNodeFinder->findFirstInFunctionLikeScoped($closure, function (Node $node) use (
-            $referencedValues
-        ): bool {
-            foreach ($referencedValues as $referencedValue) {
-                if ($this->nodeComparator->areNodesEqual($node, $referencedValue)) {
-                    return true;
-                }
-            }
-
-            return false;
-        });
+        $isFoundInStmt = (bool) $this->betterNodeFinder->findFirstInFunctionLikeScoped(
+            $closure,
+            fn (Node $node): bool => array_any(
+                $referencedValues,
+                fn (Node|array|null $referencedValue): bool => $this->nodeComparator->areNodesEqual(
+                    $node,
+                    $referencedValue
+                )
+            )
+        );
 
         if ($isFoundInStmt) {
             return true;

--- a/rules/Php80/NodeAnalyzer/MatchSwitchAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/MatchSwitchAnalyzer.php
@@ -35,13 +35,10 @@ final readonly class MatchSwitchAnalyzer
      */
     public function isReturnCondsAndExprs(array $condAndExprs): bool
     {
-        foreach ($condAndExprs as $condAndExpr) {
-            if ($condAndExpr->equalsMatchKind(MatchKind::RETURN)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $condAndExprs,
+            fn (CondAndExpr $condAndExpr): bool => $condAndExpr->equalsMatchKind(MatchKind::RETURN)
+        );
     }
 
     /**
@@ -110,13 +107,7 @@ final readonly class MatchSwitchAnalyzer
      */
     public function hasCondsAndExprDefaultValue(array $condAndExprs): bool
     {
-        foreach ($condAndExprs as $condAndExpr) {
-            if ($condAndExpr->getCondExprs() === null) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($condAndExprs, fn (CondAndExpr $condAndExpr): bool => $condAndExpr->getCondExprs() === null);
     }
 
     public function hasDefaultValue(Match_ $match): bool

--- a/rules/Php80/NodeAnalyzer/SwitchAnalyzer.php
+++ b/rules/Php80/NodeAnalyzer/SwitchAnalyzer.php
@@ -6,6 +6,7 @@ namespace Rector\Php80\NodeAnalyzer;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Case_;
 use PhpParser\Node\Stmt\Return_;
@@ -126,12 +127,6 @@ final readonly class SwitchAnalyzer
 
     private function containsCaseReturn(Case_ $case): bool
     {
-        foreach ($case->stmts as $stmt) {
-            if ($stmt instanceof Return_) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($case->stmts, fn (Stmt $stmt): bool => $stmt instanceof Return_);
     }
 }

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -10,6 +10,8 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
@@ -353,18 +355,19 @@ CODE_SAMPLE
             return false;
         }
 
-        foreach ($type->types as $type) {
-            if ($this->isCallableTypeIdentifier($type)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $type->types,
+            fn (Identifier|IntersectionType|Name $type): bool => $this->isCallableTypeIdentifier($type)
+        );
     }
 
     private function isCallableTypeIdentifier(?Node $node): bool
     {
-        return $node instanceof Identifier && $this->isName($node, 'callable');
+        if (! $node instanceof Identifier) {
+            return false;
+        }
+
+        return $this->isName($node, 'callable');
     }
 
     private function shouldSkipPropertyOrParam(Property $property, Param $param): bool

--- a/rules/Php80/ValueObject/NestedAnnotationToAttribute.php
+++ b/rules/Php80/ValueObject/NestedAnnotationToAttribute.php
@@ -62,12 +62,11 @@ final class NestedAnnotationToAttribute implements AnnotationToAttributeInterfac
 
     public function hasExplicitParameters(): bool
     {
-        foreach ($this->annotationPropertiesToAttributeClasses as $annotationPropertyToAttributeClass) {
-            if (is_string($annotationPropertyToAttributeClass->getAnnotationProperty())) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $this->annotationPropertiesToAttributeClasses,
+            fn (AnnotationPropertyToAttributeClass $annotationPropertyToAttributeClass): bool => is_string(
+                $annotationPropertyToAttributeClass->getAnnotationProperty()
+            )
+        );
     }
 }

--- a/rules/Php82/NodeManipulator/ReadonlyClassManipulator.php
+++ b/rules/Php82/NodeManipulator/ReadonlyClassManipulator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Php82\NodeManipulator;
 
+use PhpParser\Node;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
@@ -71,14 +72,7 @@ final readonly class ReadonlyClassManipulator
      */
     private function hasNonTypedProperty(array $properties): bool
     {
-        foreach ($properties as $property) {
-            // properties of readonly class must always have type
-            if ($property->type === null) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($properties, fn (Property $property): bool => ! $property->type instanceof Node);
     }
 
     private function shouldSkip(Class_ $class, Scope $scope): bool
@@ -161,13 +155,10 @@ final readonly class ReadonlyClassManipulator
      */
     private function hasReadonlyProperty(array $properties): bool
     {
-        foreach ($properties as $property) {
-            if (! $property->isReadOnly()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $properties,
+            fn (ReflectionProperty $reflectionProperty): bool => ! $reflectionProperty->isReadOnly()
+        );
     }
 
     /**
@@ -175,13 +166,7 @@ final readonly class ReadonlyClassManipulator
      */
     private function isExtendsReadonlyClass(array $parents): bool
     {
-        foreach ($parents as $parent) {
-            if ($parent->isReadOnly()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($parents, fn (ClassReflection $classReflection): bool => $classReflection->isReadOnly());
     }
 
     /**
@@ -189,13 +174,7 @@ final readonly class ReadonlyClassManipulator
      */
     private function hasWritableProperty(array $properties): bool
     {
-        foreach ($properties as $property) {
-            if (! $property->isReadonly()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($properties, fn (Property $property): bool => ! $property->isReadonly());
     }
 
     private function shouldSkipClass(Class_ $class): bool

--- a/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
+++ b/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
@@ -161,14 +161,10 @@ CODE_SAMPLE
     public function isConstGuardedByParents(Const_ $const, array $parentClassReflections): bool
     {
         $constantName = $this->getName($const);
-
-        foreach ($parentClassReflections as $parentClassReflection) {
-            if ($parentClassReflection->hasConstant($constantName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $parentClassReflections,
+            fn (ClassReflection $parentClassReflection): bool => $parentClassReflection->hasConstant($constantName)
+        );
     }
 
     private function findValueType(Expr $expr): ?Identifier

--- a/rules/Php84/Rector/FuncCall/AddEscapeArgumentRector.php
+++ b/rules/Php84/Rector/FuncCall/AddEscapeArgumentRector.php
@@ -108,13 +108,9 @@ CODE_SAMPLE
 
     private function shouldSkipNamedArg(FuncCall|MethodCall $node): bool
     {
-        foreach ($node->getArgs() as $arg) {
-            // already defined in named arg
-            if ($arg->name instanceof Identifier && $arg->name->toString() === 'escape') {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $node->getArgs(),
+            fn (Arg $arg): bool => $arg->name instanceof Identifier && $arg->name->toString() === 'escape'
+        );
     }
 }

--- a/rules/Privatization/Guard/OverrideByParentClassGuard.php
+++ b/rules/Privatization/Guard/OverrideByParentClassGuard.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Privatization\Guard;
 
+use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Reflection\ReflectionProvider;
@@ -26,12 +27,9 @@ final readonly class OverrideByParentClassGuard
             return false;
         }
 
-        foreach ($class->implements as $implement) {
-            if (! $this->reflectionProvider->hasClass($implement->toString())) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all(
+            $class->implements,
+            fn (Name $name): bool => $this->reflectionProvider->hasClass($name->toString())
+        );
     }
 }

--- a/rules/Privatization/VisibilityGuard/ClassMethodVisibilityGuard.php
+++ b/rules/Privatization/VisibilityGuard/ClassMethodVisibilityGuard.php
@@ -40,14 +40,10 @@ final readonly class ClassMethodVisibilityGuard
         $parentTraitReflections = $this->getLocalAndParentTraitReflections($classReflection);
 
         $methodName = $this->nodeNameResolver->getName($classMethod);
-
-        foreach ($parentTraitReflections as $parentTraitReflection) {
-            if ($parentTraitReflection->hasMethod($methodName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $parentTraitReflections,
+            fn (ClassReflection $classReflection): bool => $classReflection->hasMethod($methodName)
+        );
     }
 
     /**

--- a/rules/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/BoolReturnTypeFromBooleanStrictReturnsRector.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ExtendedParametersAcceptor;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\NodeAnalyzer\ExprAnalyzer;
 use Rector\PhpParser\Node\BetterNodeFinder;
@@ -170,13 +171,12 @@ CODE_SAMPLE
             return false;
         }
 
-        foreach ($functionReflection->getVariants() as $extendedParametersAcceptor) {
-            if (! $extendedParametersAcceptor->getNativeReturnType()->isBoolean()->yes()) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all(
+            $functionReflection->getVariants(),
+            fn (ExtendedParametersAcceptor $extendedParametersAcceptor): bool => $extendedParametersAcceptor->getNativeReturnType()
+                ->isBoolean()
+                ->yes()
+        );
     }
 
     /**

--- a/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByMethodCallTypeRector.php
@@ -236,12 +236,6 @@ CODE_SAMPLE
 
     private function hasAtLeastOneParamWithoutType(ClassMethod|Function_|Closure|ArrowFunction $functionLike): bool
     {
-        foreach ($functionLike->params as $param) {
-            if (! $param->type instanceof Node) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($functionLike->params, fn (Param $param): bool => ! $param->type instanceof Node);
     }
 }

--- a/rules/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
@@ -199,13 +200,10 @@ CODE_SAMPLE
             return false;
         }
 
-        foreach ($node->exprs as $expr) {
-            if ($expr instanceof Variable && $this->isName($expr, $paramName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $node->exprs,
+            fn (Expr $expr): bool => $expr instanceof Variable && $this->isName($expr, $paramName)
+        );
     }
 
     private function shouldStop(Node $node, string $paramName): bool
@@ -267,13 +265,10 @@ CODE_SAMPLE
             return false;
         }
 
-        foreach ($node->expr->getArgs() as $arg) {
-            if ($arg->value instanceof Variable && $this->isName($arg->value, $paramName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $node->expr->getArgs(),
+            fn (Arg $arg): bool => $arg->value instanceof Variable && $this->isName($arg->value, $paramName)
+        );
     }
 
     private function isEmptyOrEchoedOrCasted(Node $node, string $paramName): bool

--- a/rules/TypeDeclaration/Rector/ClassMethod/StringReturnTypeFromStrictStringReturnsRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/StringReturnTypeFromStrictStringReturnsRector.php
@@ -132,14 +132,10 @@ CODE_SAMPLE
      */
     private function hasAlwaysStringScalarReturn(array $returns): bool
     {
-        foreach ($returns as $return) {
-            // we need exact string "value" return
-            if (! $return->expr instanceof String_ && ! $return->expr instanceof InterpolatedString) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all(
+            $returns,
+            fn (Return_ $return): bool => ! (! $return->expr instanceof String_ && ! $return->expr instanceof InterpolatedString)
+        );
     }
 
     /**

--- a/rules/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector.php
+++ b/rules/TypeDeclaration/Rector/FuncCall/AddArrayAnyAllClosureParamTypeRector.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Param;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\FuncCall\AddArrayAnyAllClosureParamTypeRector\AddArrayAnyAllClosureParamTypeRectorTest
+ */
+final class AddArrayAnyAllClosureParamTypeRector extends AbstractRector implements MinPhpVersionInterface
+{
+    /**
+     * @var string[]
+     */
+    private const array FUNCTION_NAMES = ['array_any', 'array_all'];
+
+    public function __construct(
+        private readonly StaticTypeMapper $staticTypeMapper,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add a type to an untyped array_any()/array_all() closure param, based on the array item type',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+/** @var string[] $items */
+array_any($items, fn ($item): bool => $item !== '');
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+/** @var string[] $items */
+array_any($items, fn (string $item): bool => $item !== '');
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (! $this->isNames($node, self::FUNCTION_NAMES)) {
+            return null;
+        }
+
+        $arrayArg = $node->getArg('array', 0);
+        $callbackArg = $node->getArg('callback', 1);
+        if (! $arrayArg instanceof Arg || ! $callbackArg instanceof Arg) {
+            return null;
+        }
+
+        $callbackExpr = $callbackArg->value;
+        if (! $callbackExpr instanceof ArrowFunction && ! $callbackExpr instanceof Closure) {
+            return null;
+        }
+
+        $valueParam = $callbackExpr->getParams()[0] ?? null;
+        if (! $valueParam instanceof Param) {
+            return null;
+        }
+
+        // only fill in a param that has no type yet
+        if ($valueParam->type instanceof Node) {
+            return null;
+        }
+
+        $itemType = $this->resolveArrayItemType($this->getType($arrayArg->value));
+        if (! $itemType instanceof Type) {
+            return null;
+        }
+
+        if ($itemType instanceof MixedType) {
+            return null;
+        }
+
+        $paramTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($itemType, TypeKind::PARAM);
+        if (! $paramTypeNode instanceof Node) {
+            return null;
+        }
+
+        $valueParam->type = $paramTypeNode;
+
+        return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ARRAY_ANY;
+    }
+
+    private function resolveArrayItemType(Type $arrayType): ?Type
+    {
+        if ($arrayType instanceof ConstantArrayType || $arrayType instanceof ArrayType) {
+            return $arrayType->getItemType();
+        }
+
+        if ($arrayType instanceof IntersectionType) {
+            foreach ($arrayType->getTypes() as $subType) {
+                if ($subType instanceof AccessoryArrayListType) {
+                    continue;
+                }
+
+                if (! $subType instanceof ArrayType) {
+                    continue;
+                }
+
+                return $subType->getItemType();
+            }
+        }
+
+        return null;
+    }
+}

--- a/rules/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector.php
+++ b/rules/TypeDeclaration/Rector/FuncCall/NarrowArrayAnyAllNullableParamTypeRector.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Param;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector\NarrowArrayAnyAllNullableParamTypeRectorTest
+ */
+final class NarrowArrayAnyAllNullableParamTypeRector extends AbstractRector implements MinPhpVersionInterface
+{
+    /**
+     * @var string[]
+     */
+    private const array FUNCTION_NAMES = ['array_any', 'array_all', 'array_find', 'array_find_key'];
+
+    public function __construct(
+        private readonly StaticTypeMapper $staticTypeMapper,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Narrow an already nullable array_any()/array_all()/array_find()/array_find_key() closure param to the non-nullable array item type',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+/** @var string[] $items */
+array_any($items, fn (?string $item): bool => $item !== '');
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+/** @var string[] $items */
+array_any($items, fn (string $item): bool => $item !== '');
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (! $this->isNames($node, self::FUNCTION_NAMES)) {
+            return null;
+        }
+
+        $arrayArg = $node->getArg('array', 0);
+        $callbackArg = $node->getArg('callback', 1);
+        if (! $arrayArg instanceof Arg || ! $callbackArg instanceof Arg) {
+            return null;
+        }
+
+        $callbackExpr = $callbackArg->value;
+        if (! $callbackExpr instanceof ArrowFunction && ! $callbackExpr instanceof Closure) {
+            return null;
+        }
+
+        $valueParam = $callbackExpr->getParams()[0] ?? null;
+        if (! $valueParam instanceof Param) {
+            return null;
+        }
+
+        // only narrow a param that currently allows null
+        if (! $valueParam->type instanceof NullableType) {
+            return null;
+        }
+
+        $itemType = $this->resolveArrayItemType($this->getType($arrayArg->value));
+        if (! $itemType instanceof Type) {
+            return null;
+        }
+
+        // nothing to narrow when the item type is itself nullable or unknown
+        if ($itemType instanceof MixedType || ! $itemType->isNull()->no()) {
+            return null;
+        }
+
+        $paramTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($itemType, TypeKind::PARAM);
+        if (! $paramTypeNode instanceof Node) {
+            return null;
+        }
+
+        $valueParam->type = $paramTypeNode;
+
+        return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ARRAY_ANY;
+    }
+
+    private function resolveArrayItemType(Type $arrayType): ?Type
+    {
+        if ($arrayType instanceof ConstantArrayType || $arrayType instanceof ArrayType) {
+            return $arrayType->getItemType();
+        }
+
+        if ($arrayType instanceof IntersectionType) {
+            foreach ($arrayType->getTypes() as $subType) {
+                if ($subType instanceof AccessoryArrayListType) {
+                    continue;
+                }
+
+                if (! $subType instanceof ArrayType) {
+                    continue;
+                }
+
+                return $subType->getItemType();
+            }
+        }
+
+        return null;
+    }
+}

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromIterableMethodCallRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromIterableMethodCallRector.php
@@ -257,12 +257,9 @@ CODE_SAMPLE
      */
     private function callUsesClosures(array $args): bool
     {
-        foreach ($args as $arg) {
-            if ($arg instanceof Arg && $arg->value instanceof Closure) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $args,
+            fn (Arg|VariadicPlaceholder $arg): bool => $arg instanceof Arg && $arg->value instanceof Closure
+        );
     }
 }

--- a/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
+++ b/rules/TypeDeclaration/TypeAnalyzer/GenericClassStringTypeNormalizer.php
@@ -5,18 +5,13 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\TypeAnalyzer;
 
 use PHPStan\Type\Generic\GenericClassStringType;
+use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 
 final readonly class GenericClassStringTypeNormalizer
 {
     public function isAllGenericClassStringType(UnionType $unionType): bool
     {
-        foreach ($unionType->getTypes() as $type) {
-            if (! $type instanceof GenericClassStringType) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($unionType->getTypes(), fn (Type $type): bool => $type instanceof GenericClassStringType);
     }
 }

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForDimFetchArrayFromAssignsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForDimFetchArrayFromAssignsRector.php
@@ -206,13 +206,10 @@ CODE_SAMPLE
     private function isConstantArrayType(Type $returnedExprType): bool
     {
         if ($returnedExprType instanceof UnionType) {
-            foreach ($returnedExprType->getTypes() as $unionedType) {
-                if (! $unionedType instanceof ConstantArrayType) {
-                    return false;
-                }
-            }
-
-            return true;
+            return array_all(
+                $returnedExprType->getTypes(),
+                fn (Type $unionedType): bool => $unionedType instanceof ConstantArrayType
+            );
         }
 
         return $returnedExprType instanceof ConstantArrayType;

--- a/src/BetterPhpDocParser/Guard/NewPhpDocFromPHPStanTypeGuard.php
+++ b/src/BetterPhpDocParser/Guard/NewPhpDocFromPHPStanTypeGuard.php
@@ -21,12 +21,6 @@ final class NewPhpDocFromPHPStanTypeGuard
 
     private function isLegalUnionType(UnionType $type): bool
     {
-        foreach ($type->getTypes() as $unionType) {
-            if ($unionType instanceof MixedType) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($type->getTypes(), fn (Type $unionType): bool => ! $unionType instanceof MixedType);
     }
 }

--- a/src/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
+++ b/src/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
@@ -187,13 +187,10 @@ final class PhpDocInfoPrinter
 
     private function hasDocblockStart(string $output): bool
     {
-        foreach (self::DOCBLOCK_STARTS as $docblockStart) {
-            if (str_starts_with($output, $docblockStart)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            self::DOCBLOCK_STARTS,
+            fn (string $docblockStart): bool => str_starts_with($output, $docblockStart)
+        );
     }
 
     private function printDocChildNode(

--- a/src/BetterPhpDocParser/ValueObject/Parser/BetterTokenIterator.php
+++ b/src/BetterPhpDocParser/ValueObject/Parser/BetterTokenIterator.php
@@ -26,13 +26,7 @@ final class BetterTokenIterator extends TokenIterator
      */
     public function isNextTokenTypes(array $types): bool
     {
-        foreach ($types as $type) {
-            if ($this->isNextTokenType($type)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($types, fn (int $type): bool => $this->isNextTokenType($type));
     }
 
     public function isTokenTypeOnPosition(int $tokenType, int $position): bool
@@ -101,13 +95,7 @@ final class BetterTokenIterator extends TokenIterator
 
     public function containsTokenType(int $type): bool
     {
-        foreach ($this->getTokens() as $token) {
-            if ($token[1] === $type) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->getTokens(), fn (array $token): bool => $token[1] === $type);
     }
 
     private function nextTokenType(): ?int

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -57,8 +57,10 @@ use Rector\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
+use Rector\TypeDeclaration\Rector\FuncCall\AddArrayAnyAllClosureParamTypeRector;
 use Rector\TypeDeclaration\Rector\FuncCall\AddArrayFunctionClosureParamTypeRector;
 use Rector\TypeDeclaration\Rector\FuncCall\AddArrowFunctionParamArrayWhereDimFetchRector;
+use Rector\TypeDeclaration\Rector\FuncCall\NarrowArrayAnyAllNullableParamTypeRector;
 use Rector\TypeDeclaration\Rector\Function_\AddFunctionVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayReduceRector;
@@ -171,5 +173,8 @@ final class TypeDeclarationLevel
         TypedPropertyFromDocblockSetUpDefinedRector::class,
         AddClosureParamTypeFromIterableMethodCallRector::class,
         TypedStaticPropertyInBehatContextRector::class,
+        // PHP 8.4
+        NarrowArrayAnyAllNullableParamTypeRector::class,
+        AddArrayAnyAllClosureParamTypeRector::class,
     ];
 }

--- a/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
+++ b/src/FamilyTree/NodeAnalyzer/ClassChildAnalyzer.php
@@ -27,13 +27,7 @@ final readonly class ClassChildAnalyzer
             return false;
         }
 
-        foreach ($parentClassMethods as $parentClassMethod) {
-            if ($parentClassMethod->isAbstract()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($parentClassMethods, fn ($parentClassMethod) => $parentClassMethod->isAbstract());
     }
 
     /**

--- a/src/NodeAnalyzer/ArgsAnalyzer.php
+++ b/src/NodeAnalyzer/ArgsAnalyzer.php
@@ -20,13 +20,7 @@ final readonly class ArgsAnalyzer
      */
     public function hasNamedArg(array $args): bool
     {
-        foreach ($args as $arg) {
-            if ($arg->name instanceof Identifier) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($args, fn (Arg $arg): bool => $arg->name instanceof Identifier);
     }
 
     /**

--- a/src/NodeAnalyzer/CallAnalyzer.php
+++ b/src/NodeAnalyzer/CallAnalyzer.php
@@ -42,13 +42,10 @@ final readonly class CallAnalyzer
             return $isObjectCallLeft || $isObjectCallRight;
         }
 
-        foreach (self::OBJECT_CALL_TYPES as $objectCallType) {
-            if ($expr instanceof $objectCallType) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            self::OBJECT_CALL_TYPES,
+            fn (string $objectCallType): bool => $expr instanceof $objectCallType
+        );
     }
 
     /**
@@ -56,13 +53,7 @@ final readonly class CallAnalyzer
      */
     public function doesIfHasObjectCall(array $ifs): bool
     {
-        foreach ($ifs as $if) {
-            if ($this->isObjectCall($if->cond)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($ifs, fn (If_ $if): bool => $this->isObjectCall($if->cond));
     }
 
     public function isNewInstance(Variable $variable): bool

--- a/src/NodeAnalyzer/CallLikeArgumentNameAdder.php
+++ b/src/NodeAnalyzer/CallLikeArgumentNameAdder.php
@@ -85,13 +85,7 @@ final readonly class CallLikeArgumentNameAdder
             return true;
         }
 
-        foreach ($args as $arg) {
-            if ($arg->unpack) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($args, fn ($arg) => $arg->unpack);
     }
 
     /**

--- a/src/NodeAnalyzer/DoctrineEntityAnalyzer.php
+++ b/src/NodeAnalyzer/DoctrineEntityAnalyzer.php
@@ -50,13 +50,11 @@ final readonly class DoctrineEntityAnalyzer
             return false;
         }
 
-        foreach (self::DOCTRINE_MAPPING_CLASSES as $doctrineMappingClass) {
-            // skip entities
-            if ($nativeReflectionClass->getAttributes($doctrineMappingClass) !== []) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            self::DOCTRINE_MAPPING_CLASSES,
+            fn (string $doctrineMappingClass): bool => $nativeReflectionClass->getAttributes(
+                $doctrineMappingClass
+            ) !== []
+        );
     }
 }

--- a/src/NodeAnalyzer/ParamAnalyzer.php
+++ b/src/NodeAnalyzer/ParamAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\NodeAnalyzer;
 
 use PhpParser\Node;
+use PhpParser\Node\ClosureUse;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Closure;
@@ -102,13 +103,7 @@ final readonly class ParamAnalyzer
      */
     public function hasPropertyPromotion(array $params): bool
     {
-        foreach ($params as $param) {
-            if ($param->isPromoted()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($params, fn (Param $param): bool => $param->isPromoted());
     }
 
     public function isNullable(Param $param): bool
@@ -144,13 +139,10 @@ final readonly class ParamAnalyzer
 
     private function isVariableInClosureUses(Closure $closure, Variable $variable): bool
     {
-        foreach ($closure->uses as $use) {
-            if ($this->nodeComparator->areNodesEqual($use->var, $variable)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $closure->uses,
+            fn (ClosureUse $use): bool => $this->nodeComparator->areNodesEqual($use->var, $variable)
+        );
     }
 
     private function isUsedAsArg(Node $node, Param $param): bool

--- a/src/NodeAnalyzer/ScopeAnalyzer.php
+++ b/src/NodeAnalyzer/ScopeAnalyzer.php
@@ -18,12 +18,9 @@ final class ScopeAnalyzer
 
     public function isRefreshable(Node $node): bool
     {
-        foreach (self::NON_REFRESHABLE_NODES as $noScopeNode) {
-            if ($node instanceof $noScopeNode) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all(
+            self::NON_REFRESHABLE_NODES,
+            fn (string $noScopeNode): bool => ! $node instanceof $noScopeNode
+        );
     }
 }

--- a/src/NodeAnalyzer/VariadicAnalyzer.php
+++ b/src/NodeAnalyzer/VariadicAnalyzer.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptor;
 use Rector\Reflection\ReflectionResolver;
 
 final readonly class VariadicAnalyzer
@@ -31,13 +32,9 @@ final readonly class VariadicAnalyzer
 
     private function hasVariadicVariant(MethodReflection | FunctionReflection $functionLikeReflection): bool
     {
-        foreach ($functionLikeReflection->getVariants() as $parametersAcceptor) {
-            // can be any number of arguments → nothing to limit here
-            if ($parametersAcceptor->isVariadic()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $functionLikeReflection->getVariants(),
+            fn (ParametersAcceptor $parametersAcceptor): bool => $parametersAcceptor->isVariadic()
+        );
     }
 }

--- a/src/NodeManipulator/ClassDependencyManipulator.php
+++ b/src/NodeManipulator/ClassDependencyManipulator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\NodeManipulator;
 
 use PhpParser\Modifiers;
+use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\StaticCall;
@@ -334,13 +335,10 @@ final readonly class ClassDependencyManipulator
             return false;
         }
 
-        foreach ($classReflection->getParents() as $parentClassReflection) {
-            if ($parentClassReflection->hasMethod($methodName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $classReflection->getParents(),
+            fn (ClassReflection $parentClassReflection): bool => $parentClassReflection->hasMethod($methodName)
+        );
     }
 
     private function createParentClassMethodCall(string $methodName): Expression
@@ -357,13 +355,10 @@ final readonly class ClassDependencyManipulator
             return false;
         }
 
-        foreach ($constructClassMethod->params as $param) {
-            if ($this->nodeNameResolver->isName($param, $propertyName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $constructClassMethod->params,
+            fn (Node|array $param): bool => $this->nodeNameResolver->isName($param, $propertyName)
+        );
     }
 
     private function hasClassPropertyAndDependency(Class_ $class, PropertyMetadata $propertyMetadata): bool

--- a/src/NodeManipulator/ClassMethodManipulator.php
+++ b/src/NodeManipulator/ClassMethodManipulator.php
@@ -58,12 +58,9 @@ final readonly class ClassMethodManipulator
             }
         }
 
-        foreach ($classReflection->getInterfaces() as $interfaceReflection) {
-            if ($interfaceReflection->hasMethod($methodName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $classReflection->getInterfaces(),
+            fn (ClassReflection $classReflection): bool => $classReflection->hasMethod($methodName)
+        );
     }
 }

--- a/src/NodeNameResolver/NodeNameResolver.php
+++ b/src/NodeNameResolver/NodeNameResolver.php
@@ -61,13 +61,7 @@ final class NodeNameResolver
             return false;
         }
 
-        foreach ($names as $name) {
-            if ($this->isStringName($nodeName, $name)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($names, fn (string $name): bool => $this->isStringName($nodeName, $name));
     }
 
     /**
@@ -77,14 +71,7 @@ final class NodeNameResolver
     public function isName(Node | array $node, string $name): bool
     {
         $nodes = is_array($node) ? $node : [$node];
-
-        foreach ($nodes as $node) {
-            if ($this->isSingleName($node, $name)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($nodes, fn (Node $node): bool => $this->isSingleName($node, $name));
     }
 
     /**

--- a/src/NodeTypeResolver/PHPStan/Type/StaticTypeAnalyzer.php
+++ b/src/NodeTypeResolver/PHPStan/Type/StaticTypeAnalyzer.php
@@ -55,13 +55,7 @@ final readonly class StaticTypeAnalyzer
             return false;
         }
 
-        foreach ($type->getTypes() as $unionedType) {
-            if (! $this->isAlwaysTruableType($unionedType)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($type->getTypes(), fn (Type $unionedType): bool => $this->isAlwaysTruableType($unionedType));
     }
 
     private function isAlwaysTruableArrayType(ArrayType $arrayType): bool

--- a/src/PhpAttribute/NodeFactory/AnnotationToAttributeIntegerValueCaster.php
+++ b/src/PhpAttribute/NodeFactory/AnnotationToAttributeIntegerValueCaster.php
@@ -92,13 +92,7 @@ final readonly class AnnotationToAttributeIntegerValueCaster
             return false;
         }
 
-        foreach ($type->getTypes() as $unionedType) {
-            if ($unionedType->isInteger()->yes()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($type->getTypes(), fn (Type $unionedType): bool => $unionedType->isInteger()->yes());
     }
 
     /**

--- a/src/PhpParser/Enum/NodeGroup.php
+++ b/src/PhpParser/Enum/NodeGroup.php
@@ -82,12 +82,6 @@ final class NodeGroup
 
     public static function isStmtAwareNode(Node $node): bool
     {
-        foreach (self::STMTS_AWARE as $stmtAwareClass) {
-            if ($node instanceof $stmtAwareClass) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(self::STMTS_AWARE, fn (string $stmtAwareClass): bool => $node instanceof $stmtAwareClass);
     }
 }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -111,15 +111,10 @@ final readonly class BetterNodeFinder
     {
         Assert::allIsAOf($types, Node::class);
 
-        return (bool) $this->nodeFinder->findFirst($nodes, static function (Node $node) use ($types): bool {
-            foreach ($types as $type) {
-                if ($node instanceof $type) {
-                    return true;
-                }
-            }
-
-            return false;
-        });
+        return (bool) $this->nodeFinder->findFirst(
+            $nodes,
+            static fn (Node $node): bool => array_any($types, fn (string $type): bool => $node instanceof $type)
+        );
     }
 
     /**

--- a/src/PhpParser/Node/FileNode.php
+++ b/src/PhpParser/Node/FileNode.php
@@ -140,13 +140,12 @@ class FileNode extends Stmt
 
     public function hasImport(FullyQualifiedObjectType $fullyQualifiedObjectType): bool
     {
-        foreach ($this->resolveUsedImportTypes() as $useImport) {
-            if ($useImport->equals($fullyQualifiedObjectType)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $this->resolveUsedImportTypes(),
+            fn (AliasedObjectType|FullyQualifiedObjectType $useImport): bool => $useImport->equals(
+                $fullyQualifiedObjectType
+            )
+        );
     }
 
     /**
@@ -224,13 +223,7 @@ class FileNode extends Stmt
 
     public function isNamespaced(): bool
     {
-        foreach ($this->stmts as $stmt) {
-            if ($stmt instanceof Namespace_) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->stmts, fn (Stmt $stmt): bool => $stmt instanceof Namespace_);
     }
 
     public function getNamespace(): ?Namespace_

--- a/src/VendorLocker/NodeVendorLocker/ClassMethodParamVendorLockResolver.php
+++ b/src/VendorLocker/NodeVendorLocker/ClassMethodParamVendorLockResolver.php
@@ -46,12 +46,9 @@ final readonly class ClassMethodParamVendorLockResolver
      */
     private function hasParentInterfaceMethod(ClassReflection $classReflection, string $methodName): bool
     {
-        foreach ($classReflection->getInterfaces() as $interfaceClassReflection) {
-            if ($interfaceClassReflection->hasMethod($methodName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $classReflection->getInterfaces(),
+            fn (ClassReflection $interfaceClassReflection): bool => $interfaceClassReflection->hasMethod($methodName)
+        );
     }
 }


### PR DESCRIPTION
Two new PHP 8.4 type-declaration rules for `array_any()`/`array_all()` (and friends) closure params.

## AddArrayAnyAllClosureParamTypeRector

Adds a type to an **untyped** closure param, based on the array item type.

```diff
 /** @var string[] $items */
-array_any($items, fn ($item): bool => $item !== '');
+array_any($items, fn (string $item): bool => $item !== '');
```

Handles `array_any()`, `array_all()`. Only fills a param that has **no** type yet.

<br>

## NarrowArrayAnyAllNullableParamTypeRector

Narrows an **already nullable** closure param to the non-nullable array item type.

```diff
 /** @var string[] $items */
-array_any($items, fn (?string $item): bool => $item !== '');
+array_any($items, fn (string $item): bool => $item !== '');
```

Handles `array_any()`, `array_all()`, `array_find()`, `array_find_key()`. Only acts on a `?type` param, and skips when the item type is itself nullable.

The two rules are complementary and non-overlapping: one fills a missing type, the other tightens an existing nullable one.