### PR TITLE
[DeadCode] Keep parent-delegating constructor when its docblock refines parameter types

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_param_refining_docblock.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_param_refining_docblock.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+
+class SomeScalarType
+{
+    public function __construct(array $config)
+    {
+    }
+}
+
+/**
+ * @phpstan-type CustomScalarConfig array{name?: string, serialize?: callable}
+ */
+class SomeRefiningScalarType extends SomeScalarType
+{
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @phpstan-param CustomScalarConfig $config
+     */
+    public function __construct(array $config)
+    {
+        parent::__construct($config);
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
@@ -16,6 +16,7 @@ use PhpParser\NodeVisitor;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionParameter;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Enum\ObjectReference;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPStan\ScopeFetcher;
@@ -33,7 +34,8 @@ final class RemoveParentDelegatingConstructorRector extends AbstractRector
 {
     public function __construct(
         private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly ValueResolver $valueResolver
+        private readonly ValueResolver $valueResolver,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 
@@ -131,7 +133,21 @@ CODE_SAMPLE
             return null;
         }
 
+        // keep when the docblock refines parameter types beyond the native signature,
+        // e.g. @param array<string, mixed> or @phpstan-param SomeShape $config — removing
+        // the constructor would drop that type information
+        if ($this->hasParamRefiningDocblock($node)) {
+            return null;
+        }
+
         return NodeVisitor::REMOVE_NODE;
+    }
+
+    private function hasParamRefiningDocblock(ClassMethod $classMethod): bool
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
+
+        return $phpDocInfo->hasByNames(['@param', '@phpstan-param', '@psalm-param']);
     }
 
     private function matchParentConstructorReflection(ClassMethod $classMethod): ?ExtendedMethodReflection


### PR DESCRIPTION
## Bug

`RemoveParentDelegatingConstructorRector` removes a constructor that only calls `parent::__construct(...)` with the same arguments — but it ignores the **docblock**. When the child constructor exists purely to refine parameter types via PHPDoc, removing it silently drops that type information.

Reported from `webonyx/graphql-php`, which had to skip the rule on `CustomScalarType.php` (commit [`5da64b9`](https://github.com/webonyx/graphql-php/commit/5da64b983e1f49d80ee7bd1f7c03acc720776afa), "Ignore overzealous rector"):

```php
class CustomScalarType extends ScalarType
{
    /**
     * @param array<string, mixed> $config
     *
     * @phpstan-param CustomScalarConfig $config
     */
    public function __construct(array $config)
    {
        parent::__construct($config);
    }
}
```

The native signature (`array $config`) matches the parent, so the rule considered the constructor redundant and removed it — along with the `@param array<string, mixed>` / `@phpstan-param CustomScalarConfig` refinement. Callers would then be type-checked against the parent's looser `array` type.

## Fix

Skip removal when the constructor's docblock declares any parameter-type tag (`@param`, `@phpstan-param`, `@psalm-param`), since that refines types beyond the native signature.

Added fixture `skip_param_refining_docblock.php.inc` (no-change), which is fully removed without the guard.