### PR TITLE
Cache --only / --only-suffix runs under a rule-scoped key

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -56,6 +56,9 @@ final class ApplicationFileProcessor
 
     public function run(Configuration $configuration, InputInterface $input): ProcessResult
     {
+        // scope the cache to this run's --only / --only-suffix selection before any cache read/write
+        $this->changedFilesDetector->setActiveScope($configuration->getOnlyRule(), $configuration->getOnlySuffix());
+
         $filePaths = $this->filesFinder->findFilesInPaths($configuration->getPaths(), $configuration);
 
         // no files found
@@ -121,6 +124,9 @@ final class ApplicationFileProcessor
         ?callable $preFileCallback = null,
         ?callable $postFileCallback = null
     ): ProcessResult {
+        // also set here: parallel workers reach processFiles() via WorkerCommand, bypassing run()
+        $this->changedFilesDetector->setActiveScope($configuration->getOnlyRule(), $configuration->getOnlySuffix());
+
         /** @var SystemError[] $systemErrors */
         $systemErrors = [];
 
@@ -179,11 +185,8 @@ final class ApplicationFileProcessor
         if ($fileProcessResult->getSystemErrors() !== []) {
             $this->changedFilesDetector->invalidateFile($file->getFilePath());
         } elseif (! $configuration->isDryRun() || ! $fileProcessResult->getFileDiff() instanceof FileDiff) {
-            // a file clean under a subset of rules is not necessarily clean under all rules,
-            // caching it would hide its pending changes from the next full run
-            if ($configuration->getOnlyRule() === null && $configuration->getOnlySuffix() === null) {
-                $this->changedFilesDetector->cacheFile($file->getFilePath());
-            }
+            // selective runs are safe to cache now — the key is scoped to the rule selection
+            $this->changedFilesDetector->cacheFile($file->getFilePath());
         }
 
         return $fileProcessResult;

--- a/src/Caching/Detector/ChangedFilesDetector.php
+++ b/src/Caching/Detector/ChangedFilesDetector.php
@@ -21,11 +21,22 @@ final class ChangedFilesDetector
      */
     private array $cacheableFiles = [];
 
+    // scopes the per-file cache key to the active --only / --only-suffix selection (empty = full run)
+    private string $scopeSuffix = '';
+
     public function __construct(
         private readonly FileHashComputer $fileHashComputer,
         private readonly Cache $cache,
         private readonly FileHasher $fileHasher
     ) {
+    }
+
+    public function setActiveScope(?string $onlyRule, ?string $onlySuffix): void
+    {
+        // each selection gets its own cache key, so --only and full runs coexist without clearing or poisoning
+        $this->scopeSuffix = ($onlyRule === null && $onlySuffix === null)
+            ? ''
+            : '|only:' . ($onlyRule ?? '') . '|suffix:' . ($onlySuffix ?? '');
     }
 
     public function cacheFile(string $filePath): void
@@ -95,7 +106,7 @@ final class ChangedFilesDetector
 
     private function getFilePathCacheKey(string $filePath): string
     {
-        return $this->fileHasher->hash($this->resolvePath($filePath));
+        return $this->fileHasher->hash($this->resolvePath($filePath) . $this->scopeSuffix);
     }
 
     private function hashFile(string $filePath): string

--- a/tests/Application/ApplicationFileProcessor/ApplicationFileProcessorTest.php
+++ b/tests/Application/ApplicationFileProcessor/ApplicationFileProcessorTest.php
@@ -38,7 +38,7 @@ final class ApplicationFileProcessorTest extends AbstractLazyTestCase
         $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
     }
 
-    public function testOnlyRuleRunDoesNotCacheFileAsUnchanged(): void
+    public function testOnlyRuleRunCachesUnderOwnScopeWithoutPoisoningFullRun(): void
     {
         $filePath = __DIR__ . '/Source/CleanFile.php';
 
@@ -47,11 +47,16 @@ final class ApplicationFileProcessorTest extends AbstractLazyTestCase
             onlyRule: RemoveEmptyClassMethodRector::class
         ));
 
-        // a file clean under one rule is not necessarily clean under all rules
+        // a repeated --only run hits its own scoped cache entry
+        $this->changedFilesDetector->setActiveScope(RemoveEmptyClassMethodRector::class, null);
+        $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
+
+        // a full run uses a different scope key, so it is not poisoned
+        $this->changedFilesDetector->setActiveScope(null, null);
         $this->assertTrue($this->changedFilesDetector->hasFileChanged($filePath));
     }
 
-    public function testOnlySuffixRunDoesNotCacheFileAsUnchanged(): void
+    public function testOnlySuffixRunCachesUnderOwnScopeWithoutPoisoningFullRun(): void
     {
         $filePath = __DIR__ . '/Source/CleanFile.php';
 
@@ -60,6 +65,10 @@ final class ApplicationFileProcessorTest extends AbstractLazyTestCase
             onlySuffix: 'Controller.php'
         ));
 
+        $this->changedFilesDetector->setActiveScope(null, 'Controller.php');
+        $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
+
+        $this->changedFilesDetector->setActiveScope(null, null);
         $this->assertTrue($this->changedFilesDetector->hasFileChanged($filePath));
     }
 }


### PR DESCRIPTION
### Why

#8029 fixed `--only` / `--only-suffix` runs poisoning the full-run cache by not caching them at all.
As @samsonasik noted https://github.com/rectorphp/rector-src/pull/8029#issuecomment-4750810380, that removed the cache on repeated selective runs, and #7641 tried to bring it back but hit cache thrash.

This scopes the per-file cache key by the active rule selection, so selective and full runs use
separate, coexisting cache entries:

- a repeated `--only X` is served from cache again;
- a full run is never poisoned by a selective run, #8029's fix stays intact;
- nothing is cleared on a mode switch, so no back-and-forth thrash.

A full run keys exactly as before, existing caches aren't invalidated and
full-run behaviour is unchanged. That also makes it trivially revertable.

### Verify

The existing clean-file caching test is unchanged (full-run caching still works). A new test covers the selective case: after an `--only` run the file is cached under its own scope (a repeat `--only` is served from cache), while a full run treats it as changed, so a pending change can't be masked. Checked in parallel too.

Warm repeated `--only` on rector's own `rules/` (~790 files, one rule): ~14s reprocess on `main` →
~0.3s served from cache. That's the warm-repeat best case — the win is skipping the reprocess on repeats.