### PR TITLE
[DeadCode] Skip on clone on object with __clone() method on RemoveDeadStmtRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Expression/RemoveDeadStmtRector/Fixture/skip_clone_has_clone.php.inc
+++ b/rules-tests/DeadCode/Rector/Expression/RemoveDeadStmtRector/Fixture/skip_clone_has_clone.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Expression\RemoveDeadStmtRector\Fixture;
+
+final class SkipCloneHasClone
+{
+    public function __clone()
+    {
+        throw new \RuntimeException('clone is not allowed');
+    }
+}
+
+$obj = new SkipCloneHasClone();
+clone $obj;

--- a/rules/DeadCode/NodeManipulator/LivingCodeManipulator.php
+++ b/rules/DeadCode/NodeManipulator/LivingCodeManipulator.php
@@ -56,12 +56,8 @@ final readonly class LivingCodeManipulator
             return [];
         }
 
-        if ($expr instanceof Clone_) {
-            if ($this->hasCloneMagicMethod($expr)) {
-                return [$expr];
-            }
-
-            return $this->keepLivingCodeFromExpr($expr->expr);
+        if ($expr instanceof Clone_ && $this->hasCloneMagicMethod($expr)) {
+            return [$expr];
         }
 
         if ($this->isNestedExpr($expr)) {
@@ -117,7 +113,8 @@ final readonly class LivingCodeManipulator
             $expr instanceof UnaryMinus ||
             $expr instanceof UnaryPlus ||
             $expr instanceof BitwiseNot ||
-            $expr instanceof BooleanNot;
+            $expr instanceof BooleanNot ||
+            $expr instanceof Clone_;
     }
 
     private function hasCloneMagicMethod(Clone_ $clone): bool

--- a/rules/DeadCode/NodeManipulator/LivingCodeManipulator.php
+++ b/rules/DeadCode/NodeManipulator/LivingCodeManipulator.php
@@ -30,13 +30,16 @@ use PhpParser\Node\Expr\UnaryMinus;
 use PhpParser\Node\Expr\UnaryPlus;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\ValueObject\MethodName;
 
 final readonly class LivingCodeManipulator
 {
     public function __construct(
-        private NodeTypeResolver $nodeTypeResolver
+        private NodeTypeResolver $nodeTypeResolver,
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 
@@ -51,6 +54,14 @@ final readonly class LivingCodeManipulator
 
         if ($expr instanceof Closure || $expr instanceof Scalar || $expr instanceof ConstFetch) {
             return [];
+        }
+
+        if ($expr instanceof Clone_) {
+            if ($this->hasCloneMagicMethod($expr)) {
+                return [$expr];
+            }
+
+            return $this->keepLivingCodeFromExpr($expr->expr);
         }
 
         if ($this->isNestedExpr($expr)) {
@@ -106,8 +117,24 @@ final readonly class LivingCodeManipulator
             $expr instanceof UnaryMinus ||
             $expr instanceof UnaryPlus ||
             $expr instanceof BitwiseNot ||
-            $expr instanceof BooleanNot ||
-            $expr instanceof Clone_;
+            $expr instanceof BooleanNot;
+    }
+
+    private function hasCloneMagicMethod(Clone_ $clone): bool
+    {
+        $cloneObjectType = $this->nodeTypeResolver->getType($clone->expr);
+
+        foreach ($cloneObjectType->getObjectClassNames() as $className) {
+            if (! $this->reflectionProvider->hasClass($className)) {
+                continue;
+            }
+
+            if ($this->reflectionProvider->getClass($className)->hasNativeMethod(MethodName::CLONE)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function isBinaryOpWithoutChange(Expr $expr): bool


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9785
Ref https://getrector.com/demo/de6a20d5-8b29-473b-86dd-e719f4b435e2

```diff
final class DemoFile
{
    public function __clone()
    {
        throw new RuntimeException('clone is not allowed');
    }
}

$obj = new DemoFile();
-clone $obj;
```

The `clone $obj` usage is on purpose to show `RuntimeException` on the example, so should be skipped.