### PR TITLE
[Php81] Skip ArrayToFirstClassCallableRector on serialized callable array keys and Definition::setFactory()

### DIFF
--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_callback_keyed_array.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_callback_keyed_array.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
+
+final class SkipCallbackKeyedArray
+{
+    public function run()
+    {
+        $config = [
+            'callback' => [$this, 'name'],
+        ];
+    }
+
+    public function name()
+    {
+    }
+}

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_factory_keyed_array.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_factory_keyed_array.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
+
+final class SkipFactoryKeyedArray
+{
+    public function run()
+    {
+        $config = [
+            'factory' => [$this, 'name'],
+        ];
+    }
+
+    public function name()
+    {
+    }
+}

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_set_factory_argument.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_set_factory_argument.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
+
+use Symfony\Component\DependencyInjection\Definition;
+
+final class SkipSetFactoryArgument
+{
+    public function run(Definition $definition)
+    {
+        $definition->setFactory([$this, 'name']);
+    }
+
+    public function name()
+    {
+    }
+}

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_validation_groups_keyed_array.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_validation_groups_keyed_array.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
+
+final class SkipValidationGroupsKeyedArray
+{
+    public function run()
+    {
+        $config = [
+            'validation_groups' => [$this, 'name'],
+        ];
+    }
+
+    public function name()
+    {
+    }
+}

--- a/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
+++ b/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
@@ -94,6 +94,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->getAttribute(AttributeKey::IS_ARRAY_AS_STRING_CALLABLE)) {
+            return null;
+        }
+
         $scope = ScopeFetcher::fetch($node);
 
         $arrayCallable = $this->arrayCallableMethodMatcher->match($node, $scope);

--- a/src/NodeTypeResolver/Node/AttributeKey.php
+++ b/src/NodeTypeResolver/Node/AttributeKey.php
@@ -157,6 +157,12 @@ final class AttributeKey
 
     public const string IS_INSIDE_SYMFONY_PHP_CLOSURE = 'is_inside_symfony_php_closure';
 
+    /**
+     * Array callable kept as data, not converted to first class callable,
+     * e.g. 'callback'/'factory' keyed array item, or Definition::setFactory() argument
+     */
+    public const string IS_ARRAY_AS_STRING_CALLABLE = 'is_array_as_string_callable';
+
     public const string IS_INSIDE_BYREF_FUNCTION_LIKE = 'is_inside_byref_function_like';
 
     public const string CLASS_CONST_FETCH_NAME = 'class_const_fetch_name';

--- a/src/PhpParser/NodeVisitor/ContextNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/ContextNodeVisitor.php
@@ -6,12 +6,14 @@ namespace Rector\PhpParser\NodeVisitor;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Isset_;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PostDec;
 use PhpParser\Node\Expr\PostInc;
 use PhpParser\Node\Expr\PreDec;
@@ -19,8 +21,10 @@ use PhpParser\Node\Expr\PreInc;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
+use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Do_;
@@ -87,6 +91,16 @@ final class ContextNodeVisitor extends NodeVisitorAbstract implements Decorating
             return null;
         }
 
+        if ($node instanceof Array_) {
+            $this->processArrayInSerializedCallableKey($node);
+            return null;
+        }
+
+        if ($node instanceof MethodCall) {
+            $this->processSetFactoryArgument($node);
+            return null;
+        }
+
         if ($node instanceof If_ || $node instanceof Else_ || $node instanceof ElseIf_) {
             $this->processContextInIf($node);
             return null;
@@ -137,6 +151,55 @@ final class ContextNodeVisitor extends NodeVisitorAbstract implements Decorating
             foreach ($node->implements as $implement) {
                 $implement->setAttribute(AttributeKey::IS_CLASS_IMPLEMENT, true);
             }
+        }
+    }
+
+    /**
+     * The array is data, not a callable to convert: 'callback'/'factory' keyed item holds
+     * a [$value, 'method'] pair likely to be serialized as a string.
+     */
+    private function processArrayInSerializedCallableKey(Array_ $array): void
+    {
+        foreach ($array->items as $arrayItem) {
+            if (! $arrayItem instanceof ArrayItem) {
+                continue;
+            }
+
+            if (! $arrayItem->key instanceof String_) {
+                continue;
+            }
+
+            if (! in_array($arrayItem->key->value, ['callback', 'factory', 'validation_groups'], true)) {
+                continue;
+            }
+
+            if ($arrayItem->value instanceof Array_) {
+                $arrayItem->value->setAttribute(AttributeKey::IS_ARRAY_AS_STRING_CALLABLE, true);
+            }
+        }
+    }
+
+    /**
+     * Symfony's Definition::setFactory() does not accept a first class callable,
+     * keep the [$value, 'method'] array as is.
+     */
+    private function processSetFactoryArgument(MethodCall $methodCall): void
+    {
+        if (! $methodCall->name instanceof Identifier) {
+            return;
+        }
+
+        if ($methodCall->name->toString() !== 'setFactory') {
+            return;
+        }
+
+        $firstArg = $methodCall->args[0] ?? null;
+        if (! $firstArg instanceof Arg) {
+            return;
+        }
+
+        if ($firstArg->value instanceof Array_) {
+            $firstArg->value->setAttribute(AttributeKey::IS_ARRAY_AS_STRING_CALLABLE, true);
         }
     }
 


### PR DESCRIPTION
Skip `ArrayToFirstClassCallableRector` when the `[$value, 'method']` array is meant to stay an array rather than become a first class callable:

- array item keyed `'callback'`, `'factory'`, or `'validation_groups'` — likely serialized to a callable string
- argument of Symfony's `\Symfony\Component\DependencyInjection\Definition::setFactory()`, which does not accept a first class callable

Context is marked during parsing via a new `AttributeKey::IS_ARRAY_AS_STRING_CALLABLE` set in `ContextNodeVisitor`, then checked in the rule.

Covered by 4 new skip fixtures.