### PR TITLE
[TypeDeclaration] Drop AstResolver from NarrowObjectReturnTypeRector parent check

### DIFF
--- a/rules/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
@@ -19,7 +20,6 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\ValueObject\Type\FullyQualifiedIdentifierTypeNode;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
-use Rector\PhpParser\AstResolver;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
@@ -37,7 +37,6 @@ final class NarrowObjectReturnTypeRector extends AbstractRector
     public function __construct(
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly AstResolver $astResolver,
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly TypeComparator $typeComparator,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
@@ -242,6 +241,8 @@ CODE_SAMPLE
 
         $methodName = $this->getName($classMethod);
 
+        $actualObjectType = new ObjectType($actualReturnClass);
+
         foreach ($ancestors as $ancestor) {
             if ($ancestor->getFileName() === null) {
                 continue;
@@ -251,19 +252,23 @@ CODE_SAMPLE
                 continue;
             }
 
-            $parentClassMethod = $this->astResolver->resolveClassMethod($ancestor->getName(), $methodName);
-            if (! $parentClassMethod instanceof ClassMethod) {
+            $parametersAcceptor = ParametersAcceptorSelector::combineAcceptors(
+                $ancestor->getNativeMethod($methodName)
+                    ->getVariants()
+            );
+
+            // only a single, bare class-name return type can constrain narrowing
+            $parentNativeReturnType = $parametersAcceptor->getNativeReturnType();
+            if (! $parentNativeReturnType instanceof ObjectType) {
                 continue;
             }
 
-            $parentReturnType = $parentClassMethod->returnType;
-            if (! $parentReturnType instanceof Identifier && ! $parentReturnType instanceof FullyQualified) {
-                continue;
+            if (! $parentNativeReturnType->isSuperTypeOf($actualObjectType)->yes()) {
+                return false;
             }
 
-            $parentReturnTypeName = $parentReturnType->toString();
-
-            if (! $this->isNarrowingValid($parentClassMethod, $parentReturnTypeName, $actualReturnClass)) {
+            // skip narrowing when the parent @return is a generic type, e.g. Collection<int, Foo>
+            if ($parametersAcceptor->getReturnType() instanceof GenericObjectType) {
                 return false;
             }
         }


### PR DESCRIPTION
## What

`NarrowObjectReturnTypeRector::isNarrowingValidFromParent()` resolved each ancestor's method into a full AST (`AstResolver->resolveClassMethod()`) only to read two things:

1. the parent's **native return type** (must be a single bare class name), and
2. whether the parent's `@return` is a **generic** type (e.g. `Collection<int, Foo>`), which blocks narrowing.

Both are available from PHPStan's `ExtendedMethodReflection` without re-parsing the source file:

```php
$parametersAcceptor = ParametersAcceptorSelector::combineAcceptors(
    $ancestor->getNativeMethod($methodName)->getVariants()
);

$parentNativeReturnType = $parametersAcceptor->getNativeReturnType();   // native return
$parametersAcceptor->getReturnType();                                   // phpdoc-merged return
```

- `getNativeReturnType()` → replaces the `Identifier`/`FullyQualified` node check. We keep only `ObjectType` (single bare class); object-keyword, union, nullable, scalar all map to non-`ObjectType` and are skipped exactly as before.
- `getReturnType() instanceof GenericObjectType` → replaces reading the parent node's docblock via `PhpDocInfoFactory`. PHPStan resolves `@return Collection<int, Foo>` to a `GenericObjectType`, and `@return T` (template) to a non-generic type — matching the previous behaviour.

## Why

`AstResolver` re-parses the declaring file of every ancestor on every matching method. The data needed here is pure type metadata that reflection already holds, so the parse was overhead. The earlier "docblock = AST-only" assumption only holds for *raw docblock text*; the *semantic* generic-type check is fully available via `getReturnType()`.

## Tests

All existing fixtures pass unchanged, including the parent-path cases (`narrow_with_generic_parent`, `narrow_parent_has_specific_return_type`, `narrow_from_abstract_class`, `narrow_from_parent_to_child`). `vendor/bin/phpunit rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector` → 14/14 green. ECS + PHPStan level 8 clean.