### PR TITLE
[skip] display skips only on uncached run

### DIFF
--- a/src/Caching/UnchangedFilesFilter.php
+++ b/src/Caching/UnchangedFilesFilter.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Rector\Caching;
 
 use Rector\Caching\Detector\ChangedFilesDetector;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 
 final readonly class UnchangedFilesFilter
 {
@@ -29,6 +31,12 @@ final readonly class UnchangedFilesFilter
 
             $changedFileInfos[] = $filePath;
             $this->changedFilesDetector->invalidateFile($filePath);
+        }
+
+        // some files were served from cache, so rules ran on a subset only - unused skip reporting
+        // would then flag every cached file's skip as falsely unused
+        if (count($changedFileInfos) < count($filePaths)) {
+            SimpleParameterProvider::setParameter(Option::IS_CACHED_RUN, true);
         }
 
         return $changedFileInfos;

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -119,6 +119,15 @@ final class Option
     public const string IS_RUN_NARROWED = 'is_run_narrowed';
 
     /**
+     * True when the unchanged-files cache dropped at least one file from the run, so rules only ran
+     * on the changed subset. Unused skip reporting is then disabled, as skips on cached files never
+     * get a chance to match and would all look falsely unused.
+     *
+     * @internal
+     */
+    public const string IS_CACHED_RUN = 'is_cached_run';
+
+    /**
      * @internal Use RectorConfig::fileExtensions() instead
      */
     public const string FILE_EXTENSIONS = 'file_extensions';

--- a/src/Reporting/MissConfigurationReporter.php
+++ b/src/Reporting/MissConfigurationReporter.php
@@ -40,7 +40,10 @@ final readonly class MissConfigurationReporter
             count($unusedSkips) > 1 ? 'them' : 'it'
         ));
 
-        $this->symfonyStyle->listing($unusedSkips);
+        // add a blank line between items, so grouped rule skips stay visually separated
+        $spacedUnusedSkips = array_map(static fn (string $unusedSkip): string => $unusedSkip . "\n", $unusedSkips);
+
+        $this->symfonyStyle->listing($spacedUnusedSkips);
     }
 
     public function reportSkippedNeverRegisteredRules(): void

--- a/src/Reporting/UnusedSkipResolver.php
+++ b/src/Reporting/UnusedSkipResolver.php
@@ -43,6 +43,12 @@ final readonly class UnusedSkipResolver
             return [];
         }
 
+        // a cached run only re-processes changed files, so skips on cached files never get a chance
+        // to match and would all look falsely unused - reporting them would be noise
+        if (SimpleParameterProvider::provideBoolParameter(Option::IS_CACHED_RUN, false)) {
+            return [];
+        }
+
         // map of rule => (trackable skip path => relative display path); skips are tracked at
         // runtime by their path, but rule-scoped ones are printed grouped under their rule so the
         // user knows exactly what to remove. Skip-everywhere rule skips (null path) are forgotten

--- a/tests/Reporting/UnusedSkipResolverTest.php
+++ b/tests/Reporting/UnusedSkipResolverTest.php
@@ -46,6 +46,7 @@ final class UnusedSkipResolverTest extends AbstractLazyTestCase
         SimpleParameterProvider::setParameter(Option::SKIP, []);
         SimpleParameterProvider::setParameter(Option::REPORT_UNUSED_SKIPS, false);
         SimpleParameterProvider::setParameter(Option::IS_RUN_NARROWED, false);
+        SimpleParameterProvider::setParameter(Option::IS_CACHED_RUN, false);
     }
 
     public function testResolvesUnusedSkipsAsRuleAndPath(): void
@@ -108,6 +109,18 @@ final class UnusedSkipResolverTest extends AbstractLazyTestCase
 
         // narrowed run (cli paths, "--only", "--only-suffix") only touches part of the codebase,
         // so skips outside that scope are not false positives
+        $processResult = new ProcessResult([], [], 0, []);
+
+        $this->assertSame([], $this->unusedSkipResolver->resolve($processResult));
+    }
+
+    public function testResolvesNothingWhenRunIsCached(): void
+    {
+        SimpleParameterProvider::setParameter(Option::REPORT_UNUSED_SKIPS, true);
+        SimpleParameterProvider::setParameter(Option::IS_CACHED_RUN, true);
+
+        // a cached run only re-processes changed files, so skips on cached files never match and
+        // are not false positives
         $processResult = new ProcessResult([], [], 0, []);
 
         $this->assertSame([], $this->unusedSkipResolver->resolve($processResult));


### PR DESCRIPTION
## Display unused skips only on an uncached run

Follow-up to unused-skip reporting. On a cached run only the changed files are re-processed, so skips on cached files never get a chance to match and would all look falsely unused. This disables unused-skip reporting whenever the run is incomplete.

### Changes

- **`Option::IS_CACHED_RUN`** — new internal flag, set in `UnchangedFilesFilter` when the unchanged-files cache drops at least one file from the run (`count($changedFileInfos) < count($filePaths)`).
- **`UnusedSkipResolver`** — returns `[]` when `IS_CACHED_RUN` is set, so no false positives reach console or JSON output.
- **`MissConfigurationReporter`** — adds a blank line between listed items, keeping grouped rule skips visually separated.
- **Test** — `testResolvesNothingWhenRunIsCached` covers the cached-run guard.

Clear the cache (`--clear-cache`) to get full unused-skip reporting again.
