### PR TITLE
[rector] Add AddParamTypeToRefactorMethodRector if missing

### DIFF
--- a/config/set/rector-preset.php
+++ b/config/set/rector-preset.php
@@ -7,6 +7,7 @@ use Rector\Config\RectorConfig;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector;
 use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
+use Rector\TypeDeclarationDocblocks\Rector\Class_\AddParamTypeToRefactorMethodRector;
 use Rector\Utils\Rector\RemoveRefactorDuplicatedNodeInstanceCheckRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -14,6 +15,7 @@ return static function (RectorConfig $rectorConfig): void {
         DeclareStrictTypesRector::class,
         PostIncDecToPreIncDecRector::class,
         FinalizeTestCaseClassRector::class,
+        AddParamTypeToRefactorMethodRector::class,
         RemoveRefactorDuplicatedNodeInstanceCheckRector::class,
         AddSeeTestAnnotationRector::class,
     ]);

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/AddParamTypeToRefactorMethodRectorTest.php
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/AddParamTypeToRefactorMethodRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddParamTypeToRefactorMethodRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddParamTypeToRefactorMethodRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/Fixture/add_multiple_node_types.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/Fixture/add_multiple_node_types.php.inc
@@ -1,0 +1,58 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddParamTypeToRefactorMethodRector\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AddMultipleNodeTypes extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Identical::class, NotIdentical::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddParamTypeToRefactorMethodRector\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AddMultipleNodeTypes extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Identical::class, NotIdentical::class];
+    }
+
+    /**
+     * @param Identical|NotIdentical $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/Fixture/add_single_node_type.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/Fixture/add_single_node_type.php.inc
@@ -1,0 +1,56 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddParamTypeToRefactorMethodRector\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AddSingleNodeType extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddParamTypeToRefactorMethodRector\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AddSingleNodeType extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/Fixture/skip_already_has_param.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/Fixture/skip_already_has_param.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddParamTypeToRefactorMethodRector\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class SkipAlreadyHasParam extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/Fixture/skip_interface_node_type.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/Fixture/skip_interface_node_type.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddParamTypeToRefactorMethodRector\Fixture;
+
+use PhpParser\Node;
+use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class SkipInterfaceNodeType extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [StmtsAwareInterface::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/Fixture/skip_non_rector_class.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/Fixture/skip_non_rector_class.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddParamTypeToRefactorMethodRector\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+
+final class SkipNonRectorClass
+{
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclarationDocblocks\Rector\Class_\AddParamTypeToRefactorMethodRector;
+
+return RectorConfig::configure()
+    ->withRules([AddParamTypeToRefactorMethodRector::class])
+    ->withImportNames();

--- a/rules/Transform/Rector/ConstFetch/ConstFetchToClassConstFetchRector.php
+++ b/rules/Transform/Rector/ConstFetch/ConstFetchToClassConstFetchRector.php
@@ -38,6 +38,9 @@ final class ConstFetchToClassConstFetchRector extends AbstractRector implements 
         return [ConstFetch::class];
     }
 
+    /**
+     * @param ConstFetch $node
+     */
     public function refactor(Node $node): ?ClassConstFetch
     {
         foreach ($this->constFetchToClassConsts as $constFetchToClassConst) {

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector.php
@@ -6,11 +6,11 @@ namespace Rector\TypeDeclarationDocblocks\Rector\Class_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -18,7 +18,6 @@ use PHPStan\Type\TypeCombinator;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\PhpParser\Node\Value\ValueResolver;
-use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -81,14 +80,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $scope = ScopeFetcher::fetch($node);
-        $classReflection = $scope->getClassReflection();
-
-        if (! $classReflection instanceof ClassReflection) {
+        if (! $node->extends instanceof Name) {
             return null;
         }
 
-        if (! $classReflection->is('Rector\Rector\AbstractRector')) {
+        if (! $this->isObjectType($node, new ObjectType('Rector\Rector\AbstractRector'))) {
             return null;
         }
 

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclarationDocblocks\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddParamTypeToRefactorMethodRector\AddParamTypeToRefactorMethodRectorTest
+ */
+final class AddParamTypeToRefactorMethodRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly PhpDocTypeChanger $phpDocTypeChanger,
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ValueResolver $valueResolver,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add @param node type to refactor() method based on getNodeTypes() of a Rector rule, to avoid instanceof checks and unknown types reported by PHPStan',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+public function getNodeTypes(): array
+{
+    return [MethodCall::class];
+}
+
+public function refactor(Node $node): ?Node
+{
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+public function getNodeTypes(): array
+{
+    return [MethodCall::class];
+}
+
+/**
+ * @param MethodCall $node
+ */
+public function refactor(Node $node): ?Node
+{
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $scope = ScopeFetcher::fetch($node);
+        $classReflection = $scope->getClassReflection();
+
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        if (! $classReflection->is('Rector\Rector\AbstractRector')) {
+            return null;
+        }
+
+        $refactorClassMethod = $node->getMethod('refactor');
+        if (! $refactorClassMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        $param = $refactorClassMethod->params[0] ?? null;
+        if ($param === null) {
+            return null;
+        }
+
+        $refactorPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($refactorClassMethod);
+
+        // only add when missing, never override an existing, possibly more precise @param
+        if ($refactorPhpDocInfo->getParamTagValueByName('node') instanceof ParamTagValueNode) {
+            return null;
+        }
+
+        $nodeType = $this->matchSingleNodeTypesType($node);
+        if (! $nodeType instanceof Type) {
+            return null;
+        }
+
+        $hasChanged = $this->phpDocTypeChanger->changeParamType(
+            $refactorClassMethod,
+            $refactorPhpDocInfo,
+            $nodeType,
+            $param,
+            'node'
+        );
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    private function matchSingleNodeTypesType(Class_ $class): ?Type
+    {
+        $getNodeTypesClassMethod = $class->getMethod('getNodeTypes');
+        if (! $getNodeTypesClassMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        $soleReturn = $getNodeTypesClassMethod->stmts[0] ?? null;
+        if (! $soleReturn instanceof Return_) {
+            return null;
+        }
+
+        // only inline array literals, e.g. "return [MethodCall::class];"
+        // constant groups like NodeGroup::STMTS_AWARE expand to an unwieldy union
+        if (! $soleReturn->expr instanceof Array_) {
+            return null;
+        }
+
+        $nodeTypes = $this->valueResolver->getValue($soleReturn->expr);
+        if (! is_array($nodeTypes) || $nodeTypes === []) {
+            return null;
+        }
+
+        $objectTypes = [];
+        foreach ($nodeTypes as $nodeType) {
+            if (! is_string($nodeType)) {
+                return null;
+            }
+
+            // skip interface node types, they expand to an unwieldy union of all implementers
+            if (! $this->reflectionProvider->hasClass($nodeType)) {
+                return null;
+            }
+
+            if ($this->reflectionProvider->getClass($nodeType)->isInterface()) {
+                return null;
+            }
+
+            $objectTypes[] = new ObjectType($nodeType);
+        }
+
+        return TypeCombinator::union(...$objectTypes);
+    }
+}

--- a/tests/Issues/ScopeNotAvailable/Variable/ArrayItemForeachValueRector.php
+++ b/tests/Issues/ScopeNotAvailable/Variable/ArrayItemForeachValueRector.php
@@ -26,6 +26,9 @@ final class ArrayItemForeachValueRector extends AbstractRector
         return [Variable::class];
     }
 
+    /**
+     * @param Variable $node
+     */
     public function refactor(Node $node): Node
     {
         return $node;

--- a/tests/PhpParser/NodeTraverser/ClassLike/RuleUsingClassLikeRector.php
+++ b/tests/PhpParser/NodeTraverser/ClassLike/RuleUsingClassLikeRector.php
@@ -28,6 +28,9 @@ final class RuleUsingClassLikeRector extends AbstractRector
         return [ClassLike::class];
     }
 
+    /**
+     * @param ClassLike $node
+     */
     public function refactor(Node $node): Node
     {
         return $node;

--- a/tests/PhpParser/NodeTraverser/Class_/RuleUsingClassRector.php
+++ b/tests/PhpParser/NodeTraverser/Class_/RuleUsingClassRector.php
@@ -28,6 +28,9 @@ final class RuleUsingClassRector extends AbstractRector
         return [Class_::class];
     }
 
+    /**
+     * @param Class_ $node
+     */
     public function refactor(Node $node): Node
     {
         return $node;

--- a/tests/PhpParser/NodeTraverser/Function_/RuleUsingFunctionRector.php
+++ b/tests/PhpParser/NodeTraverser/Function_/RuleUsingFunctionRector.php
@@ -28,6 +28,9 @@ final class RuleUsingFunctionRector extends AbstractRector
         return [Function_::class];
     }
 
+    /**
+     * @param Function_ $node
+     */
     public function refactor(Node $node): Node
     {
         return $node;


### PR DESCRIPTION
Adds new `AddParamTypeToRefactorMethodRector` to the `rector-preset` set.

When a Rector rule's `getNodeTypes()` returns a single concrete node type via an inline array literal, the rule adds the matching `@param` annotation to `refactor()`. This lets PHPStan know the concrete `$node` type, removing the need for `instanceof` checks inside `refactor()` and avoiding "unknown type" errors when a method is called on `$node`.

```diff
 public function getNodeTypes(): array
 {
     return [MethodCall::class];
 }

+/**
+ * @param MethodCall $node
+ */
 public function refactor(Node $node): ?Node
 {
 }
```

Pairs with the existing `RemoveRefactorDuplicatedNodeInstanceCheckRector` (add `@param` -> remove now-redundant `instanceof`).

Skips (avoid noisy/incorrect output):
- `@param node` already present (never overrides a more precise type)
- interface node types (e.g. `StmtsAwareInterface`) that expand to a large implementer union
- non-array returns such as `NodeGroup::STMTS_AWARE` constant groups

Self-applied to own source: missing `@param` added to 5 rules (`ConstFetch`, `Variable`, `ClassLike`, `Class_`, `Function_`).
