### PR TITLE
[AutoImport] Avoid used import into param that skipped from removal rule

### DIFF
--- a/src/PhpParser/NodeVisitor/PhpDocInfoRemovingNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/PhpDocInfoRemovingNodeVisitor.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PhpParser\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+final class PhpDocInfoRemovingNodeVisitor extends NodeVisitorAbstract
+{
+    public function enterNode(Node $node): Node
+    {
+        $node->setAttribute(AttributeKey::PHP_DOC_INFO, null);
+        return $node;
+    }
+}

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -153,12 +153,11 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
                 return null;
             }
 
-            $totalDocs = count($docs);
             foreach ($docs as $doc) {
-                $nodeToCheck = $totalDocs === 1 ? $node : clone $node;
-                if ($totalDocs > 1) {
-                    $nodeToCheck->setDocComment($doc);
-                }
+                // parse the current comment independently of potentially mutated cached PHPDoc
+                $nodeToCheck = clone $node;
+                $nodeToCheck->setAttribute(AttributeKey::PHP_DOC_INFO, null);
+                $nodeToCheck->setDocComment($doc);
 
                 $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($nodeToCheck);
                 $names = [...$names, ...$phpDocInfo->getAnnotationClassNames()];

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -153,9 +153,9 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
                 return null;
             }
 
+            $nodeToCheck = clone $node;
             foreach ($docs as $doc) {
                 // parse the current comment independently of potentially mutated cached PHPDoc
-                $nodeToCheck = clone $node;
                 $nodeToCheck->setAttribute(AttributeKey::PHP_DOC_INFO, null);
                 $nodeToCheck->setDocComment($doc);
 

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -153,9 +153,9 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
                 return null;
             }
 
-            $nodeToCheck = clone $node;
             foreach ($docs as $doc) {
                 // parse the current comment independently of potentially mutated cached PHPDoc
+                $nodeToCheck = clone $node;
                 $nodeToCheck->setAttribute(AttributeKey::PHP_DOC_INFO, null);
                 $nodeToCheck->setDocComment($doc);
 

--- a/src/PostRector/Rector/UnusedImportRemovingPostRector.php
+++ b/src/PostRector/Rector/UnusedImportRemovingPostRector.php
@@ -153,11 +153,12 @@ final class UnusedImportRemovingPostRector extends AbstractPostRector
                 return null;
             }
 
+            $totalDocs = count($docs);
             foreach ($docs as $doc) {
-                // parse the current comment independently of potentially mutated cached PHPDoc
-                $nodeToCheck = clone $node;
-                $nodeToCheck->setAttribute(AttributeKey::PHP_DOC_INFO, null);
-                $nodeToCheck->setDocComment($doc);
+                $nodeToCheck = $totalDocs === 1 ? $node : clone $node;
+                if ($totalDocs > 1) {
+                    $nodeToCheck->setDocComment($doc);
+                }
 
                 $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($nodeToCheck);
                 $names = [...$names, ...$phpDocInfo->getAnnotationClassNames()];

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -281,7 +281,16 @@ CODE_SAMPLE;
     private function cloneNode(Node $node): Node
     {
         $nodeTraverser = new NodeTraverser(new CloningVisitor());
-        return $nodeTraverser->traverse([$node])[0];
+        $clonedNode = $nodeTraverser->traverse([$node])[0];
+
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
+            $clonedNode,
+            static function (Node $subNode): void {
+                $subNode->setAttribute(AttributeKey::PHP_DOC_INFO, null);
+            }
+        );
+
+        return $clonedNode;
     }
 
     /**

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -35,6 +35,7 @@ use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Node\NodeFactory;
+use Rector\PhpParser\NodeVisitor\PhpDocInfoRemovingNodeVisitor;
 use Rector\Skipper\Skipper\Skipper;
 use Rector\Skipper\ValueObject\SkipMatch;
 use Rector\ValueObject\Application\File;
@@ -280,17 +281,8 @@ CODE_SAMPLE;
      */
     private function cloneNode(Node $node): Node
     {
-        $nodeTraverser = new NodeTraverser(new CloningVisitor());
-        $clonedNode = $nodeTraverser->traverse([$node])[0];
-
-        $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
-            $clonedNode,
-            static function (Node $subNode): void {
-                $subNode->setAttribute(AttributeKey::PHP_DOC_INFO, null);
-            }
-        );
-
-        return $clonedNode;
+        $nodeTraverser = new NodeTraverser(new CloningVisitor(), new PhpDocInfoRemovingNodeVisitor());
+        return $nodeTraverser->traverse([$node])[0];
     }
 
     /**

--- a/stubs/Config/App.php
+++ b/stubs/Config/App.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Config;
+
+if (class_exists('Config\App')) {
+    return;
+}
+
+class App
+{
+}

--- a/tests/Issues/ImportFullyQualifiedIdentifierDocblock/Fixture/keep_import_used_in_param.php.inc
+++ b/tests/Issues/ImportFullyQualifiedIdentifierDocblock/Fixture/keep_import_used_in_param.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeIgniter\HTTP;
+
+use Config\App;
+
+final class Response
+{
+    public $property;
+
+    /**
+     * @param App $config
+     *
+     * @deprecated The param $config is no longer used.
+     */
+    public function __construct($config)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace CodeIgniter\HTTP;
+
+use DateTime;
+use Config\App;
+
+final class Response
+{
+    /**
+     * @var DateTime
+     */
+    public $property;
+
+    /**
+     * @param App $config
+     *
+     * @deprecated The param $config is no longer used.
+     */
+    public function __construct($config)
+    {
+    }
+}
+
+?>

--- a/tests/Issues/ImportFullyQualifiedIdentifierDocblock/config/configured_rule.php
+++ b/tests/Issues/ImportFullyQualifiedIdentifierDocblock/config/configured_rule.php
@@ -3,8 +3,14 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\Tests\Issues\ImportFullyQualifiedIdentifierDocblock\Source\AddFullyQualifiedIdentifierDocblockRector;
 
 return RectorConfig::configure()
-    ->withRules([AddFullyQualifiedIdentifierDocblockRector::class])
-    ->withImportNames();
+    ->withRules([AddFullyQualifiedIdentifierDocblockRector::class, RemoveUnusedConstructorParamRector::class])
+    ->withImportNames()
+    ->withSkip([
+        RemoveUnusedConstructorParamRector::class => [
+            realpath(__DIR__ . '/../Fixture') . '/keep_import_used_in_param.php',
+        ],
+    ]);


### PR DESCRIPTION
This happen when:

- There is enabled `RemoveUnusedConstructorParamRector`
- Skipped on the target fixture
- Apply auto import with removal unused use (marked as removable, which should not)

Ref https://github.com/rectorphp/rector-src/pull/8043#issuecomment-4768876831