### PR TITLE
[perf] Drop AstResolver from named-arg position resolution

### DIFF
--- a/rules/Arguments/ArgumentDefaultValueReplacer.php
+++ b/rules/Arguments/ArgumentDefaultValueReplacer.php
@@ -12,16 +12,17 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
 use Rector\Arguments\Contract\ReplaceArgumentDefaultValueInterface;
 use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
 use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\NodeTypeResolver\NodeTypeResolver;
-use Rector\PhpParser\AstResolver;
 use Rector\PhpParser\Node\NodeFactory;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Reflection\ReflectionResolver;
@@ -33,7 +34,6 @@ final readonly class ArgumentDefaultValueReplacer
         private NodeFactory $nodeFactory,
         private ValueResolver $valueResolver,
         private ArgsAnalyzer $argsAnalyzer,
-        private AstResolver $astResolver,
         private NodeTypeResolver $nodeTypeResolver,
         private ReflectionResolver $reflectionResolver
     ) {
@@ -125,20 +125,21 @@ final readonly class ArgumentDefaultValueReplacer
         // if it is, we use the position of the named argyment as the position to replace
         // if it is not, we cannot replace it
         if ($firstNamedArgPosition !== null && $position >= $firstNamedArgPosition) {
-            $call = $this->astResolver->resolveClassMethodOrFunctionFromCall($expr);
-            if ($call === null) {
+            $reflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($expr);
+            if (! $reflection instanceof MethodReflection && ! $reflection instanceof FunctionReflection) {
                 return null;
             }
 
-            $paramName = null;
-            $variable = $call->params[$position]->var;
-            if ($variable instanceof Variable) {
-                $paramName = $variable->name;
-            }
+            $parametersAcceptor = ParametersAcceptorSelector::combineAcceptors($reflection->getVariants());
+            $parameterReflection = $parametersAcceptor->getParameters()[$position] ?? null;
 
             $newPosition = -1;
-            if (is_string($paramName)) {
-                $newPosition = $this->argsAnalyzer->resolveArgPosition($arguments, $paramName, $newPosition);
+            if ($parameterReflection !== null) {
+                $newPosition = $this->argsAnalyzer->resolveArgPosition(
+                    $arguments,
+                    $parameterReflection->getName(),
+                    $newPosition
+                );
             }
 
             if ($newPosition === -1) {

--- a/rules/Arguments/Rector/MethodCall/RemoveMethodCallParamRector.php
+++ b/rules/Arguments/Rector/MethodCall/RemoveMethodCallParamRector.php
@@ -7,12 +7,14 @@ namespace Rector\Arguments\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\Variable;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
 use Rector\Arguments\ValueObject\RemoveMethodCallParam;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\NodeAnalyzer\ArgsAnalyzer;
-use Rector\PhpParser\AstResolver;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
@@ -29,7 +31,7 @@ final class RemoveMethodCallParamRector extends AbstractRector implements Config
     private array $removeMethodCallParams = [];
 
     public function __construct(
-        private readonly AstResolver $astResolver,
+        private readonly ReflectionResolver $reflectionResolver,
         private readonly ArgsAnalyzer $argsAnalyzer,
     ) {
     }
@@ -100,20 +102,21 @@ CODE_SAMPLE
             // if it is, we use the position of the named argument as the position to remove
             // if it is not, we cannot remove it
             if ($firstNamedArgPosition !== null && $position >= $firstNamedArgPosition) {
-                $call = $this->astResolver->resolveClassMethodOrFunctionFromCall($node);
-                if ($call === null) {
+                $reflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($node);
+                if (! $reflection instanceof MethodReflection && ! $reflection instanceof FunctionReflection) {
                     return null;
                 }
 
-                $paramName = null;
-                $variable = $call->params[$position]->var;
-                if ($variable instanceof Variable) {
-                    $paramName = $variable->name;
-                }
+                $parametersAcceptor = ParametersAcceptorSelector::combineAcceptors($reflection->getVariants());
+                $parameterReflection = $parametersAcceptor->getParameters()[$position] ?? null;
 
                 $newPosition = -1;
-                if (is_string($paramName)) {
-                    $newPosition = $this->argsAnalyzer->resolveArgPosition($args, $paramName, $newPosition);
+                if ($parameterReflection !== null) {
+                    $newPosition = $this->argsAnalyzer->resolveArgPosition(
+                        $args,
+                        $parameterReflection->getName(),
+                        $newPosition
+                    );
                 }
 
                 if ($newPosition === -1) {


### PR DESCRIPTION
## What

`RemoveMethodCallParamRector` and `ArgumentDefaultValueReplacer` both resolve a named-argument position by reading the **parameter name** at a given index of the called method/function. They did this via `AstResolver->resolveClassMethodOrFunctionFromCall()`, which **re-parses the callee's source file into a decorated AST** — heavy — only to read `$param->var->name`.

This swaps that for `ReflectionResolver->resolveFunctionLikeReflectionFromCall()` + `ParametersAcceptorSelector`, reading the name straight off `ParameterReflection::getName()`. No file re-parse.

```php
$reflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($node);
if (! $reflection instanceof MethodReflection && ! $reflection instanceof FunctionReflection) {
    return null;
}
$parametersAcceptor = ParametersAcceptorSelector::combineAcceptors($reflection->getVariants());
$parameterReflection = $parametersAcceptor->getParameters()[$position] ?? null;
```

Same pattern already used by `CallLikeParamDefaultResolver`.

## Why

AstResolver is one of the costlier analyses in the engine (parses extra files beyond the one being processed). These two sites needed only metadata reflection already holds, so the parse was pure overhead. The branch is only hit when a call uses named arguments, but removing the dependency is free correctness/perf.

## Scope note

Only the two sites that need *just the param name* are converted. Other AstResolver callers genuinely need the AST (default-value expressions, attributes, method bodies, docblocks) and are left untouched.

## Tests

Existing named-argument fixtures (`remove_named_arguments`, `replace_named_arguments`) cover the changed branch. `vendor/bin/phpunit rules-tests/Arguments` green (37 tests). ECS + PHPStan clean.