### PR TITLE
[DeadCode] Skip foreach over side-effecting expression in RemoveDeadIfForeachForRector

### DIFF
--- a/rules-tests/DeadCode/Rector/For_/RemoveDeadIfForeachForRector/Fixture/skip_foreach_over_call_side_effect.php.inc
+++ b/rules-tests/DeadCode/Rector/For_/RemoveDeadIfForeachForRector/Fixture/skip_foreach_over_call_side_effect.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\For_\RemoveDeadIfForeachForRector\Fixture;
+
+class SkipForeachOverCallSideEffect
+{
+    private $result;
+
+    public function run()
+    {
+        if (! isset($this->result)) {
+            foreach ($this->events() as $event) {
+            }
+        }
+
+        return $this->result;
+    }
+
+    private function events(): iterable
+    {
+        $this->result = 1;
+        yield 1;
+    }
+}

--- a/rules/DeadCode/Rector/For_/RemoveDeadIfForeachForRector.php
+++ b/rules/DeadCode/Rector/For_/RemoveDeadIfForeachForRector.php
@@ -166,6 +166,11 @@ CODE_SAMPLE
             return;
         }
 
+        // the iterated expression itself may have side effects, e.g. foreach (generator() as $event) {}
+        if ($this->hasNodeSideEffect($for->expr)) {
+            return;
+        }
+
         $exprs = [$for->expr, $for->valueVar, $for->valueVar];
         $variables = $this->betterNodeFinder->findInstanceOf($exprs, Variable::class);
         foreach ($variables as $variable) {


### PR DESCRIPTION
## Problem

`RemoveDeadIfForeachForRector` removed a `foreach` with an empty body even when the iterated expression has side effects, e.g. consuming a generator:

```php
public function run(): WorkflowState
{
    if (! isset($this->result)) {
        foreach ($this->events() as $event) {
        }
    }

    return $this->result;
}
```

Here `$this->events()` is a generator that sets `$this->result` as it is consumed. The empty body is not dead code — iterating *is* the work. The rule deleted the whole `if`/`foreach`, silently breaking behavior.

Spotted in the wild: https://github.com/neuron-core/neuron-ai/blob/3.x/rector.php#L23-L27 had to `withSkip()` this rule on `WorkflowHandler.php`.

## Fix

`processForForeach()` only checked whether loop *variables* were used in the next statement; it ignored side effects in the iterated expression itself. Bail out when `$for->expr` contains a `CallLike`/`Assign` (reusing the existing `hasNodeSideEffect()` helper already used by `processIf()`).

Added `skip_foreach_over_call_side_effect.php.inc` fixture covering the case.