### PR TITLE
[DeadCode] Keep type-assertion guard in BooleanAnd when right operand reuses the variable

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/boolean_and_guard_not_reused.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/boolean_and_guard_not_reused.php.inc
@@ -2,11 +2,11 @@
 
 namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
 
-final class BooleanAndWithObject
+final class BooleanAndGuardNotReused
 {
-    public function run(\stdClass $someObject)
+    public function run(\stdClass $someObject, bool $flag)
     {
-        if (is_object($someObject) && method_exists($someObject, 'some_method')) {
+        if (is_object($someObject) && $flag) {
             return 100;
         }
 
@@ -20,11 +20,11 @@ final class BooleanAndWithObject
 
 namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
 
-final class BooleanAndWithObject
+final class BooleanAndGuardNotReused
 {
-    public function run(\stdClass $someObject)
+    public function run(\stdClass $someObject, bool $flag)
     {
-        if (method_exists($someObject, 'some_method')) {
+        if ($flag) {
             return 100;
         }
 

--- a/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_type_guard_reused_in_boolean_and.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector/Fixture/skip_type_guard_reused_in_boolean_and.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector\Fixture;
+
+final class BooleanAndWithObject
+{
+    public function run(\stdClass $someObject)
+    {
+        if (is_object($someObject) && method_exists($someObject, 'some_method')) {
+            return 100;
+        }
+
+        return 0;
+    }
+}

--- a/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveAlwaysTrueIfConditionRector.php
@@ -54,6 +54,31 @@ final class RemoveAlwaysTrueIfConditionRector extends AbstractRector
         'extension_loaded',
     ];
 
+    /**
+     * Type-assertion guards. Their "always true" result may come from a phpdoc-narrowed type
+     * that runtime can violate (e.g. user config, decoded JSON), so when the right operand reuses
+     * the guarded variable, removing the guard would change behavior.
+     *
+     * @var string[]
+     */
+    private const array TYPE_ASSERTION_FUNCTIONS = [
+        'is_string',
+        'is_int',
+        'is_integer',
+        'is_float',
+        'is_double',
+        'is_bool',
+        'is_array',
+        'is_object',
+        'is_callable',
+        'is_iterable',
+        'is_numeric',
+        'is_scalar',
+        'is_countable',
+        'is_null',
+        'is_a',
+    ];
+
     public function __construct(
         private readonly ExprAnalyzer $exprAnalyzer,
         private readonly BetterNodeFinder $betterNodeFinder,
@@ -233,7 +258,49 @@ CODE_SAMPLE
             return null;
         }
 
+        // keep a type-assertion guard (e.g. is_string($x)) when the right operand reuses the same
+        // variable: its "always true" type may be phpdoc-only and violated at runtime, so dropping
+        // the guard would let the right operand run on an unexpected type
+        if ($this->isReusedTypeGuard($booleanAnd)) {
+            return null;
+        }
+
         $if->cond = $booleanAnd->right;
         return $if;
+    }
+
+    private function isReusedTypeGuard(BooleanAnd $booleanAnd): bool
+    {
+        /** @var FuncCall[] $funcCalls */
+        $funcCalls = $this->betterNodeFinder->findInstancesOf($booleanAnd->left, [FuncCall::class]);
+        foreach ($funcCalls as $funcCall) {
+            if (! $this->isNames($funcCall, self::TYPE_ASSERTION_FUNCTIONS)) {
+                continue;
+            }
+
+            $args = $funcCall->getArgs();
+            if (! isset($args[0])) {
+                continue;
+            }
+
+            $subject = $args[0]->value;
+            if (! $subject instanceof Variable) {
+                continue;
+            }
+
+            $isReusedOnRight = (bool) $this->betterNodeFinder->findFirst(
+                $booleanAnd->right,
+                fn (Node $subNode): bool => $subNode instanceof Variable && $this->nodeComparator->areNodesEqual(
+                    $subNode,
+                    $subject
+                )
+            );
+
+            if ($isReusedOnRight) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Bug

`RemoveAlwaysTrueIfConditionRector` strips the left operand of a `&&` condition when it is "always true". For a **type-assertion guard** (`is_string`, `is_array`, ...) whose "always true" comes from a **phpdoc-narrowed** type, that type can be violated at runtime — and the right operand often depends on the guard.

Reported from `spiral/framework` (`PrototypeBootloader::initRegistry`), which had to skip the rule:

```php
// $shortcut comes from getBindings(), which reads user config (runtime-wide)
if (\is_string($shortcut) && (\class_exists($shortcut, true) || \interface_exists($shortcut, true))) {
    $registry->bindProperty($property, $shortcut);
}
```

PHPStan narrows `$shortcut` to `string` (an earlier `is_array($shortcut) && isset($shortcut['resolve'])` branch removes the array shape via the `@psalm-type`), so `is_string()` is "always true" and the rule removed it:

```php
if (\class_exists($shortcut, true) || \interface_exists($shortcut, true)) {
```

A malformed (non-string) binding in user config then reaches `class_exists(array)` → `TypeError`. The `is_string()` guard exists precisely for that runtime case.

## Fix

In the `BooleanAnd` path, keep the condition when the left operand is a type-assertion guard (`is_string`/`is_array`/`is_int`/...) whose argument variable is **reused in the right operand**. In that case the guard protects the right side, so it must not be dropped even if "always true" by declared types.

When the guarded variable is **not** reused on the right, stripping still happens.

## Fixtures

- `skip_type_guard_reused_in_boolean_and.php.inc` (no-change) — `is_object($o) && method_exists($o, ...)`. This was previously the `boolean_and.php.inc` *change* fixture; the guard is now kept.
- `boolean_and_guard_not_reused.php.inc` (change) — `is_object($o) && $flag` still strips, since `$o` is not reused.
