### PR TITLE
[DeadCode] Skip RemoveDoubleAssignRector when assign target contains a side-effecting call

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/skip_call_in_assign_target.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveDoubleAssignRector/Fixture/skip_call_in_assign_target.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveDoubleAssignRector\Fixture;
+
+final class SkipCallInAssignTarget
+{
+    public function run($container)
+    {
+        $container->get(SomeService::class)->enabled = true;
+        $container->get(SomeService::class)->enabled = true;
+        $container->get(SomeService::class)->enabled = true;
+    }
+}

--- a/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveDoubleAssignRector.php
@@ -100,6 +100,15 @@ CODE_SAMPLE
                 continue;
             }
 
+            // the assignment target itself may contain a call with side effects,
+            // e.g. $object->getService()->property = 1; — removing the first assign would skip the call
+            if ($this->betterNodeFinder->findFirst(
+                $stmt->expr->var,
+                fn (Node $subNode): bool => $this->sideEffectNodeDetector->detectCallExpr($subNode)
+            ) instanceof Node) {
+                continue;
+            }
+
             // next stmts can have side effect as well
             if (($nextAssign->var instanceof PropertyFetch || $nextAssign->var instanceof StaticPropertyFetch) && $this->sideEffectNodeDetector->detectCallExpr(
                 $nextAssign->expr


### PR DESCRIPTION
## Bug

`RemoveDoubleAssignRector` removes repeated assignments when the left-hand **target** of the assignment contains a call expression with side effects.

Found while reviewing the skip list of `spiral/framework`'s `rector.php`, which had to disable this rule on `FinalizeAttributeTest`:

```php
$root->runScoped(static function (Container $c1): void {
    $c1->get(AttrScopeFooFinalize::class)->throwException = true;
    $c1->get(AttrScopeFooFinalize::class)->throwException = true; // removed by Rector
    $c1->get(AttrScopeFooFinalize::class)->throwException = true; // removed by Rector
}, name: 'foo');
```

Each `->get(...)` resolves a fresh object from the container — a side-effecting call. Collapsing the duplicates drops those calls and changes behavior.

## Cause

The rule already guards against calls on the **right-hand side** (`$stmt->expr->expr`) and inside `try/catch`, but never inspects the **assignment target** (`$stmt->expr->var`). A property-fetch chain such as `$obj->getService()->prop` hides a `MethodCall` in the target, so the duplicate was removed.

`detectCallExpr()` only inspects the top node, and the call here is nested under a `PropertyFetch`, so the check is done via `BetterNodeFinder::findFirst()` over the whole target subtree.

## Fix

Skip the statement when the assignment target contains any side-effecting call expression. Added fixture `skip_call_in_assign_target.php.inc` (no-change), which is mangled without the guard.