### PR TITLE
[DeadCode] Add RemoveDuplicatedReturnSelfDocblockRector to drop @return docblock duplicating native self/static

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/remove_return_current_object_docblock.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/remove_return_current_object_docblock.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector\Fixture;
+
+final class RemoveReturnCurrentObjectDocblock
+{
+    /**
+     * @return RemoveReturnCurrentObjectDocblock
+     */
+    public function test(): self
+    {
+        return $this;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector\Fixture;
+
+final class RemoveReturnCurrentObjectDocblock
+{
+    public function test(): self
+    {
+        return $this;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/remove_return_self_docblock.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/remove_return_self_docblock.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector\Fixture;
+
+final class RemoveReturnSelfDocblock
+{
+    /**
+     * @return self
+     */
+    public function test(): self
+    {
+        return $this;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector\Fixture;
+
+final class RemoveReturnSelfDocblock
+{
+    public function test(): self
+    {
+        return $this;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/remove_return_static_docblock.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/remove_return_static_docblock.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector\Fixture;
+
+class RemoveReturnStaticDocblock
+{
+    /**
+     * @return static
+     */
+    public function test(): static
+    {
+        $obj = new static();
+        return $obj;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector\Fixture;
+
+class RemoveReturnStaticDocblock
+{
+    public function test(): static
+    {
+        $obj = new static();
+        return $obj;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/remove_return_this_docblock.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/remove_return_this_docblock.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector\Fixture;
+
+final class RemoveReturnThisDocblock
+{
+    /**
+     * @return $this
+     */
+    public function test(): self
+    {
+        return $this;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector\Fixture;
+
+final class RemoveReturnThisDocblock
+{
+    public function test(): self
+    {
+        return $this;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/skip_other_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/skip_other_type.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector\Fixture;
+
+final class SkipOtherType
+{
+    /**
+     * @return \stdClass
+     */
+    public function test(): self
+    {
+        return $this;
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/RemoveDuplicatedReturnSelfDocblockRectorTest.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/RemoveDuplicatedReturnSelfDocblockRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveDuplicatedReturnSelfDocblockRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveDuplicatedReturnSelfDocblockRector::class]);

--- a/rules/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StaticType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector\RemoveDuplicatedReturnSelfDocblockRectorTest
+ */
+final class RemoveDuplicatedReturnSelfDocblockRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly ReflectionResolver $reflectionResolver,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove @return docblock that duplicates the native self/static return type of the current object',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    /**
+     * @return $this
+     */
+    public function some(): self
+    {
+        return $this;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function some(): self
+    {
+        return $this;
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node->returnType instanceof Identifier && ! $node->returnType instanceof Name) {
+            return null;
+        }
+
+        $returnTypeName = $node->returnType->toString();
+        if (! in_array($returnTypeName, ['self', 'static'], true)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $returnTagValueNode = $phpDocInfo->getReturnTagValue();
+        if (! $returnTagValueNode instanceof ReturnTagValueNode) {
+            return null;
+        }
+
+        if ($returnTagValueNode->description !== '') {
+            return null;
+        }
+
+        if (! $this->isCurrentObjectReturnDocType($returnTagValueNode->type, $node, $classReflection)) {
+            return null;
+        }
+
+        $phpDocInfo->removeByType(ReturnTagValueNode::class);
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+
+        return $node;
+    }
+
+    private function isCurrentObjectReturnDocType(
+        TypeNode $typeNode,
+        ClassMethod $classMethod,
+        ClassReflection $classReflection
+    ): bool {
+        $docType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($typeNode, $classMethod);
+
+        // covers @return $this and @return static
+        if ($docType instanceof StaticType) {
+            return $docType->getClassName() === $classReflection->getName();
+        }
+
+        // covers @return self and @return CurrentObject
+        if ($docType instanceof ObjectType) {
+            return $docType->getClassName() === $classReflection->getName();
+        }
+
+        return false;
+    }
+}

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -15,6 +15,7 @@ use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\ClassConst\RemoveUnusedPrivateClassConstantRector;
 use Rector\DeadCode\Rector\ClassLike\RemoveTypedPropertyNonMockDocblockRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveArgumentFromDefaultParentCallRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveNullTagValueNodeRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector;
@@ -116,6 +117,7 @@ final class DeadCodeLevel
         RemoveVoidDocblockFromMagicMethodRector::class,
         RemoveUselessParamTagRector::class,
         RemoveUselessReturnTagRector::class,
+        RemoveDuplicatedReturnSelfDocblockRector::class,
         RemoveUselessReadOnlyTagRector::class,
         RemoveNonExistingVarAnnotationRector::class,
         RemoveUselessVarTagRector::class,


### PR DESCRIPTION
Adds a dedicated DeadCode rule `RemoveDuplicatedReturnSelfDocblockRector` that removes a `@return` docblock when it only duplicates the native `self`/`static` return type of the current object.

This was originally bundled into `ReturnTypeFromStrictFluentReturnRector`; moved here so the fluent rule stays focused on adding the return type, while docblock cleanup is a DeadCode concern. The fluent rule is left untouched.

Covers `@return $this`, `@return self`, `@return static`, and `@return CurrentClass` (the gap vs the existing `RemoveUselessReturnTagRector` is mainly `@return $this`).

```php
 final class SomeClass
 {
-    /**
-     * @return $this
-     */
     public function some(): self
     {
         return $this;
     }
 }
```
