### PR TITLE
[DeadCode] Avoid scan whole new stmts on RemoveAlwaysTrueIfConditionRector on dynamic variable check

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/scoped_dynamic_variable.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/scoped_dynamic_variable.php.inc
@@ -1,0 +1,65 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+class ScopedDynamicVariable
+{
+    public function build(array $params): string
+    {
+        $addHelpMessage = true;
+
+        foreach (['addHelpMessage'] as $f) {
+            if (isset($params[$f])) {
+                ${$f} = (bool) $params[$f];
+            }
+        }
+
+        if ($addHelpMessage) {
+            return 'help';
+        }
+
+        return 'no help';
+    }
+
+    public function differentScope()
+    {
+        $int = 1;
+        if ($int === 1) {
+            return 'hi';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+class ScopedDynamicVariable
+{
+    public function build(array $params): string
+    {
+        $addHelpMessage = true;
+
+        foreach (['addHelpMessage'] as $f) {
+            if (isset($params[$f])) {
+                ${$f} = (bool) $params[$f];
+            }
+        }
+
+        if ($addHelpMessage) {
+            return 'help';
+        }
+
+        return 'no help';
+    }
+
+    public function differentScope()
+    {
+        $int = 1;
+        return 'hi';
+    }
+}
+
+?>

--- a/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
@@ -149,15 +149,9 @@ CODE_SAMPLE
     {
         /** @var Variable[] $variables */
         $variables = $this->betterNodeFinder->findInstancesOf($expr, [Variable::class]);
-
-        $hasPlainVariable = false;
         foreach ($variables as $variable) {
-            if ($this->exprAnalyzer->isNonTypedFromParam($variable)) {
-                return true;
-            }
-
             if (! $variable->name instanceof Expr) {
-                $hasPlainVariable = true;
+                return true;
             }
 
             $type = $this->nodeTypeResolver->getNativeType($variable);
@@ -170,18 +164,7 @@ CODE_SAMPLE
             }
         }
 
-        // a dynamic variable assignment, e.g. ${$name} = ..., is invisible to native type inference, so the
-        // condition variable may be overwritten at runtime and is not safe to evaluate as always true
-        return $hasPlainVariable && $this->hasDynamicVariable();
-    }
-
-    private function hasDynamicVariable(): bool
-    {
-        return (bool) $this->betterNodeFinder->findFirst(
-            $this->getFile()
-                ->getNewStmts(),
-            static fn (Node $node): bool => $node instanceof Variable && $node->name instanceof Expr
-        );
+        return false;
     }
 
     private function shouldSkipExpr(Expr $expr): bool

--- a/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
@@ -19,7 +19,6 @@ use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\NodeVisitor;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\IntersectionType;
 use Rector\DeadCode\NodeAnalyzer\SafeLeftTypeBooleanAndOrAnalyzer;
 use Rector\NodeAnalyzer\ExprAnalyzer;
@@ -163,21 +162,6 @@ CODE_SAMPLE
                         return true;
                     }
                 }
-            }
-        }
-
-        $scope = ScopeFetcher::fetch($expr);
-        $definedVariables = $scope->getDefinedVariables();
-
-        foreach ($definedVariables as $definedVariable) {
-            if (! $scope->hasVariableType($definedVariable)->yes()) {
-                continue;
-            }
-
-            $variableType = $scope->getVariableType($definedVariable);
-            if ($variableType instanceof ConstantStringType
-                && in_array($variableType->getValue(), $definedVariables, true)) {
-                return true;
             }
         }
 

--- a/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
@@ -19,6 +19,7 @@ use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\NodeVisitor;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\IntersectionType;
 use Rector\DeadCode\NodeAnalyzer\SafeLeftTypeBooleanAndOrAnalyzer;
 use Rector\NodeAnalyzer\ExprAnalyzer;
@@ -149,8 +150,9 @@ CODE_SAMPLE
     {
         /** @var Variable[] $variables */
         $variables = $this->betterNodeFinder->findInstancesOf($expr, [Variable::class]);
+
         foreach ($variables as $variable) {
-            if (! $variable->name instanceof Expr) {
+            if ($this->exprAnalyzer->isNonTypedFromParam($variable)) {
                 return true;
             }
 
@@ -161,6 +163,21 @@ CODE_SAMPLE
                         return true;
                     }
                 }
+            }
+        }
+
+        $scope = ScopeFetcher::fetch($expr);
+        $definedVariables = $scope->getDefinedVariables();
+
+        foreach ($definedVariables as $definedVariable) {
+            if (! $scope->hasVariableType($definedVariable)->yes()) {
+                continue;
+            }
+
+            $variableType = $scope->getVariableType($definedVariable);
+            if ($variableType instanceof ConstantStringType
+                && in_array($variableType->getValue(), $definedVariables, true)) {
+                return true;
             }
         }
 

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -169,6 +169,15 @@ final readonly class ExprAnalyzer
             return true;
         }
 
+        if ($nativeType instanceof UnionType && ! $nativeType->equals($type)) {
+            return true;
+        }
+
+        if (! $nativeType->isSuperTypeOf($type)
+            ->yes()) {
+            return true;
+        }
+
         $definedVariables = $scope->getDefinedVariables();
         foreach ($definedVariables as $definedVariable) {
             $variableType = $scope->getVariableType($definedVariable);
@@ -178,12 +187,7 @@ final readonly class ExprAnalyzer
             }
         }
 
-        if ($nativeType instanceof UnionType) {
-            return ! $nativeType->equals($type);
-        }
-
-        return ! $nativeType->isSuperTypeOf($type)
-            ->yes();
+        return false;
     }
 
     public function isDynamicExpr(Expr $expr): bool

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -171,10 +171,6 @@ final readonly class ExprAnalyzer
 
         $definedVariables = $scope->getDefinedVariables();
         foreach ($definedVariables as $definedVariable) {
-            if (! $scope->hasVariableType($definedVariable)->yes()) {
-                continue;
-            }
-
             $variableType = $scope->getVariableType($definedVariable);
             if ($variableType instanceof ConstantStringType
                 && in_array($variableType->getValue(), $definedVariables, true)) {

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -141,7 +141,7 @@ final readonly class ExprAnalyzer
     public function isNonTypedFromParam(Expr $expr): bool
     {
         if (! $expr instanceof Variable) {
-            return false;
+            return true;
         }
 
         $scope = $expr->getAttribute(AttributeKey::SCOPE);

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -141,7 +141,7 @@ final readonly class ExprAnalyzer
     public function isNonTypedFromParam(Expr $expr): bool
     {
         if (! $expr instanceof Variable) {
-            return true;
+            return false;
         }
 
         $scope = $expr->getAttribute(AttributeKey::SCOPE);

--- a/src/NodeAnalyzer/ExprAnalyzer.php
+++ b/src/NodeAnalyzer/ExprAnalyzer.php
@@ -50,6 +50,7 @@ use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Scalar\InterpolatedString;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\UnionType;
@@ -166,6 +167,19 @@ final readonly class ExprAnalyzer
 
         if (! $scope->hasVariableType((string) $this->nodeNameResolver->getName($expr))->yes()) {
             return true;
+        }
+
+        $definedVariables = $scope->getDefinedVariables();
+        foreach ($definedVariables as $definedVariable) {
+            if (! $scope->hasVariableType($definedVariable)->yes()) {
+                continue;
+            }
+
+            $variableType = $scope->getVariableType($definedVariable);
+            if ($variableType instanceof ConstantStringType
+                && in_array($variableType->getValue(), $definedVariables, true)) {
+                return true;
+            }
         }
 
         if ($nativeType instanceof UnionType) {

--- a/src/PhpParser/NodeVisitor/ContextNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/ContextNodeVisitor.php
@@ -112,6 +112,11 @@ final class ContextNodeVisitor extends NodeVisitorAbstract implements Decorating
             return null;
         }
 
+        if ($node instanceof Variable && $node->name instanceof Expr) {
+            $node->setAttribute(AttributeKey::IS_DYNAMIC_VARIABLE, true);
+            return null;
+        }
+
         $this->processContextInClass($node);
         return null;
     }

--- a/src/PhpParser/NodeVisitor/ContextNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/ContextNodeVisitor.php
@@ -112,11 +112,6 @@ final class ContextNodeVisitor extends NodeVisitorAbstract implements Decorating
             return null;
         }
 
-        if ($node instanceof Variable && $node->name instanceof Expr) {
-            $node->setAttribute(AttributeKey::IS_DYNAMIC_VARIABLE, true);
-            return null;
-        }
-
         $this->processContextInClass($node);
         return null;
     }


### PR DESCRIPTION
check directly on `$scope->getDefinedVariables()` seems enough.

Ref https://github.com/rectorphp/rector-src/pull/8055#pullrequestreview-4536740657