### PR TITLE
[CI] Fix import order in CheaperGuardFirstRule

### DIFF
--- a/utils/phpstan/src/Rule/CheaperGuardFirstRule.php
+++ b/utils/phpstan/src/Rule/CheaperGuardFirstRule.php
@@ -4,22 +4,22 @@ declare(strict_types=1);
 
 namespace Rector\Utils\PHPStan\Rule;
 
-use PhpParser\Node\Stmt\Else_;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\NullsafeMethodCall;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Name;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Continue_;
+use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;


### PR DESCRIPTION
`composer check-cs` flags an unordered import block in `utils/phpstan/src/Rule/CheaperGuardFirstRule.php` on `main`. Applies the ECS `OrderedImportsFixer` autofix — import reordering only, no logic change.