### PR TITLE
[Php70] Skip memoize item by key on IfIssetToCoalescingRector

### DIFF
--- a/rules-tests/Php70/Rector/StmtsAwareInterface/IfIssetToCoalescingRector/Fixture/skip_memoize_item_by_key.php.inc
+++ b/rules-tests/Php70/Rector/StmtsAwareInterface/IfIssetToCoalescingRector/Fixture/skip_memoize_item_by_key.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector\Fixture;
+
+class SkipMemoizeItemByKey
+{
+    private $items = [];
+
+    public function resolve($key)
+    {
+        if (isset($this->items[$key])) {
+            return $this->items[$key];
+        }
+
+        return $this->items[$key] = 'fallback value';
+    }
+}

--- a/rules/Php70/Rector/StmtsAwareInterface/IfIssetToCoalescingRector.php
+++ b/rules/Php70/Rector/StmtsAwareInterface/IfIssetToCoalescingRector.php
@@ -6,6 +6,7 @@ namespace Rector\Php70\Rector\StmtsAwareInterface;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\Ternary;
@@ -110,6 +111,11 @@ CODE_SAMPLE
 
             $ifIsset = $previousStmt->cond;
             if (! $this->nodeComparator->areNodesEqual($ifOnlyStmt->expr, $ifIsset->vars[0])) {
+                continue;
+            }
+
+            if ($stmt->expr instanceof Assign &&
+                $this->nodeComparator->areNodesEqual($ifOnlyStmt->expr, $stmt->expr->var)) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9784
Ref https://getrector.com/demo/17f33148-a662-4998-b212-d8a5ed25b305

The transformed code become hard to read can possibly cause changed behaviour due to no parentheses on complex use.

```diff
-        if (isset($this->items[$key])) {
-            return $this->items[$key];
-        }
-
-        return $this->items[$key] = 'default';
+        return $this->items[$key] ?? $this->items[$key] = 'default';
```

so I think it should be skipped.
