### PR TITLE
[Php81] Skip readonly on property returned by reference in ReadOnlyPropertyRector

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_returned_by_ref.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_returned_by_ref.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class SkipReturnedByRef
+{
+    public function __construct(
+        private array $byLine = [],
+    ) {
+    }
+
+    public function &getByLine(): array
+    {
+        return $this->byLine;
+    }
+}

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeVisitor;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
@@ -174,6 +175,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // returned by reference can be mutated outside the class, so it cannot be readonly
+        if ($this->isPropertyReturnedByRef($class, (string) $this->getName($property))) {
+            return null;
+        }
+
         $this->visibilityManipulator->makeReadonly($property);
         $this->removeReadOnlyDoc($property);
 
@@ -236,11 +242,45 @@ CODE_SAMPLE
             return null;
         }
 
+        // returned by reference can be mutated outside the class, so it cannot be readonly
+        if ($this->isPropertyReturnedByRef($class, (string) $this->getName($param))) {
+            return null;
+        }
+
         $this->visibilityManipulator->makeReadonly($param);
 
         $this->removeReadOnlyDoc($param);
 
         return $param;
+    }
+
+    private function isPropertyReturnedByRef(Class_ $class, string $propertyName): bool
+    {
+        foreach ($class->getMethods() as $classMethod) {
+            if (! $classMethod->byRef) {
+                continue;
+            }
+
+            $returns = $this->betterNodeFinder->findInstanceOf($classMethod, Return_::class);
+            foreach ($returns as $return) {
+                if (! $return->expr instanceof Expr) {
+                    continue;
+                }
+
+                $propertyFetch = $this->betterNodeFinder->findFirst(
+                    $return->expr,
+                    fn (Node $subNode): bool => $subNode instanceof PropertyFetch
+                        && $this->isName($subNode->var, 'this')
+                        && $this->isName($subNode, $propertyName)
+                );
+
+                if ($propertyFetch instanceof PropertyFetch) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private function isPromotedPropertyAssigned(Class_ $class, Param $param): bool


### PR DESCRIPTION
## Problem

`ReadOnlyPropertyRector` made a promoted property `readonly` even when it is returned by reference from a `& method()`. Returning by reference lets callers hold and mutate the value, so the property cannot be `readonly` — PHP throws a fatal **"Cannot acquire reference to readonly property"** at runtime.

Spotted in the wild in infection: https://github.com/infection/infection/blob/HEAD/src/TestFramework/Tracing/Trace/TestLocations.php

```php
final class TestLocations
{
    public function __construct(
        private array $byLine = [],
        private readonly array $byMethod = [],
    ) {
    }

    public function &getTestsLocationsBySourceLine(): array
    {
        return $this->byLine;
    }
}
```

The rule rewrote `private array $byLine` to `private readonly array $byLine`, which breaks the by-reference getter.

## Fix

Add `isPropertyReturnedByRef()` guard. Before making a property/promoted param `readonly`, bail out if any method declared with `&` (returns by reference) returns `$this-><property>` (directly or as the base of a nested expression).

Added `skip_returned_by_ref.php.inc` fixture covering the case.