### PR TITLE
[Cache] Fix double clear-cache

### DIFF
--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -204,8 +204,7 @@ EOF
         }
 
         // clear cache
-        $optionClearCache = (bool) $input->getOption(Option::CLEAR_CACHE);
-        if ($optionDebug || $optionClearCache) {
+        if ($optionDebug) {
             $this->changedFilesDetector->clear();
         }
     }

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -199,12 +199,9 @@ EOF
         }
 
         $optionDebug = (bool) $input->getOption(Option::DEBUG);
-        if ($optionDebug) {
-            $application->setCatchExceptions(false);
-        }
-
         // clear cache
         if ($optionDebug) {
+            $application->setCatchExceptions(false);
             $this->changedFilesDetector->clear();
         }
     }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9787

For safer usage, it can be reduced with clear early on `debug`, clear later on `--clear-cache` option.