### PR TITLE
[CodeQuality] Add SwitchTrueToMatchRector as replacement for deprecated SwitchTrueToIfRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/Fixture/skip_break.php.inc
+++ b/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/Fixture/skip_break.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Switch_\SwitchTrueToMatchRector\Fixture;
+
+class SkipBreak
+{
+    public function run(int $int): string
+    {
+        $str = 'error';
+        switch (true) {
+            case $int === 0:
+                $str = 'zero';
+                break;
+            default:
+                $str = 'other';
+                break;
+        }
+
+        return $str;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/Fixture/skip_default_not_last.php.inc
+++ b/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/Fixture/skip_default_not_last.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Switch_\SwitchTrueToMatchRector\Fixture;
+
+class SkipDefaultNotLast
+{
+    public function run($value)
+    {
+        switch (true) {
+            default:
+                return 'maybe';
+            case $value === 0:
+                return 'no';
+        }
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/Fixture/skip_false.php.inc
+++ b/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/Fixture/skip_false.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Switch_\SwitchTrueToMatchRector\Fixture;
+
+class SkipFalse
+{
+    public function run($value)
+    {
+        switch (false) {
+            case $value === 0:
+                return 'no';
+            default:
+                return 'maybe';
+        }
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/Fixture/skip_no_default.php.inc
+++ b/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/Fixture/skip_no_default.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Switch_\SwitchTrueToMatchRector\Fixture;
+
+class SkipNoDefault
+{
+    public function run($value)
+    {
+        switch (true) {
+            case $value === 0:
+                return 'no';
+            case $value === 1:
+                return 'yes';
+        }
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/Fixture/with_default.php.inc
+++ b/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/Fixture/with_default.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Switch_\SwitchTrueToMatchRector\Fixture;
+
+class WithDefault
+{
+    public function run($value)
+    {
+        switch (true) {
+            case $value === 0:
+                return 'no';
+            case $value === 1:
+                return 'yes';
+            case $value === 2:
+                return 'maybe';
+            default:
+                return 'nevermind';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Switch_\SwitchTrueToMatchRector\Fixture;
+
+class WithDefault
+{
+    public function run($value)
+    {
+        return match (true) {
+            $value === 0 => 'no',
+            $value === 1 => 'yes',
+            $value === 2 => 'maybe',
+            default => 'nevermind',
+        };
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/SwitchTrueToMatchRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/SwitchTrueToMatchRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Switch_\SwitchTrueToMatchRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SwitchTrueToMatchRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Switch_\SwitchTrueToMatchRector;
+use Rector\Config\RectorConfig;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->phpVersion(PhpVersion::PHP_80);
+    $rectorConfig->rule(SwitchTrueToMatchRector::class);
+};

--- a/rules/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector.php
+++ b/rules/CodeQuality/Rector/Switch_/SwitchTrueToMatchRector.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\Switch_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Match_;
+use PhpParser\Node\MatchArm;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Stmt\Switch_;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodeQuality\Rector\Switch_\SwitchTrueToMatchRector\SwitchTrueToMatchRectorTest
+ */
+final class SwitchTrueToMatchRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly ValueResolver $valueResolver,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change `switch (true)` of returning cases to `match (true)` expression', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($value)
+    {
+        switch (true) {
+            case $value === 0:
+                return 'no';
+            case $value === 1:
+                return 'yes';
+            default:
+                return 'maybe';
+        }
+    }
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($value)
+    {
+        return match (true) {
+            $value === 0 => 'no',
+            $value === 1 => 'yes',
+            default => 'maybe',
+        };
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Switch_::class];
+    }
+
+    /**
+     * @param Switch_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->valueResolver->isTrue($node->cond)) {
+            return null;
+        }
+
+        if ($node->cases === []) {
+            return null;
+        }
+
+        $matchArms = [];
+        $hasDefault = false;
+
+        $lastCaseKey = array_key_last($node->cases);
+
+        foreach ($node->cases as $key => $case) {
+            // a match arm can only carry a single return expression
+            if (count($case->stmts) !== 1) {
+                return null;
+            }
+
+            $onlyStmt = $case->stmts[0];
+            if (! $onlyStmt instanceof Return_) {
+                return null;
+            }
+
+            if (! $onlyStmt->expr instanceof Expr) {
+                return null;
+            }
+
+            if ($case->cond instanceof Expr) {
+                $matchArms[] = new MatchArm([$case->cond], $onlyStmt->expr);
+                continue;
+            }
+
+            // default case must be the last one, as a match default arm catches everything
+            if ($key !== $lastCaseKey) {
+                return null;
+            }
+
+            $hasDefault = true;
+            $matchArms[] = new MatchArm(null, $onlyStmt->expr);
+        }
+
+        // require a default arm, otherwise match (true) throws UnhandledMatchError where switch (true) falls through
+        if (! $hasDefault) {
+            return null;
+        }
+
+        $match = new Match_($this->nodeFactory->createTrue(), $matchArms);
+
+        return new Return_($match);
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::MATCH_EXPRESSION;
+    }
+}

--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -75,6 +75,7 @@ use Rector\CodeQuality\Rector\NullsafeMethodCall\CleanupUnneededNullsafeOperator
 use Rector\CodeQuality\Rector\Property\FixClassCaseSensitivityVarDocblockRector;
 use Rector\CodeQuality\Rector\StmtsAwareInterface\MoveInnerFunctionToTopLevelRector;
 use Rector\CodeQuality\Rector\Switch_\SingularSwitchToIfRector;
+use Rector\CodeQuality\Rector\Switch_\SwitchTrueToMatchRector;
 use Rector\CodeQuality\Rector\Ternary\ArrayKeyExistsTernaryThenValueToCoalescingRector;
 use Rector\CodeQuality\Rector\Ternary\NumberCompareToMaxFuncCallRector;
 use Rector\CodeQuality\Rector\Ternary\SimplifyTautologyTernaryRector;
@@ -170,6 +171,7 @@ final class CodeQualityLevel
         VariableConstFetchToClassConstFetchRector::class,
         SwitchNegatedTernaryRector::class,
         SingularSwitchToIfRector::class,
+        SwitchTrueToMatchRector::class,
         SimplifyIfNullableReturnRector::class,
         CallUserFuncWithArrowFunctionToInlineRector::class,
         FlipTypeControlToUseExclusiveTypeRector::class,


### PR DESCRIPTION
Replaces the deprecated `SwitchTrueToIfRector` with `SwitchTrueToMatchRector`.

Instead of expanding a compact `switch (true)` into many `if` statements, it converts it into a single `match (true)` expression.

```diff
 class SomeClass
 {
     public function run($value)
     {
-        switch (true) {
-            case $value === 0:
-                return 'no';
-            case $value === 1:
-                return 'yes';
-            default:
-                return 'maybe';
-        }
+        return match (true) {
+            $value === 0 => 'no',
+            $value === 1 => 'yes',
+            default => 'maybe',
+        };
     }
 }
```

### Scope / safety

- Only `switch (true)`.
- Every case must be a single `return <expr>;` (a `match` arm is one expression).
- Requires a `default` case, and it must be the last one. This avoids a behavior change: a `match (true)` with no matching arm throws `UnhandledMatchError`, whereas `switch (true)` falls through.
- Added to `CodeQualityLevel`.

Cases with `break`, assignments, or no/non-trailing `default` are skipped.


Replaces the rule deprecated in #8109.