### PR TITLE
[reporting] Report unused skips in JSON output too

### DIFF
--- a/src/ChangesReporting/Output/Factory/JsonOutputFactory.php
+++ b/src/ChangesReporting/Output/Factory/JsonOutputFactory.php
@@ -15,8 +15,14 @@ use Rector\ValueObject\ProcessResult;
  */
 final class JsonOutputFactory
 {
-    public static function create(ProcessResult $processResult, Configuration $configuration): string
-    {
+    /**
+     * @param string[] $unusedSkips
+     */
+    public static function create(
+        ProcessResult $processResult,
+        Configuration $configuration,
+        array $unusedSkips = []
+    ): string {
         $errorsJson = [
             'totals' => [
                 'changed_files' => $processResult->getTotalChanged(),
@@ -50,6 +56,10 @@ final class JsonOutputFactory
         $errorsData = self::createErrorsData($systemErrors, $configuration->isReportingWithRealPath());
         if ($errorsData !== []) {
             $errorsJson['errors'] = $errorsData;
+        }
+
+        if ($unusedSkips !== []) {
+            $errorsJson['unused_skips'] = $unusedSkips;
         }
 
         return Json::encode($errorsJson, pretty: true);

--- a/src/ChangesReporting/Output/JsonOutputFormatter.php
+++ b/src/ChangesReporting/Output/JsonOutputFormatter.php
@@ -6,12 +6,18 @@ namespace Rector\ChangesReporting\Output;
 
 use Rector\ChangesReporting\Contract\Output\OutputFormatterInterface;
 use Rector\ChangesReporting\Output\Factory\JsonOutputFactory;
+use Rector\Reporting\UnusedSkipResolver;
 use Rector\ValueObject\Configuration;
 use Rector\ValueObject\ProcessResult;
 
 final readonly class JsonOutputFormatter implements OutputFormatterInterface
 {
     public const string NAME = 'json';
+
+    public function __construct(
+        private UnusedSkipResolver $unusedSkipResolver
+    ) {
+    }
 
     public function getName(): string
     {
@@ -20,6 +26,9 @@ final readonly class JsonOutputFormatter implements OutputFormatterInterface
 
     public function report(ProcessResult $processResult, Configuration $configuration): void
     {
-        echo JsonOutputFactory::create($processResult, $configuration) . PHP_EOL;
+        // console output is silenced in json mode, so unused skips are surfaced in the payload
+        $unusedSkips = $this->unusedSkipResolver->resolve($processResult);
+
+        echo JsonOutputFactory::create($processResult, $configuration, $unusedSkips) . PHP_EOL;
     }
 }

--- a/src/Reporting/MissConfigurationReporter.php
+++ b/src/Reporting/MissConfigurationReporter.php
@@ -8,8 +8,6 @@ use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Configuration\VendorMissAnalyseGuard;
 use Rector\PostRector\Contract\Rector\PostRectorInterface;
-use Rector\Skipper\SkipCriteriaResolver\SkippedClassResolver;
-use Rector\Skipper\SkipCriteriaResolver\SkippedPathsResolver;
 use Rector\ValueObject\ProcessResult;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -21,8 +19,7 @@ final readonly class MissConfigurationReporter
     public function __construct(
         private SymfonyStyle $symfonyStyle,
         private VendorMissAnalyseGuard $vendorMissAnalyseGuard,
-        private SkippedClassResolver $skippedClassResolver,
-        private SkippedPathsResolver $skippedPathsResolver,
+        private UnusedSkipResolver $unusedSkipResolver,
     ) {
     }
 
@@ -32,44 +29,7 @@ final readonly class MissConfigurationReporter
      */
     public function reportUnusedSkips(ProcessResult $processResult): void
     {
-        if (! SimpleParameterProvider::provideBoolParameter(Option::REPORT_UNUSED_SKIPS, false)) {
-            return;
-        }
-
-        // map of trackable skip path => human-readable display; skips are tracked at runtime by
-        // their path, but rule-scoped ones are printed as "rule => path" so the user knows exactly
-        // what to remove. Skip-everywhere rule skips (null path) are forgotten from the container
-        // at boot, so they never reach the skipper and cannot be tracked.
-        $skipDisplaysByPath = [];
-        foreach ($this->skippedClassResolver->resolve() as $rectorClass => $paths) {
-            if ($paths === null) {
-                continue;
-            }
-
-            // rule-scoped paths are intentional, so they are reported even as mask paths
-            foreach ($paths as $path) {
-                $skipDisplaysByPath[$path] = $rectorClass . ' => ' . $path;
-            }
-        }
-
-        // global mask paths like "*/some/*" are hard to spot and report false positives, skip them
-        foreach ($this->skippedPathsResolver->resolve() as $globalPath) {
-            if (str_contains($globalPath, '*')) {
-                continue;
-            }
-
-            $skipDisplaysByPath[$globalPath] = $globalPath;
-        }
-
-        $usedSkips = $processResult->getUsedSkips();
-
-        $unusedSkips = [];
-        foreach ($skipDisplaysByPath as $path => $skipDisplay) {
-            if (! in_array($path, $usedSkips, true)) {
-                $unusedSkips[] = $skipDisplay;
-            }
-        }
-
+        $unusedSkips = $this->unusedSkipResolver->resolve($processResult);
         if ($unusedSkips === []) {
             return;
         }

--- a/src/Reporting/UnusedSkipResolver.php
+++ b/src/Reporting/UnusedSkipResolver.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Reporting;
+
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Skipper\SkipCriteriaResolver\SkippedClassResolver;
+use Rector\Skipper\SkipCriteriaResolver\SkippedPathsResolver;
+use Rector\ValueObject\ProcessResult;
+
+/**
+ * @see \Rector\Tests\Reporting\UnusedSkipResolverTest
+ */
+final readonly class UnusedSkipResolver
+{
+    public function __construct(
+        private SkippedClassResolver $skippedClassResolver,
+        private SkippedPathsResolver $skippedPathsResolver,
+    ) {
+    }
+
+    /**
+     * Resolves skips configured via "->withSkip()" that never matched any element during the run.
+     * Rule-scoped skips are returned as "rule => path" so the user knows exactly what to remove;
+     * global skips are returned as a plain path. Returns an empty array unless
+     * "->reportUnusedSkips()" is enabled.
+     *
+     * @return string[]
+     */
+    public function resolve(ProcessResult $processResult): array
+    {
+        if (! SimpleParameterProvider::provideBoolParameter(Option::REPORT_UNUSED_SKIPS, false)) {
+            return [];
+        }
+
+        // map of trackable skip path => human-readable display; skips are tracked at runtime by
+        // their path, but rule-scoped ones are printed as "rule => path" so the user knows exactly
+        // what to remove. Skip-everywhere rule skips (null path) are forgotten from the container
+        // at boot, so they never reach the skipper and cannot be tracked.
+        $skipDisplaysByPath = [];
+        foreach ($this->skippedClassResolver->resolve() as $rectorClass => $paths) {
+            if ($paths === null) {
+                continue;
+            }
+
+            // rule-scoped paths are intentional, so they are reported even as mask paths
+            foreach ($paths as $path) {
+                $skipDisplaysByPath[$path] = $rectorClass . ' => ' . $path;
+            }
+        }
+
+        // global mask paths like "*/some/*" are hard to spot and report false positives, skip them
+        foreach ($this->skippedPathsResolver->resolve() as $globalPath) {
+            if (str_contains($globalPath, '*')) {
+                continue;
+            }
+
+            $skipDisplaysByPath[$globalPath] = $globalPath;
+        }
+
+        $usedSkips = $processResult->getUsedSkips();
+
+        $unusedSkips = [];
+        foreach ($skipDisplaysByPath as $path => $skipDisplay) {
+            if (! in_array($path, $usedSkips, true)) {
+                $unusedSkips[] = $skipDisplay;
+            }
+        }
+
+        return $unusedSkips;
+    }
+}

--- a/tests/Reporting/MissConfigurationReporterTest.php
+++ b/tests/Reporting/MissConfigurationReporterTest.php
@@ -8,8 +8,7 @@ use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Configuration\VendorMissAnalyseGuard;
 use Rector\Reporting\MissConfigurationReporter;
-use Rector\Skipper\SkipCriteriaResolver\SkippedClassResolver;
-use Rector\Skipper\SkipCriteriaResolver\SkippedPathsResolver;
+use Rector\Reporting\UnusedSkipResolver;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use Rector\Tests\Skipper\Skipper\Fixture\Element\FifthElement;
 use Rector\Tests\Skipper\Skipper\Fixture\Element\ThreeMan;
@@ -41,8 +40,7 @@ final class MissConfigurationReporterTest extends AbstractLazyTestCase
         $this->missConfigurationReporter = new MissConfigurationReporter(
             $symfonyStyle,
             new VendorMissAnalyseGuard(),
-            $this->make(SkippedClassResolver::class),
-            $this->make(SkippedPathsResolver::class),
+            $this->make(UnusedSkipResolver::class),
         );
 
         SimpleParameterProvider::setParameter(Option::SKIP, [

--- a/tests/Reporting/UnusedSkipResolverTest.php
+++ b/tests/Reporting/UnusedSkipResolverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Reporting;
+
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Reporting\UnusedSkipResolver;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\Tests\Skipper\Skipper\Fixture\Element\FifthElement;
+use Rector\Tests\Skipper\Skipper\Fixture\Element\ThreeMan;
+use Rector\Tests\Skipper\Skipper\Source\AnotherClassToSkip;
+use Rector\ValueObject\ProcessResult;
+
+final class UnusedSkipResolverTest extends AbstractLazyTestCase
+{
+    private const string UNUSED_RULE_MASK = '*/dead-rule/*';
+
+    private const string USED_RULE_MASK = '*/matched-rule/*';
+
+    private const string GLOBAL_MASK = '*/global-mask/*';
+
+    private UnusedSkipResolver $unusedSkipResolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->unusedSkipResolver = $this->make(UnusedSkipResolver::class);
+
+        SimpleParameterProvider::setParameter(Option::SKIP, [
+            // skip-everywhere rule skip - forgotten at boot, not trackable, excluded
+            ThreeMan::class,
+            // rule-scoped path skip, never matched - intentional, reported even as mask
+            FifthElement::class => [self::UNUSED_RULE_MASK],
+            // rule-scoped path skip, matched - excluded
+            AnotherClassToSkip::class => [self::USED_RULE_MASK],
+            // global mask path skip - hard to spot, false-positive prone, excluded
+            self::GLOBAL_MASK,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        SimpleParameterProvider::setParameter(Option::SKIP, []);
+        SimpleParameterProvider::setParameter(Option::REPORT_UNUSED_SKIPS, false);
+    }
+
+    public function testResolvesUnusedSkipsAsRuleAndPath(): void
+    {
+        SimpleParameterProvider::setParameter(Option::REPORT_UNUSED_SKIPS, true);
+
+        $processResult = new ProcessResult([], [], 0, [self::USED_RULE_MASK]);
+        $unusedSkips = $this->unusedSkipResolver->resolve($processResult);
+
+        // rule-scoped unused skip is reported as "rule => path"
+        $this->assertContains(FifthElement::class . ' => ' . self::UNUSED_RULE_MASK, $unusedSkips);
+
+        // matched rule-scoped skip, global mask and skip-everywhere rule are excluded
+        $this->assertNotContains(AnotherClassToSkip::class . ' => ' . self::USED_RULE_MASK, $unusedSkips);
+        $this->assertNotContains(self::GLOBAL_MASK, $unusedSkips);
+        $this->assertNotContains(ThreeMan::class, $unusedSkips);
+    }
+
+    public function testResolvesNothingWhenDisabled(): void
+    {
+        SimpleParameterProvider::setParameter(Option::REPORT_UNUSED_SKIPS, false);
+
+        $processResult = new ProcessResult([], [], 0, []);
+
+        $this->assertSame([], $this->unusedSkipResolver->resolve($processResult));
+    }
+}


### PR DESCRIPTION
## Why

`->reportUnusedSkips()` reports skips that never matched, so you can clean up dead `->withSkip()` entries. It writes via `SymfonyStyle`, but when `--output-format=json` is used, `ProcessCommand` forces `VERBOSITY_QUIET` and the warning is silenced entirely. Editor/CI integrations typically run `--dry-run --output-format=json`, so unused skips never showed up there.

## What

Surface unused skips in the JSON payload too. The computation is extracted into a shared `UnusedSkipResolver` service, so console and JSON stay in sync.

## Example

Config:

```php
return RectorConfig::configure()
    ->withRules([SimplifyUselessVariableRector::class])
    ->reportUnusedSkips()
    ->withSkip([
        SimplifyUselessVariableRector::class => [
            __DIR__ . '/src/Used.php',          // matched -> not reported
            __DIR__ . '/src/NeverMatches.php',  // never matched -> reported
        ],
    ]);
```

Console output (already worked):

```
 [WARNING] This skip is unused, it never matched any element. You can remove it
           from "->withSkip()"

 * Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector => /src/NeverMatches.php
```

JSON output **before** -- unused skips silently missing:

```json
{
    "totals": { "changed_files": 1, "errors": 0 },
    "file_diffs": [ ... ],
    "changed_files": [ "src/SomeClass.php" ]
}
```

JSON output **after** -- new `unused_skips` key:

```json
{
    "totals": { "changed_files": 1, "errors": 0 },
    "file_diffs": [ ... ],
    "changed_files": [ "src/SomeClass.php" ],
    "unused_skips": [
        "Rector\\CodeQuality\\Rector\\FunctionLike\\SimplifyUselessVariableRector => /src/NeverMatches.php"
    ]
}
```

The key is added only when `reportUnusedSkips()` is enabled and something is actually unused, so the JSON schema is otherwise untouched.

## Changes

- **`src/Reporting/UnusedSkipResolver.php`** (new) -- single source of truth. Returns `"rule => path"` for rule-scoped skips and a plain path for global ones; honors the `reportUnusedSkips()` guard; keeps the existing rules (per-path granularity, rule-scoped masks kept, global masks excluded).
- **`src/Reporting/MissConfigurationReporter.php`** -- delegates to the resolver; console output unchanged.
- **`src/ChangesReporting/Output/JsonOutputFormatter.php`** -- injects the resolver, passes results to the factory.
- **`src/ChangesReporting/Output/Factory/JsonOutputFactory.php`** -- optional `$unusedSkips` param, adds the `unused_skips` key when non-empty.

## Tests

- New `UnusedSkipResolverTest` (unit): rule-scoped unused skip reported as `rule => path`; matched / global-mask / skip-everywhere excluded; disabled returns empty.
- `MissConfigurationReporterTest` updated to the new constructor.
