### PR TITLE
[Strict] Skip class re-parse for typed default property in UninitializedPropertyAnalyzer

### DIFF
--- a/rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector/Fixture/skip_untyped_property.php.inc
+++ b/rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector/Fixture/skip_untyped_property.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector\Fixture;
+
+final class SkipUntypedProperty
+{
+    public $items;
+
+    public function isEmpty()
+    {
+        return empty($this->items);
+    }
+
+    public function isNotEmpty()
+    {
+        return ! empty($this->items);
+    }
+}

--- a/rules/Strict/NodeAnalyzer/UninitializedPropertyAnalyzer.php
+++ b/rules/Strict/NodeAnalyzer/UninitializedPropertyAnalyzer.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ThisType;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
@@ -22,7 +23,8 @@ final readonly class UninitializedPropertyAnalyzer
         private AstResolver $astResolver,
         private NodeTypeResolver $nodeTypeResolver,
         private ConstructorAssignDetector $constructorAssignDetector,
-        private NodeNameResolver $nodeNameResolver
+        private NodeNameResolver $nodeNameResolver,
+        private ReflectionProvider $reflectionProvider
     ) {
     }
 
@@ -45,13 +47,20 @@ final readonly class UninitializedPropertyAnalyzer
             return false;
         }
 
+        $propertyName = (string) $this->nodeNameResolver->getName($expr);
+
+        // fast-path: a typed property with an explicit default is always initialized,
+        // so we can skip the heavy class parsing below
+        if ($this->hasTypedDefaultProperty($className, $propertyName)) {
+            return false;
+        }
+
         $classLike = $this->astResolver->resolveClassFromName($className);
 
         if (! $classLike instanceof ClassLike) {
             return false;
         }
 
-        $propertyName = (string) $this->nodeNameResolver->getName($expr);
         $property = $classLike->getProperty($propertyName);
 
         if (! $property instanceof Property) {
@@ -67,5 +76,23 @@ final readonly class UninitializedPropertyAnalyzer
         }
 
         return ! $this->constructorAssignDetector->isPropertyAssigned($classLike, $propertyName);
+    }
+
+    private function hasTypedDefaultProperty(string $className, string $propertyName): bool
+    {
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return false;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+        if (! $classReflection->hasNativeProperty($propertyName)) {
+            return false;
+        }
+
+        $nativeReflectionProperty = $classReflection->getNativeProperty($propertyName)
+            ->getNativeReflection();
+
+        // an untyped property has an implicit null default, which is not an explicit initialization
+        return $nativeReflectionProperty->hasType() && $nativeReflectionProperty->hasDefaultValue();
     }
 }


### PR DESCRIPTION
## What

`UninitializedPropertyAnalyzer::isUninitialized()` resolved the declaring class into a full AST via `AstResolver->resolveClassFromName()` for every property fetch, only to then check the property's default and whether it's assigned in the constructor.

A **typed property with an explicit default** (`private array $items = [];`) is always initialized — it can never be in an uninitialized state — so the answer is `false` without parsing anything. This adds a `ReflectionProvider` fast-path that returns early in that case, before the parse:

```php
if ($this->hasTypedDefaultProperty($className, $propertyName)) {
    return false;
}
```

```php
private function hasTypedDefaultProperty(string $className, string $propertyName): bool
{
    if (! $this->reflectionProvider->hasClass($className)) {
        return false;
    }

    $classReflection = $this->reflectionProvider->getClass($className);
    if (! $classReflection->hasNativeProperty($propertyName)) {
        return false;
    }

    $nativeReflectionProperty = $classReflection->getNativeProperty($propertyName)->getNativeReflection();

    // an untyped property has an implicit null default, which is not an explicit initialization
    return $nativeReflectionProperty->hasType() && $nativeReflectionProperty->hasDefaultValue();
}
```

This is a **partial** improvement: when the property has no default (or isn't typed), the analyzer still falls through to `AstResolver` + `ConstructorAssignDetector`, because "is this property assigned in the constructor?" is flow analysis that reflection cannot answer. Only the always-initialized case is short-circuited.

## Why the `hasType()` guard

An untyped property (`public $items;`) reports an implicit `null` default — `ReflectionProperty::hasDefaultValue()` returns `true` even though there is no explicit `= ...`. Guarding on `hasType()` keeps untyped properties on the original path so behaviour is unchanged.

## Tests

Existing fixtures already cover both branches and pass unchanged:
- `property_with_default_value` (typed + default → fast-path)
- `may_uninitialized_property_no_default_value` (typed, no default → AST path)

Added `skip_untyped_property` to lock the untyped-property behaviour (left unchanged).

`vendor/bin/phpunit rules-tests/Strict/Rector/Empty_/DisallowedEmptyRuleFixerRector` → 18/18 green. ECS + full PHPStan level 8 clean.