### PR TITLE
[TypeDeclaration][DeadCode] Skip class with Doctrine static function mapping (loadMetadata) in TypedPropertyFromAssignsRector and RemoveUnusedPrivatePropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_static_function_mapping.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector/Fixture/skip_static_function_mapping.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+final class SkipStaticFunctionMapping
+{
+    private $name;
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->mapField([
+            'fieldName' => 'name',
+            'type' => 'string',
+        ]);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/Doctrine/skip_static_function_mapping.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector/Fixture/Doctrine/skip_static_function_mapping.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector\Fixture\Doctrine;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+final class SkipStaticFunctionMapping
+{
+    private $name;
+
+    public function run()
+    {
+        $this->name = 'string';
+    }
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->mapField([
+            'fieldName' => 'name',
+            'type' => 'string',
+        ]);
+    }
+}

--- a/rules/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveUnusedPrivatePropertyRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Return_;
@@ -144,6 +145,12 @@ CODE_SAMPLE
 
     private function shouldSkipClass(Class_ $class): bool
     {
+        // skip Doctrine static function mapping, properties are mapped in loadMetadata() method
+        // @see https://www.doctrine-project.org/projects/doctrine-orm/en/3.6/reference/php-mapping.html#static-function
+        if ($class->getMethod('loadMetadata') instanceof ClassMethod) {
+            return true;
+        }
+
         foreach ($class->stmts as $stmt) {
             // unclear what property can be used there
             if ($stmt instanceof TraitUse) {

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromAssignsRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\UnionType as NodeUnionType;
 use PHPStan\Reflection\ClassReflection;
@@ -129,6 +130,12 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        // skip Doctrine static function mapping, properties are mapped in loadMetadata() method
+        // @see https://www.doctrine-project.org/projects/doctrine-orm/en/3.6/reference/php-mapping.html#static-function
+        if ($node->getMethod('loadMetadata') instanceof ClassMethod) {
+            return null;
+        }
+
         $hasChanged = false;
         $classReflection = null;
 


### PR DESCRIPTION
Skip classes that use [Doctrine static function mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/3.6/reference/php-mapping.html#static-function) in `TypedPropertyFromAssignsRector` and `RemoveUnusedPrivatePropertyRector`.

Such classes map their fields in a `loadMetadata()` method instead of attributes/annotations, so the existing attribute/annotation-based skip does not catch them. Both rules now bail out when the class defines a `loadMetadata()` method.

## Example

```php
use Doctrine\ORM\Mapping\ClassMetadata;

final class Product
{
    private $name;

    public static function loadMetadata(ClassMetadata $metadata): void
    {
        $metadata->mapField([
            'fieldName' => 'name',
            'type' => 'string',
        ]);
    }
}
```

The `$name` property is Doctrine-mapped via `loadMetadata()`, so it is left untouched (no type added, not removed as unused).
