### PR TITLE
[TypeDeclaration] Skip class with Doctrine static function mapping (loadMetadata) in TypedPropertyFromStrictConstructorRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/skip_static_function_mapping.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/skip_static_function_mapping.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+final class SkipStaticFunctionMapping
+{
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->mapField([
+            'fieldName' => 'name',
+            'type' => 'string',
+        ]);
+    }
+}

--- a/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
+++ b/rules/TypeDeclaration/Rector/Property/TypedPropertyFromStrictConstructorRector.php
@@ -92,6 +92,12 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        // skip Doctrine static function mapping, properties are mapped in loadMetadata() method
+        // @see https://www.doctrine-project.org/projects/doctrine-orm/en/3.6/reference/php-mapping.html#static-function
+        if ($node->getMethod('loadMetadata') instanceof ClassMethod) {
+            return null;
+        }
+
         $constructClassMethod = $node->getMethod(MethodName::CONSTRUCT);
         if (! $constructClassMethod instanceof ClassMethod) {
             return null;


### PR DESCRIPTION
Skip classes that use [Doctrine static function mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/3.6/reference/php-mapping.html#static-function) in `TypedPropertyFromStrictConstructorRector`.

Such classes map their fields in a `loadMetadata()` method instead of attributes/annotations, so the existing attribute/annotation-based skip does not catch them. The rule now bails out when the class defines a `loadMetadata()` method.

## Example

```php
use Doctrine\ORM\Mapping\ClassMetadata;

final class Product
{
    private $name;

    public function __construct(string $name)
    {
        $this->name = $name;
    }

    public static function loadMetadata(ClassMetadata $metadata): void
    {
        $metadata->mapField([
            'fieldName' => 'name',
            'type' => 'string',
        ]);
    }
}
```

The `$name` property is Doctrine-mapped via `loadMetadata()`, so it is left untouched (no type added).

Follow-up to #8059, which applied the same skip to `TypedPropertyFromAssignsRector` and `RemoveUnusedPrivatePropertyRector`. See also rectorphp/rector-doctrine#484.
