### PR TITLE
[dx] Reorder rule guards to bail cheaply before expensive analysis

### DIFF
--- a/rules/CodeQuality/Rector/Expression/InlineIfToExplicitIfRector.php
+++ b/rules/CodeQuality/Rector/Expression/InlineIfToExplicitIfRector.php
@@ -89,16 +89,16 @@ CODE_SAMPLE
         /** @var BooleanAnd|BooleanOr $booleanExpr */
         $booleanExpr = $expression->expr;
 
-        $leftStaticType = $this->getType($booleanExpr->left);
-        if (! $leftStaticType->isBoolean()->yes()) {
-            return null;
-        }
-
         $exprLeft = $booleanExpr->left instanceof BooleanNot
             ? $booleanExpr->left->expr
             : $booleanExpr->left;
 
         if ($exprLeft instanceof FuncCall && $this->isName($exprLeft, 'defined')) {
+            return null;
+        }
+
+        $leftStaticType = $this->getType($booleanExpr->left);
+        if (! $leftStaticType->isBoolean()->yes()) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector.php
+++ b/rules/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector.php
@@ -54,10 +54,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): BooleanAnd|BooleanOr|null
     {
-        $type = $this->nodeTypeResolver->getNativeType($node->left);
-
-        if ($node->left instanceof Assign && ! $type->isBoolean()->yes()) {
-            return null;
+        if ($node->left instanceof Assign) {
+            $type = $this->nodeTypeResolver->getNativeType($node->left);
+            if (! $type->isBoolean()->yes()) {
+                return null;
+            }
         }
 
         return $this->refactorLogicalToBoolean($node);

--- a/rules/CodeQuality/Rector/Ternary/NumberCompareToMaxFuncCallRector.php
+++ b/rules/CodeQuality/Rector/Ternary/NumberCompareToMaxFuncCallRector.php
@@ -66,9 +66,6 @@ CODE_SAMPLE
         }
 
         $binaryOp = $node->cond;
-        if (! $this->areIntegersCompared($binaryOp)) {
-            return null;
-        }
 
         if ($binaryOp instanceof Smaller || $binaryOp instanceof SmallerOrEqual) {
             if (! $this->nodeComparator->areNodesEqual($binaryOp->left, $node->else)) {
@@ -76,6 +73,10 @@ CODE_SAMPLE
             }
 
             if (! $this->nodeComparator->areNodesEqual($binaryOp->right, $node->if)) {
+                return null;
+            }
+
+            if (! $this->areIntegersCompared($binaryOp)) {
                 return null;
             }
 
@@ -88,6 +89,10 @@ CODE_SAMPLE
             }
 
             if (! $this->nodeComparator->areNodesEqual($binaryOp->right, $node->else)) {
+                return null;
+            }
+
+            if (! $this->areIntegersCompared($binaryOp)) {
                 return null;
             }
 

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentImplodeRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentImplodeRector.php
@@ -84,15 +84,15 @@ CODE_SAMPLE
             return $node;
         }
 
+        if (count($node->getArgs()) !== 2) {
+            return null;
+        }
+
         $firstArg = $node->getArgs()[0];
         $firstArgumentValue = $firstArg->value;
 
         $firstArgumentType = $this->getType($firstArgumentValue);
         if ($firstArgumentType->isString()->yes()) {
-            return null;
-        }
-
-        if (count($node->getArgs()) !== 2) {
             return null;
         }
 

--- a/rules/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector.php
+++ b/rules/DeadCode/Rector/Stmt/RemoveNextSameValueConditionRector.php
@@ -101,15 +101,6 @@ CODE_SAMPLE
                 continue;
             }
 
-            // first condition must be without side effect
-            if ($this->sideEffectNodeDetector->detect($stmt->cond)) {
-                continue;
-            }
-
-            if ($this->isCondVariableUsedInIfBody($stmt)) {
-                continue;
-            }
-
             $nextStmt = $node->stmts[$key + 1] ?? null;
             if (! $nextStmt instanceof If_) {
                 continue;
@@ -125,6 +116,15 @@ CODE_SAMPLE
             }
 
             if ($nextStmt->else instanceof Else_) {
+                continue;
+            }
+
+            // first condition must be without side effect
+            if ($this->sideEffectNodeDetector->detect($stmt->cond)) {
+                continue;
+            }
+
+            if ($this->isCondVariableUsedInIfBody($stmt)) {
                 continue;
             }
 

--- a/rules/Php74/Rector/StaticCall/ExportToReflectionFunctionRector.php
+++ b/rules/Php74/Rector/StaticCall/ExportToReflectionFunctionRector.php
@@ -70,16 +70,16 @@ CODE_SAMPLE
             return null;
         }
 
-        $callerType = $this->nodeTypeResolver->getType($node->class);
-        if (! $callerType->isSuperTypeOf(new ObjectType('ReflectionFunction'))->yes()) {
-            return null;
-        }
-
         if (! $this->isName($node->name, 'export')) {
             return null;
         }
 
         if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        $callerType = $this->nodeTypeResolver->getType($node->class);
+        if (! $callerType->isSuperTypeOf(new ObjectType('ReflectionFunction'))->yes()) {
             return null;
         }
 

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -177,12 +177,12 @@ CODE_SAMPLE
             return null;
         }
 
-        $constructorPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($constructClassMethod);
-
         $classReflection = $this->reflectionResolver->resolveClassReflection($node);
         if (! $classReflection instanceof ClassReflection) {
             return null;
         }
+
+        $constructorPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($constructClassMethod);
 
         $hasChanged = false;
         foreach ($promotionCandidates as $promotionCandidate) {

--- a/rules/Php82/Rector/New_/FilesystemIteratorSkipDotsRector.php
+++ b/rules/Php82/Rector/New_/FilesystemIteratorSkipDotsRector.php
@@ -58,11 +58,11 @@ final class FilesystemIteratorSkipDotsRector extends AbstractRector implements M
             return null;
         }
 
-        if (! $this->isObjectType($node->class, new ObjectType('FilesystemIterator'))) {
+        if (! isset($node->args[1])) {
             return null;
         }
 
-        if (! isset($node->args[1])) {
+        if (! $this->isObjectType($node->class, new ObjectType('FilesystemIterator'))) {
             return null;
         }
 

--- a/rules/Php84/Rector/FuncCall/AddEscapeArgumentRector.php
+++ b/rules/Php84/Rector/FuncCall/AddEscapeArgumentRector.php
@@ -75,13 +75,13 @@ CODE_SAMPLE
             return $node;
         }
 
-        if (! $this->isObjectType($node->var, new ObjectType('SplFileObject'))) {
-            return null;
-        }
-
         $name = $this->getName($node->name);
 
         if (! in_array($name, ['setCsvControl', 'fputcsv', 'fgetcsv'], true)) {
+            return null;
+        }
+
+        if (! $this->isObjectType($node->var, new ObjectType('SplFileObject'))) {
             return null;
         }
 

--- a/rules/Php85/Rector/FuncCall/OrdSingleByteRector.php
+++ b/rules/Php85/Rector/FuncCall/OrdSingleByteRector.php
@@ -74,14 +74,6 @@ CODE_SAMPLE
         $firstArg = $args[0];
 
         $argExpr = $firstArg->value;
-        $type = $this->nodeTypeResolver->getNativeType($argExpr);
-
-        if (! $type->isString()->yes() && ! $type->isInteger()->yes()) {
-            return null;
-        }
-
-        $value = $this->valueResolver->getValue($argExpr);
-        $isInt = is_int($value);
 
         if ($argExpr instanceof String_ && strlen($argExpr->value) === 1) {
             return null;
@@ -90,6 +82,15 @@ CODE_SAMPLE
         if ($argExpr instanceof Int_ && strlen((string) $argExpr->value) === 1) {
             return null;
         }
+
+        $type = $this->nodeTypeResolver->getNativeType($argExpr);
+
+        if (! $type->isString()->yes() && ! $type->isInteger()->yes()) {
+            return null;
+        }
+
+        $value = $this->valueResolver->getValue($argExpr);
+        $isInt = is_int($value);
 
         if (! $argExpr instanceof Int_) {
             return $this->refactorStringType($argExpr, $isInt, $args, $node);

--- a/rules/Php85/Rector/FuncCall/RemoveFinfoBufferContextArgRector.php
+++ b/rules/Php85/Rector/FuncCall/RemoveFinfoBufferContextArgRector.php
@@ -65,11 +65,10 @@ CODE_SAMPLE
             return null;
         }
 
-        $objectType = new ObjectType('finfo');
-        if ($node instanceof MethodCall && (! $this->nodeTypeResolver->isObjectType(
-            $node->var,
-            $objectType
-        ) || ! $this->isName($node->name, 'buffer'))) {
+        if ($node instanceof MethodCall && (! $this->isName(
+            $node->name,
+            'buffer'
+        ) || ! $this->nodeTypeResolver->isObjectType($node->var, new ObjectType('finfo')))) {
             return null;
         }
 

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromDataProviderRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromDataProviderRector.php
@@ -109,12 +109,12 @@ CODE_SAMPLE
                 continue;
             }
 
-            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-
             $dataProviderNodes = $this->dataProviderMethodsFinder->findDataProviderNodes($node, $classMethod);
             if ($dataProviderNodes->getClassMethods() === []) {
                 continue;
             }
+
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
 
             foreach ($classMethod->getParams() as $paramPosition => $param) {
                 // we are interested only in array params

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForArrayDimAssignedObjectRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForArrayDimAssignedObjectRector.php
@@ -98,6 +98,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        // definitely not an array return
+        if ($node->returnType instanceof Node && ! $this->isName($node->returnType, 'array')) {
+            return null;
+        }
+
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         $returnType = $phpDocInfo->getReturnType();
 
@@ -106,11 +111,6 @@ CODE_SAMPLE
         }
 
         if ($this->usefulArrayTagNodeAnalyzer->isUsefulArrayTag($phpDocInfo->getReturnTagValue())) {
-            return null;
-        }
-
-        // definitely not an array return
-        if ($node->returnType instanceof Node && ! $this->isName($node->returnType, 'array')) {
             return null;
         }
 

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector.php
@@ -109,13 +109,13 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        if ($this->usefulArrayTagNodeAnalyzer->isUsefulArrayTag($phpDocInfo->getReturnTagValue())) {
+        // definitely not an array return
+        if ($node->returnType instanceof Node && ! $this->isName($node->returnType, 'array')) {
             return null;
         }
 
-        // definitely not an array return
-        if ($node->returnType instanceof Node && ! $this->isName($node->returnType, 'array')) {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+        if ($this->usefulArrayTagNodeAnalyzer->isUsefulArrayTag($phpDocInfo->getReturnTagValue())) {
             return null;
         }
 

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForJsonArrayRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForJsonArrayRector.php
@@ -85,8 +85,6 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-
         // definitely not an array return
         if ($node->returnType instanceof Node && ! $this->isName($node->returnType, 'array')) {
             return null;
@@ -106,9 +104,8 @@ CODE_SAMPLE
             return null;
         }
 
-        $classMethodDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-
-        if ($this->usefulArrayTagNodeAnalyzer->isUsefulArrayTag($classMethodDocInfo->getReturnTagValue())) {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+        if ($this->usefulArrayTagNodeAnalyzer->isUsefulArrayTag($phpDocInfo->getReturnTagValue())) {
             return null;
         }
 

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockFromMethodCallDocblockRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockFromMethodCallDocblockRector.php
@@ -105,13 +105,13 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        if ($this->usefulArrayTagNodeAnalyzer->isUsefulArrayTag($phpDocInfo->getReturnTagValue())) {
+        // definitely not an array return
+        if (! $node->returnType instanceof Node || ! $this->isName($node->returnType, 'array')) {
             return null;
         }
 
-        // definitely not an array return
-        if (! $node->returnType instanceof Node || ! $this->isName($node->returnType, 'array')) {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+        if ($this->usefulArrayTagNodeAnalyzer->isUsefulArrayTag($phpDocInfo->getReturnTagValue())) {
             return null;
         }
 


### PR DESCRIPTION
## What

Across 16 rules, an expensive analysis call (`getType`/`getNativeType`, `isObjectType`, `createFromNodeOrEmpty` docblock parsing, or a subtree traversal) ran **before** a cheap, independent guard that could already return early. This reorders each so the cheap guard runs first — the expensive call is skipped whenever the cheap guard bails.

All reorders are behavior-preserving: in each case the cheap guard does **not** depend on the expensive result, so moving it earlier changes only *when* we short-circuit, not *whether*.

## Rules touched

**Type resolution moved after a cheap name/instanceof/arg guard**
- `Php74/ExportToReflectionFunctionRector` — `isName('export')` + `isFirstClassCallable()` before `getType($node->class)`
- `Php82/FilesystemIteratorSkipDotsRector` — `isset($args[1])` before `isObjectType`
- `Php84/AddEscapeArgumentRector` — method-name `in_array` before `isObjectType`
- `Php85/OrdSingleByteRector` — single-char `String_`/`Int_` literal checks before `getNativeType`
- `Php85/RemoveFinfoBufferContextArgRector` — `isName('buffer')` short-circuits before `isObjectType` in the `||`
- `CodingStyle/ConsistentImplodeRector` — `count($args) !== 2` before `getType` (also removes a latent undefined-index on malformed 0-arg calls)
- `CodeQuality/LogicalToBooleanRector` — `getNativeType` only computed inside the `instanceof Assign` branch that uses it
- `CodeQuality/InlineIfToExplicitIfRector` — `defined()` FuncCall guard before `getType`
- `CodeQuality/NumberCompareToMaxFuncCallRector` — `areIntegersCompared` (2× `getType`) gated behind the structural pattern match, so non-comparison `BinaryOp`s bail free

**Docblock parsing moved after a cheap guard**
- `Php80/ClassPropertyAssignToConstructorPromotionRector` — class-reflection guard before `createFromNodeOrEmpty`
- `TypeDeclarationDocblocks/AddReturnDocblockFromMethodCallDocblockRector`
- `TypeDeclarationDocblocks/AddReturnDocblockForCommonObjectDenominatorRector`
- `TypeDeclarationDocblocks/AddReturnDocblockForArrayDimAssignedObjectRector` — native `returnType` array check before parsing the docblock
- `TypeDeclarationDocblocks/AddReturnDocblockForJsonArrayRector` — same, **plus** removes a duplicate `createFromNodeOrEmpty` call (parsed twice)
- `TypeDeclarationDocblocks/AddParamArrayDocblockFromDataProviderRector` — parse docblock only after a data provider is found

**Expensive traversal moved after cheap structural match**
- `DeadCode/RemoveNextSameValueConditionRector` — next-statement existence/equality checks before the side-effect + cond-variable-usage traversals of the current `if`

## Tests

No behavior change, so existing fixtures are the proof. Full suites for every touched category pass:
`rules-tests/{Php74,Php80,Php82,Php84,Php85,CodingStyle,CodeQuality,DeadCode,TypeDeclarationDocblocks}` → 2668 tests green. ECS + PHPStan level 8 clean.

## Note

A 17th candidate (`DeadCode/RemoveUselessTernaryRector`) was rejected during review: its `getNativeType` result is needed by an earlier check that legitimately runs before the structural guard, so reordering there would change behavior.