### PR TITLE
[Php81] Skip as argument unpack on ArrayToFirstClassCallableRector

### DIFF
--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_in_reflection_method.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_in_reflection_method.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
+
+use ReflectionMethod;
+
+class SkipInReflectionMethod
+{
+    function methodInjection()
+    {}
+
+    public function get()
+    {
+        return new ReflectionMethod(...[$this, 'methodInjection']);
+    }
+}

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_in_reflection_method_as_argument_unpack.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_in_reflection_method_as_argument_unpack.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixtu
 
 use ReflectionMethod;
 
-class SkipInReflectionMethod
+class SkipInReflectionMethodAsArgumentUnpack
 {
     function methodInjection()
     {}

--- a/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
+++ b/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
@@ -118,6 +118,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->getAttribute(AttributeKey::IS_UNPACKED_ARG_VALUE)) {
+            return null;
+        }
+
         $args = [new VariadicPlaceholder()];
         if ($callerExpr instanceof ClassConstFetch) {
             $type = $this->getType($callerExpr->class);

--- a/src/NodeTypeResolver/Node/AttributeKey.php
+++ b/src/NodeTypeResolver/Node/AttributeKey.php
@@ -129,6 +129,8 @@ final class AttributeKey
 
     public const string IS_ARG_VALUE = 'is_arg_value';
 
+    public const string IS_UNPACKED_ARG_VALUE = 'is_unpacked_arg_value';
+
     public const string IS_PARAM_VAR = 'is_param_var';
 
     public const string IS_PARAM_DEFAULT = 'is_param_default';

--- a/src/PhpParser/NodeVisitor/ContextNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/ContextNodeVisitor.php
@@ -94,6 +94,10 @@ final class ContextNodeVisitor extends NodeVisitorAbstract implements Decorating
 
         if ($node instanceof Arg) {
             $node->value->setAttribute(AttributeKey::IS_ARG_VALUE, true);
+            if ($node->unpack) {
+                $node->value->setAttribute(AttributeKey::IS_UNPACKED_ARG_VALUE, true);
+            }
+
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9783

that cause error:

```
Fatal error: Uncaught TypeError: Only arrays and Traversables can be unpacked
```

Ref https://3v4l.org/gO5mO#v8.1.34