### PR TITLE
[TypeDeclaration] Add ClosureReturnTypeFromAssertInstanceOfRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Closure/ClosureReturnTypeFromAssertInstanceOfRector/ClosureReturnTypeFromAssertInstanceOfRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/ClosureReturnTypeFromAssertInstanceOfRector/ClosureReturnTypeFromAssertInstanceOfRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\ClosureReturnTypeFromAssertInstanceOfRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ClosureReturnTypeFromAssertInstanceOfRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/ClosureReturnTypeFromAssertInstanceOfRector/Fixture/assert_instance_of_narrowed_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/ClosureReturnTypeFromAssertInstanceOfRector/Fixture/assert_instance_of_narrowed_return.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\ClosureReturnTypeFromAssertInstanceOfRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class AssertInstanceOfNarrowedReturn extends TestCase
+{
+    public function test()
+    {
+        $callback = function (object $object) {
+            $this->assertInstanceOf(\DateTime::class, $object);
+
+            return $object;
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\ClosureReturnTypeFromAssertInstanceOfRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class AssertInstanceOfNarrowedReturn extends TestCase
+{
+    public function test()
+    {
+        $callback = function (object $object): \DateTime {
+            $this->assertInstanceOf(\DateTime::class, $object);
+
+            return $object;
+        };
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Closure/ClosureReturnTypeFromAssertInstanceOfRector/Fixture/skip_no_assert_instance_of.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/ClosureReturnTypeFromAssertInstanceOfRector/Fixture/skip_no_assert_instance_of.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\ClosureReturnTypeFromAssertInstanceOfRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNoAssertInstanceOf extends TestCase
+{
+    public function test()
+    {
+        $callback = function (object $event) {
+            return $event;
+        };
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/ClosureReturnTypeFromAssertInstanceOfRector/Fixture/skip_outside_test_case.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Closure/ClosureReturnTypeFromAssertInstanceOfRector/Fixture/skip_outside_test_case.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Closure\ClosureReturnTypeFromAssertInstanceOfRector\Fixture;
+
+final class SkipOutsideTestCase
+{
+    public function run()
+    {
+        $callback = function (object $event) {
+            return $event;
+        };
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Closure/ClosureReturnTypeFromAssertInstanceOfRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Closure/ClosureReturnTypeFromAssertInstanceOfRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeFromAssertInstanceOfRector;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ClosureReturnTypeFromAssertInstanceOfRector::class);
+    $rectorConfig->phpVersion(PhpVersion::PHP_82);
+};

--- a/rules/TypeDeclaration/Rector/Closure/ClosureReturnTypeFromAssertInstanceOfRector.php
+++ b/rules/TypeDeclaration/Rector/Closure/ClosureReturnTypeFromAssertInstanceOfRector.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\Closure;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\NeverType;
+use Rector\Enum\ClassName;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\Closure\ClosureReturnTypeFromAssertInstanceOfRector\ClosureReturnTypeFromAssertInstanceOfRectorTest
+ */
+final class ClosureReturnTypeFromAssertInstanceOfRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly ReturnTypeInferer $returnTypeInferer,
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly BetterNodeFinder $betterNodeFinder,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add return type to closures narrowed by assertInstanceOf() inside PHPUnit test case classes',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test()
+    {
+        $callback = function (object $object) {
+            $this->assertInstanceOf(SomeType::class, $object);
+
+            return $object;
+        };
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test()
+    {
+        $callback = function (object $object): SomeType {
+            $this->assertInstanceOf(SomeType::class, $object);
+
+            return $object;
+        };
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Closure::class];
+    }
+
+    /**
+     * @param Closure $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        // type is already set
+        if ($node->returnType instanceof Node) {
+            return null;
+        }
+
+        $scope = ScopeFetcher::fetch($node);
+        if (! $this->isInsideTestCaseClass($scope)) {
+            return null;
+        }
+
+        // only handle closures narrowed by assertInstanceOf(); plain returns are handled by ClosureReturnTypeRector
+        if (! $this->hasAssertInstanceOf($node)) {
+            return null;
+        }
+
+        $closureReturnType = $this->returnTypeInferer->inferFunctionLike($node);
+
+        // handled by other rules
+        if ($closureReturnType instanceof NeverType) {
+            return null;
+        }
+
+        $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($closureReturnType, TypeKind::RETURN);
+        if (! $returnTypeNode instanceof Node) {
+            return null;
+        }
+
+        $node->returnType = $returnTypeNode;
+
+        return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::SCALAR_TYPES;
+    }
+
+    private function hasAssertInstanceOf(Closure $closure): bool
+    {
+        return (bool) $this->betterNodeFinder->findFirst(
+            $closure->stmts,
+            fn (Node $node): bool => ($node instanceof MethodCall || $node instanceof StaticCall)
+                && $this->isName($node->name, 'assertInstanceOf')
+        );
+    }
+
+    private function isInsideTestCaseClass(Scope $scope): bool
+    {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        // is phpunit test case?
+        return $classReflection->is(ClassName::TEST_CASE_CLASS);
+    }
+}

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -54,6 +54,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\StringReturnTypeFromStrictScalarRe
 use Rector\TypeDeclaration\Rector\ClassMethod\StringReturnTypeFromStrictStringReturnsRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureNeverReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
+use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeFromAssertInstanceOfRector;
 use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
 use Rector\TypeDeclaration\Rector\FuncCall\AddArrayAnyAllClosureParamTypeRector;
@@ -174,5 +175,6 @@ final class TypeDeclarationLevel
         // PHP 8.4
         NarrowArrayAnyAllNullableParamTypeRector::class,
         AddArrayAnyAllClosureParamTypeRector::class,
+        ClosureReturnTypeFromAssertInstanceOfRector::class,
     ];
 }


### PR DESCRIPTION
Adds `ClosureReturnTypeFromAssertInstanceOfRector` — adds a return type to a closure **inside a PHPUnit `TestCase`** when the returned value is narrowed by `assertInstanceOf()`.

This is the critical case `ClosureReturnTypeRector` cannot cover: the closure body asserts the type, so the return is known. Plain closures without `assertInstanceOf()` are left to `ClosureReturnTypeRector`.

```php
use PHPUnit\Framework\TestCase;

final class SomeTest extends TestCase
{
    public function test()
    {
        // before
        $callback = function (object $object) {
            $this->assertInstanceOf(SomeType::class, $object);
            return $object;
        };

        // after
        $callback = function (object $object): SomeType {
            $this->assertInstanceOf(SomeType::class, $object);
            return $object;
        };
    }
}
```

**Scope**
- `Closure` only (arrow functions cannot hold an `assertInstanceOf()` statement before the return)
- Gated on enclosing class `->is('PHPUnit\Framework\TestCase')`
- Requires `assertInstanceOf()` (`$this->` or static) in the closure body; skipped otherwise
- Return type inferred via `ReturnTypeInferer` (PHPStan phpunit type-specifier narrows the asserted variable)
- Registered in `TypeDeclarationLevel`

**Fixtures**: assertInstanceOf-narrowed return (transforms), no-assertInstanceOf (skip), outside test case (skip).