### PR TITLE
[skip] track used skips as class => [paths] map

### DIFF
--- a/src/Parallel/Application/ParallelFileProcessor.php
+++ b/src/Parallel/Application/ParallelFileProcessor.php
@@ -75,7 +75,7 @@ final class ParallelFileProcessor
         /** @var SystemError[] $systemErrors */
         $systemErrors = [];
 
-        /** @var array<string, true> $usedSkips */
+        /** @var array<string, array<string, true>> $usedSkips */
         $usedSkips = [];
 
         $tcpServer = new TcpServer('127.0.0.1:0', $streamSelectLoop);
@@ -196,12 +196,15 @@ final class ParallelFileProcessor
                      *      file_diffs: array<string, mixed>,
                      *      files_count: int,
                      *      system_errors_count: int,
-                     *      used_skips: string[]
+                     *      used_skips: array<string, string[]>
                      * } $json */
                     $totalChanged += $json[Bridge::TOTAL_CHANGED];
 
-                    foreach ($json[Bridge::USED_SKIPS] as $usedSkip) {
-                        $usedSkips[$usedSkip] = true;
+                    foreach ($json[Bridge::USED_SKIPS] as $skip => $paths) {
+                        $usedSkips[$skip] ??= [];
+                        foreach ($paths as $path) {
+                            $usedSkips[$skip][$path] = true;
+                        }
                     }
 
                     // decode arrays to objects
@@ -286,6 +289,11 @@ final class ParallelFileProcessor
             ));
         }
 
-        return new ProcessResult($systemErrors, $fileDiffs, $totalChanged, array_keys($usedSkips));
+        $mergedUsedSkips = [];
+        foreach ($usedSkips as $skip => $paths) {
+            $mergedUsedSkips[$skip] = array_keys($paths);
+        }
+
+        return new ProcessResult($systemErrors, $fileDiffs, $totalChanged, $mergedUsedSkips);
     }
 }

--- a/src/Reporting/UnusedSkipResolver.php
+++ b/src/Reporting/UnusedSkipResolver.php
@@ -106,7 +106,7 @@ final readonly class UnusedSkipResolver
     }
 
     /**
-     * @param string[] $usedSkips
+     * @param array<string, string[]> $usedSkips
      * @return string[]
      */
     private function resolveUnusedRuleScopedSkips(array $usedSkips): array
@@ -117,9 +117,9 @@ final readonly class UnusedSkipResolver
         foreach ($this->resolveRelativePathsByClass() as $rectorClass => $relativePaths) {
             $unusedRelativePaths = [];
             foreach ($relativePaths as $path => $relativePath) {
-                // used skips are tracked scoped to their rule as "class|path", so the same path
+                // used skips are tracked scoped to their rule (class => [path]), so the same path
                 // skipped under another rule does not mark this one used (see SkipSkipper)
-                if (! in_array($rectorClass . '|' . $path, $usedSkips, true)) {
+                if (! in_array($path, $usedSkips[$rectorClass] ?? [], true)) {
                     $unusedRelativePaths[] = $relativePath;
                 }
             }
@@ -136,14 +136,15 @@ final readonly class UnusedSkipResolver
     }
 
     /**
-     * @param string[] $usedSkips
+     * @param array<string, string[]> $usedSkips
      * @return string[]
      */
     private function resolveUnusedGlobalSkips(array $usedSkips): array
     {
         $unusedSkips = [];
         foreach ($this->resolveGlobalRelativePaths() as $path => $relativePath) {
-            if (! in_array($path, $usedSkips, true)) {
+            // global path skips are tracked by their own path key, with no nested paths
+            if (! array_key_exists($path, $usedSkips)) {
                 $unusedSkips[] = $relativePath;
             }
         }

--- a/src/Skipper/Skipper/SkipSkipper.php
+++ b/src/Skipper/Skipper/SkipSkipper.php
@@ -30,11 +30,11 @@ final readonly class SkipSkipper
                 return true;
             }
 
-            // mark the specific matched path used, scoped to its rule via "class|path" - the same
-            // path can be skipped under multiple rules, so a path-only key would mark them all used
+            // mark the specific matched path used, scoped to its rule - the same path can be skipped
+            // under multiple rules, so the path is nested under its rule, not tracked on its own
             $matchedPath = $this->fileInfoMatcher->matchPattern($filePath, $skippedFiles);
             if ($matchedPath !== null) {
-                $this->usedSkipCollector->markUsed($skippedClass . '|' . $matchedPath);
+                $this->usedSkipCollector->markUsed($skippedClass, $matchedPath);
                 return true;
             }
         }

--- a/src/Skipper/Skipper/UsedSkipCollector.php
+++ b/src/Skipper/Skipper/UsedSkipCollector.php
@@ -13,20 +13,33 @@ namespace Rector\Skipper\Skipper;
 final class UsedSkipCollector
 {
     /**
-     * @var array<string, true>
+     * Map of skip element (rule class or global path) to the set of paths matched under it.
+     * Rule-scoped skips collect their matched paths; skip-everywhere rules and global path skips
+     * keep an empty path set, the same shape as the "->withSkip()" config.
+     *
+     * @var array<string, array<string, true>>
      */
     private array $usedSkips = [];
 
-    public function markUsed(string $skip): void
+    public function markUsed(string $skip, ?string $path = null): void
     {
-        $this->usedSkips[$skip] = true;
+        $this->usedSkips[$skip] ??= [];
+
+        if ($path !== null) {
+            $this->usedSkips[$skip][$path] = true;
+        }
     }
 
     /**
-     * @return string[]
+     * @return array<string, string[]>
      */
     public function provide(): array
     {
-        return array_keys($this->usedSkips);
+        $usedSkips = [];
+        foreach ($this->usedSkips as $skip => $paths) {
+            $usedSkips[$skip] = array_keys($paths);
+        }
+
+        return $usedSkips;
     }
 }

--- a/src/ValueObject/ProcessResult.php
+++ b/src/ValueObject/ProcessResult.php
@@ -14,7 +14,7 @@ final class ProcessResult
     /**
      * @param SystemError[] $systemErrors
      * @param FileDiff[] $fileDiffs
-     * @param string[] $usedSkips
+     * @param array<string, string[]> $usedSkips
      */
     public function __construct(
         private array $systemErrors,
@@ -24,7 +24,11 @@ final class ProcessResult
     ) {
         Assert::allIsInstanceOf($systemErrors, SystemError::class);
         Assert::allIsInstanceOf($fileDiffs, FileDiff::class);
-        Assert::allString($usedSkips);
+
+        Assert::allString(array_keys($usedSkips));
+        foreach ($usedSkips as $usedSkip) {
+            Assert::allString($usedSkip);
+        }
     }
 
     /**
@@ -62,13 +66,16 @@ final class ProcessResult
      * their result from worker processes only. Merge those main-process marks back in, or they would
      * be wrongly reported as unused.
      *
-     * @param string[] $usedSkips
+     * @param array<string, string[]> $usedSkips
      */
     public function addUsedSkips(array $usedSkips): void
     {
-        Assert::allString($usedSkips);
+        foreach ($usedSkips as $skip => $paths) {
+            Assert::allString($paths);
 
-        $this->usedSkips = array_values(array_unique([...$this->usedSkips, ...$usedSkips]));
+            $existingPaths = $this->usedSkips[$skip] ?? [];
+            $this->usedSkips[$skip] = array_values(array_unique([...$existingPaths, ...$paths]));
+        }
     }
 
     public function getTotalChanged(): int
@@ -77,7 +84,7 @@ final class ProcessResult
     }
 
     /**
-     * @return string[]
+     * @return array<string, string[]>
      */
     public function getUsedSkips(): array
     {

--- a/tests/Reporting/MissConfigurationReporterTest.php
+++ b/tests/Reporting/MissConfigurationReporterTest.php
@@ -65,8 +65,10 @@ final class MissConfigurationReporterTest extends AbstractLazyTestCase
     {
         SimpleParameterProvider::setParameter(Option::REPORT_UNUSED_SKIPS, true);
 
-        // matched rule-scoped path is marked used scoped to its rule as "class|path"
-        $processResult = new ProcessResult([], [], 0, [AnotherClassToSkip::class . '|' . self::USED_RULE_MASK]);
+        // matched rule-scoped path is marked used scoped to its rule (class => [path])
+        $processResult = new ProcessResult([], [], 0, [
+            AnotherClassToSkip::class => [self::USED_RULE_MASK],
+        ]);
         $this->missConfigurationReporter->reportUnusedSkips($processResult);
 
         $output = $this->bufferedOutput->fetch();

--- a/tests/Reporting/UnusedSkipResolverTest.php
+++ b/tests/Reporting/UnusedSkipResolverTest.php
@@ -53,8 +53,10 @@ final class UnusedSkipResolverTest extends AbstractLazyTestCase
     {
         SimpleParameterProvider::setParameter(Option::REPORT_UNUSED_SKIPS, true);
 
-        // used skips are tracked scoped to their rule as "class|path"
-        $processResult = new ProcessResult([], [], 0, [AnotherClassToSkip::class . '|' . self::USED_RULE_MASK]);
+        // used skips are tracked scoped to their rule (class => [path])
+        $processResult = new ProcessResult([], [], 0, [
+            AnotherClassToSkip::class => [self::USED_RULE_MASK],
+        ]);
         $unusedSkips = $this->unusedSkipResolver->resolve($processResult);
 
         // rule-scoped unused skip is reported as "rule:" with the path nested below
@@ -78,7 +80,9 @@ final class UnusedSkipResolverTest extends AbstractLazyTestCase
         ]);
 
         // used skip is scoped to its rule, so the shared path stays unused under the other rule
-        $processResult = new ProcessResult([], [], 0, [AnotherClassToSkip::class . '|' . $sharedMask]);
+        $processResult = new ProcessResult([], [], 0, [
+            AnotherClassToSkip::class => [$sharedMask],
+        ]);
         $unusedSkips = $this->unusedSkipResolver->resolve($processResult);
 
         // the never-matched rule still reports its shared path as unused

--- a/tests/Skipper/Skipper/UsedSkipCollectorTest.php
+++ b/tests/Skipper/Skipper/UsedSkipCollectorTest.php
@@ -54,15 +54,15 @@ final class UsedSkipCollectorTest extends AbstractLazyTestCase
 
         $usedSkips = $this->usedSkipCollector->provide();
 
-        // matched skips are collected
-        $this->assertContains(FifthElement::class, $usedSkips);
+        // matched skips are collected as keys
+        $this->assertArrayHasKey(FifthElement::class, $usedSkips);
         $this->assertNotEmpty(array_filter(
-            $usedSkips,
+            array_keys($usedSkips),
             static fn (string $usedSkip): bool => str_ends_with($usedSkip, 'SomeSkippedPath')
         ));
 
         // unmatched skip is never collected
-        $this->assertNotContains(self::UNUSED_SKIP_MARKER, $usedSkips);
+        $this->assertArrayNotHasKey(self::UNUSED_SKIP_MARKER, $usedSkips);
     }
 
     public function testCollectsMatchedPathNotRuleClassForRuleScopedSkip(): void
@@ -83,11 +83,11 @@ final class UsedSkipCollectorTest extends AbstractLazyTestCase
 
         $usedSkips = $this->usedSkipCollector->provide();
 
-        // the specific matched path is collected scoped to its rule as "class|path"
-        $this->assertContains(AnotherClassToSkip::class . '|' . '*/someDirectory/*', $usedSkips);
-        $this->assertNotContains(AnotherClassToSkip::class, $usedSkips);
+        // the specific matched path is collected nested under its rule class
+        $this->assertArrayHasKey(AnotherClassToSkip::class, $usedSkips);
+        $this->assertContains('*/someDirectory/*', $usedSkips[AnotherClassToSkip::class]);
 
         // the unmatched sibling path under the same rule is never collected
-        $this->assertNotContains(AnotherClassToSkip::class . '|' . self::UNUSED_SKIP_MARKER, $usedSkips);
+        $this->assertNotContains(self::UNUSED_SKIP_MARKER, $usedSkips[AnotherClassToSkip::class]);
     }
 }


### PR DESCRIPTION
Tracks used skips as a `class => [path, path2]` map instead of flat `class|path` join strings, matching the shape skips are already configured with in `->withSkip()`.

### Before

`ProcessResult::getUsedSkips()` returned `string[]` where rule-scoped skips were encoded as `"class|path"`, forcing the resolver to rebuild that join string to test membership:

```php
if (! in_array($rectorClass . '|' . $path, $usedSkips, true)) {
```

### After

`getUsedSkips()` returns `array<string, string[]>` — rule class to its matched paths — so the lookup is a direct nested check:

```php
if (! in_array($path, $usedSkips[$rectorClass] ?? [], true)) {
```

### Changes

- `UsedSkipCollector::markUsed(string $skip, ?string $path = null)` stores a nested map; `provide()` returns `class => [paths]`.
- `SkipSkipper` marks the matched path under its rule instead of joining with `|`.
- `ProcessResult` constructor/`addUsedSkips()` validate and merge the nested shape per key.
- `ParallelFileProcessor` merges worker maps nested.
- Global path-only skips stay tracked by their own key (empty path set); resolver uses `array_key_exists`.

Tests updated accordingly. `composer complete-check` green.
