### PR TITLE
[skip] fix match class + path matching in reporting of unused skips

### DIFF
--- a/src/Reporting/UnusedSkipResolver.php
+++ b/src/Reporting/UnusedSkipResolver.php
@@ -117,7 +117,9 @@ final readonly class UnusedSkipResolver
         foreach ($this->resolveRelativePathsByClass() as $rectorClass => $relativePaths) {
             $unusedRelativePaths = [];
             foreach ($relativePaths as $path => $relativePath) {
-                if (! in_array($path, $usedSkips, true)) {
+                // used skips are tracked scoped to their rule as "class|path", so the same path
+                // skipped under another rule does not mark this one used (see SkipSkipper)
+                if (! in_array($rectorClass . '|' . $path, $usedSkips, true)) {
                     $unusedRelativePaths[] = $relativePath;
                 }
             }

--- a/src/Skipper/Skipper/SkipSkipper.php
+++ b/src/Skipper/Skipper/SkipSkipper.php
@@ -30,10 +30,11 @@ final readonly class SkipSkipper
                 return true;
             }
 
-            // mark the specific matched path used, so unused paths under the same rule are reported
+            // mark the specific matched path used, scoped to its rule via "class|path" - the same
+            // path can be skipped under multiple rules, so a path-only key would mark them all used
             $matchedPath = $this->fileInfoMatcher->matchPattern($filePath, $skippedFiles);
             if ($matchedPath !== null) {
-                $this->usedSkipCollector->markUsed($matchedPath);
+                $this->usedSkipCollector->markUsed($skippedClass . '|' . $matchedPath);
                 return true;
             }
         }

--- a/tests/Reporting/MissConfigurationReporterTest.php
+++ b/tests/Reporting/MissConfigurationReporterTest.php
@@ -65,8 +65,8 @@ final class MissConfigurationReporterTest extends AbstractLazyTestCase
     {
         SimpleParameterProvider::setParameter(Option::REPORT_UNUSED_SKIPS, true);
 
-        // matched rule-scoped path is marked used by its path, not by the rule class
-        $processResult = new ProcessResult([], [], 0, [self::USED_RULE_MASK]);
+        // matched rule-scoped path is marked used scoped to its rule as "class|path"
+        $processResult = new ProcessResult([], [], 0, [AnotherClassToSkip::class . '|' . self::USED_RULE_MASK]);
         $this->missConfigurationReporter->reportUnusedSkips($processResult);
 
         $output = $this->bufferedOutput->fetch();

--- a/tests/Reporting/UnusedSkipResolverTest.php
+++ b/tests/Reporting/UnusedSkipResolverTest.php
@@ -53,7 +53,8 @@ final class UnusedSkipResolverTest extends AbstractLazyTestCase
     {
         SimpleParameterProvider::setParameter(Option::REPORT_UNUSED_SKIPS, true);
 
-        $processResult = new ProcessResult([], [], 0, [self::USED_RULE_MASK]);
+        // used skips are tracked scoped to their rule as "class|path"
+        $processResult = new ProcessResult([], [], 0, [AnotherClassToSkip::class . '|' . self::USED_RULE_MASK]);
         $unusedSkips = $this->unusedSkipResolver->resolve($processResult);
 
         // rule-scoped unused skip is reported as "rule:" with the path nested below
@@ -63,6 +64,28 @@ final class UnusedSkipResolverTest extends AbstractLazyTestCase
         $this->assertNotContains(AnotherClassToSkip::class . ':' . "\n     * " . self::USED_RULE_MASK, $unusedSkips);
         $this->assertNotContains(self::GLOBAL_MASK, $unusedSkips);
         $this->assertNotContains(ThreeMan::class, $unusedSkips);
+    }
+
+    public function testSamePathUnderAnotherRuleDoesNotMarkSkipUsed(): void
+    {
+        SimpleParameterProvider::setParameter(Option::REPORT_UNUSED_SKIPS, true);
+
+        $sharedMask = '*/shared-mask/*';
+        SimpleParameterProvider::setParameter(Option::SKIP, [
+            // same path skipped under two rules - only the first one actually matched a file
+            AnotherClassToSkip::class => [$sharedMask],
+            FifthElement::class => [$sharedMask],
+        ]);
+
+        // used skip is scoped to its rule, so the shared path stays unused under the other rule
+        $processResult = new ProcessResult([], [], 0, [AnotherClassToSkip::class . '|' . $sharedMask]);
+        $unusedSkips = $this->unusedSkipResolver->resolve($processResult);
+
+        // the never-matched rule still reports its shared path as unused
+        $this->assertContains(FifthElement::class . ':' . "\n     * " . $sharedMask, $unusedSkips);
+
+        // the matched rule is excluded
+        $this->assertNotContains(AnotherClassToSkip::class . ':' . "\n     * " . $sharedMask, $unusedSkips);
     }
 
     public function testReportsUnusedSkipAsRelativePath(): void

--- a/tests/Skipper/Skipper/UsedSkipCollectorTest.php
+++ b/tests/Skipper/Skipper/UsedSkipCollectorTest.php
@@ -83,11 +83,11 @@ final class UsedSkipCollectorTest extends AbstractLazyTestCase
 
         $usedSkips = $this->usedSkipCollector->provide();
 
-        // the specific matched path is collected, not the rule class
-        $this->assertContains('*/someDirectory/*', $usedSkips);
+        // the specific matched path is collected scoped to its rule as "class|path"
+        $this->assertContains(AnotherClassToSkip::class . '|' . '*/someDirectory/*', $usedSkips);
         $this->assertNotContains(AnotherClassToSkip::class, $usedSkips);
 
         // the unmatched sibling path under the same rule is never collected
-        $this->assertNotContains(self::UNUSED_SKIP_MARKER, $usedSkips);
+        $this->assertNotContains(AnotherClassToSkip::class . '|' . self::UNUSED_SKIP_MARKER, $usedSkips);
     }
 }


### PR DESCRIPTION
## Bug

`UnusedSkipResolver::resolveUnusedRuleScopedSkips()` matched used skips by **path only**, ignoring the rule class.

Used skips live in one flat list (`UsedSkipCollector`), mixing rule-scoped paths and global paths. The same path skipped under two rules collapsed to a single key, so a match under one rule silently marked the same path under every other rule as "used".

### Before (false negative)

```php
->withSkip([
    SomeRector::class    => ['src/Foo.php'], // matched a file -> used
    AnotherRector::class => ['src/Foo.php'], // never matched -> still UNUSED
])
```

`src/Foo.php` matched under `SomeRector`, landed in the used list as the bare path `src/Foo.php`. The resolver then checked `in_array('src/Foo.php', $usedSkips)` for `AnotherRector` too — found it — and reported the genuinely unused skip as used. It was never flagged for removal.

### After (fixed)

Used skips are now tracked scoped to their rule as `class|path`:

- `SkipSkipper::doesMatchSkip()` marks `$skippedClass . '|' . $matchedPath`
- `UnusedSkipResolver` checks `in_array($rectorClass . '|' . $path, $usedSkips, true)`

`SomeRector|src/Foo.php` and `AnotherRector|src/Foo.php` are distinct keys, so the unmatched skip under `AnotherRector` is correctly reported as unused.

Global skips and skip-everywhere (`null` path) rules are unchanged — they carry no rule scope.

## Tests

- New regression `testSamePathUnderAnotherRuleDoesNotMarkSkipUsed` — same path under two rules, only one matched; asserts the other still reports unused.
- Updated `UnusedSkipResolverTest` + `UsedSkipCollectorTest` to the `class|path` key shape.