### PR TITLE
[reporting] render unused rule-scoped skips as nested list

### DIFF
--- a/e2e/parallel-unused-skips/expected-output.diff
+++ b/e2e/parallel-unused-skips/expected-output.diff
@@ -3,4 +3,5 @@
  [WARNING] This skip is unused, it never matched any element. You can remove it
            from "->withSkip()"
 
- * Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector => */NonexistentUnused/*
+ * Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector:
+     * */NonexistentUnused/*

--- a/e2e/parallel-unused-skips/rector.php
+++ b/e2e/parallel-unused-skips/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/custom',
+        __DIR__ . '/src',
+    ])
+    // uncomment to reach your current PHP version
+    // ->withPhpSets()
+    ->withTypeCoverageLevel(0)
+    ->withDeadCodeLevel(0)
+    ->withCodeQualityLevel(0);

--- a/src/Reporting/UnusedSkipResolver.php
+++ b/src/Reporting/UnusedSkipResolver.php
@@ -25,9 +25,9 @@ final readonly class UnusedSkipResolver
 
     /**
      * Resolves skips configured via "->withSkip()" that never matched any element during the run.
-     * Rule-scoped skips are grouped under their rule ("rule => path", or "rule => [ path\n path ]"
-     * for multiple paths) so the user knows exactly what to remove; global skips are returned as a
-     * plain path. Returns an empty array unless "->reportUnusedSkips()" is enabled.
+     * Rule-scoped skips are grouped under their rule ("rule:" on its own line, each path nested
+     * below it) so the user knows exactly what to remove; global skips are returned as a plain
+     * path. Returns an empty array unless "->reportUnusedSkips()" is enabled.
      *
      * @return string[]
      */
@@ -86,12 +86,8 @@ final readonly class UnusedSkipResolver
                 continue;
             }
 
-            if (count($unusedRelativePaths) === 1) {
-                $unusedSkips[] = $rectorClass . ' => ' . $unusedRelativePaths[0];
-                continue;
-            }
-
-            $unusedSkips[] = $rectorClass . ' => [ ' . implode("\n    ", $unusedRelativePaths) . ' ]';
+            // rule on its own line, with each unused path nested below it as a "->listing()" sub-item
+            $unusedSkips[] = $rectorClass . ':' . "\n     * " . implode("\n     * ", $unusedRelativePaths);
         }
 
         foreach ($globalRelativePaths as $path => $relativePath) {

--- a/tests/Reporting/UnusedSkipResolverTest.php
+++ b/tests/Reporting/UnusedSkipResolverTest.php
@@ -55,11 +55,11 @@ final class UnusedSkipResolverTest extends AbstractLazyTestCase
         $processResult = new ProcessResult([], [], 0, [self::USED_RULE_MASK]);
         $unusedSkips = $this->unusedSkipResolver->resolve($processResult);
 
-        // rule-scoped unused skip is reported as "rule => path"
-        $this->assertContains(FifthElement::class . ' => ' . self::UNUSED_RULE_MASK, $unusedSkips);
+        // rule-scoped unused skip is reported as "rule:" with the path nested below
+        $this->assertContains(FifthElement::class . ':' . "\n     * " . self::UNUSED_RULE_MASK, $unusedSkips);
 
         // matched rule-scoped skip, global mask and skip-everywhere rule are excluded
-        $this->assertNotContains(AnotherClassToSkip::class . ' => ' . self::USED_RULE_MASK, $unusedSkips);
+        $this->assertNotContains(AnotherClassToSkip::class . ':' . "\n     * " . self::USED_RULE_MASK, $unusedSkips);
         $this->assertNotContains(self::GLOBAL_MASK, $unusedSkips);
         $this->assertNotContains(ThreeMan::class, $unusedSkips);
     }
@@ -76,7 +76,10 @@ final class UnusedSkipResolverTest extends AbstractLazyTestCase
         $unusedSkips = $this->unusedSkipResolver->resolve(new ProcessResult([], [], 0, []));
 
         // the absolute path is shortened to a relative one, matching the "->withSkip()" syntax
-        $this->assertContains(FifthElement::class . ' => src/Reporting/UnusedSkipResolver.php', $unusedSkips);
+        $this->assertContains(
+            FifthElement::class . ':' . "\n     * " . 'src/Reporting/UnusedSkipResolver.php',
+            $unusedSkips
+        );
     }
 
     public function testGroupsMultipleUnusedPathsUnderRule(): void
@@ -91,9 +94,9 @@ final class UnusedSkipResolverTest extends AbstractLazyTestCase
 
         $unusedSkips = $this->unusedSkipResolver->resolve(new ProcessResult([], [], 0, []));
 
-        // multiple unused paths are grouped under their rule, not repeated per line
+        // multiple unused paths are grouped under their rule, each nested on its own line
         $this->assertContains(
-            FifthElement::class . ' => [ src/Reporting/UnusedSkipResolver.php' . "\n    " . 'src/Reporting/MissConfigurationReporter.php ]',
+            FifthElement::class . ':' . "\n     * " . 'src/Reporting/UnusedSkipResolver.php' . "\n     * " . 'src/Reporting/MissConfigurationReporter.php',
             $unusedSkips
         );
     }


### PR DESCRIPTION
Renders unused rule-scoped skips as a nested list instead of inline `rule => path` / `rule => [ ... ]` form.

Before:
```
 * Rector\...\ReturnTypeFromReturnDirectArrayRector => [ app/.../LeadModel.php
    app/.../TranslationEntityTrait.php ]
```

After:
```
 * Rector\...\ReturnTypeFromReturnDirectArrayRector:
     * app/bundles/LeadBundle/Model/LeadModel.php
     * app/bundles/CoreBundle/Entity/TranslationEntityTrait.php
```

Single and multiple paths now use the same nested shape via `SymfonyStyle::listing()`.
