### PR TITLE
[Php74] Skip anonymous classes in RestoreDefaultNullToNullableTypePropertyRector

### DIFF
--- a/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_anonymous_class.php.inc
+++ b/rules-tests/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector/Fixture/skip_anonymous_class.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector\Fixture;
+
+function someFactory()
+{
+    return new class {
+        public ?string $name;
+    };
+}

--- a/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
+++ b/rules/Php74/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
@@ -64,6 +64,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        if ($node->isAnonymous()) {
+            return null;
+        }
+
         if ($this->isReadonlyClass($node)) {
             return null;
         }


### PR DESCRIPTION
## What

`RestoreDefaultNullToNullableTypePropertyRector` now bails early for anonymous classes:

```php
public function refactor(Node $node): ?Node
{
    if ($node->isAnonymous()) {
        return null;
    }
    ...
```

## Tests

Added `skip_anonymous_class` fixture (a `new class { public ?string $name; }` left unchanged). Full rule suite green (13 tests). ECS + PHPStan level 8 clean.