### PR TITLE
[DeadCode] Keep private method called via self::class static call

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/keep_self_class_static_call.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/keep_self_class_static_call.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+// a private method called through a class-string static call, self::class::sampleClass(),
+// is not detected by the usage analyzer - keep it
+final class KeepSelfClassStaticCall
+{
+    public function run(): object
+    {
+        return self::class::sampleClass();
+    }
+
+    private function sampleClass(): object
+    {
+        return new \stdClass();
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -24,9 +24,6 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * Class-string static call detection mirrors PHPStan's UnusedPrivateMethodRule fix
- * @see https://github.com/phpstan/phpstan-src/pull/5953
- *
  * @see \Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\RemoveUnusedPrivateMethodRectorTest
  */
 final class RemoveUnusedPrivateMethodRector extends AbstractRector
@@ -168,6 +165,9 @@ CODE_SAMPLE
     }
 
     /**
+     * Mirrors PHPStan's UnusedPrivateMethodRule fix for class-string static calls
+     * @see https://github.com/phpstan/phpstan-src/pull/5953
+     *
      * @return string[]
      */
     private function resolveClassStringStaticCallNames(Class_ $class): array

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Rector\DeadCode\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
@@ -91,6 +94,10 @@ CODE_SAMPLE
 
         $dataProviderMethodNames = $this->resolveDataProviderMethodNames($node);
 
+        // methods invoked via a class-string static call, e.g. self::class::sampleClass(),
+        // are not seen by the usage analyzer
+        $classStringCallMethodNames = $this->resolveClassStringStaticCallNames($node);
+
         foreach ($node->stmts as $classStmtKey => $classStmt) {
             if (! $classStmt instanceof ClassMethod) {
                 continue;
@@ -115,6 +122,10 @@ CODE_SAMPLE
             }
 
             if ($this->isNames($classMethod, $dataProviderMethodNames)) {
+                continue;
+            }
+
+            if ($this->isNames($classMethod, $classStringCallMethodNames)) {
                 continue;
             }
 
@@ -151,6 +162,35 @@ CODE_SAMPLE
         }
 
         return $classReflection->hasMethod(MethodName::CALL);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolveClassStringStaticCallNames(Class_ $class): array
+    {
+        $methodNames = [];
+
+        /** @var StaticCall[] $staticCalls */
+        $staticCalls = $this->betterNodeFinder->findInstanceOf($class->stmts, StaticCall::class);
+        foreach ($staticCalls as $staticCall) {
+            // e.g. self::class::sampleClass() - the called class is a ::class expression
+            if (! $staticCall->class instanceof ClassConstFetch) {
+                continue;
+            }
+
+            if (! $this->isName($staticCall->class->name, 'class')) {
+                continue;
+            }
+
+            if (! $staticCall->name instanceof Identifier) {
+                continue;
+            }
+
+            $methodNames[] = $staticCall->name->toString();
+        }
+
+        return $methodNames;
     }
 
     private function hasDynamicMethodCallOnFetchThis(ClassMethod $classMethod): bool

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -24,6 +24,9 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * Class-string static call detection mirrors PHPStan's UnusedPrivateMethodRule fix
+ * @see https://github.com/phpstan/phpstan-src/pull/5953
+ *
  * @see \Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\RemoveUnusedPrivateMethodRectorTest
  */
 final class RemoveUnusedPrivateMethodRector extends AbstractRector


### PR DESCRIPTION
## Why

`RemoveUnusedPrivateMethodRector` removes private methods that look unused to static analysis. But a private method invoked through a **class-string static call** is not seen by the usage analyzer, so it gets wrongly removed.

This pattern was found by scanning `withSkip()` across popular Rector configs - real projects disable the rule on files where private methods are called this way.

## Code sample

```php
final class SomeClass
{
    public function run(): object
    {
        return self::class::sampleClass();
    }

    private function sampleClass(): object
    {
        return new \stdClass();
    }
}
```

Before this PR, `sampleClass()` is removed (the `self::class::sampleClass()` call is invisible to the analyzer), breaking `run()`. After, it is kept.

## Fix

`resolveClassStringStaticCallNames()` collects method names invoked via a `::class` static call (`self::class::x()`, `static::class::x()`, `Foo::class::x()`) and skips removing them.

## Tests

New keep-fixture `keep_self_class_static_call.php.inc`. ECS + PHPStan clean, all rule tests green.