### PR TITLE
[Php81] Skip ReadOnlyPropertyRector on property changed via reference in foreach

### DIFF
--- a/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_changed_by_ref_in_foreach.php.inc
+++ b/rules-tests/Php81/Rector/Property/ReadOnlyPropertyRector/Fixture/skip_changed_by_ref_in_foreach.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Property\ReadOnlyPropertyRector\Fixture;
+
+final class SkipChangedByRefInForeach
+{
+    private array $relativeDateStrings;
+
+    public function __construct()
+    {
+        $this->relativeDateStrings = ['yesterday', 'today'];
+        foreach ($this->relativeDateStrings as &$string) {
+            $string = strtoupper($string);
+        }
+    }
+}

--- a/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
+++ b/rules/Php81/Rector/Property/ReadOnlyPropertyRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeVisitor;
@@ -180,6 +181,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // changed via reference in foreach, e.g. foreach ($this->items as &$item), so it cannot be readonly
+        if ($this->isPropertyChangedInByRefForeach($class, (string) $this->getName($property))) {
+            return null;
+        }
+
         $this->visibilityManipulator->makeReadonly($property);
         $this->removeReadOnlyDoc($property);
 
@@ -247,6 +253,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // changed via reference in foreach, e.g. foreach ($this->items as &$item), so it cannot be readonly
+        if ($this->isPropertyChangedInByRefForeach($class, (string) $this->getName($param))) {
+            return null;
+        }
+
         $this->visibilityManipulator->makeReadonly($param);
 
         $this->removeReadOnlyDoc($param);
@@ -281,6 +292,26 @@ CODE_SAMPLE
         }
 
         return false;
+    }
+
+    private function isPropertyChangedInByRefForeach(Class_ $class, string $propertyName): bool
+    {
+        return (bool) $this->betterNodeFinder->findFirst($class, function (Node $node) use ($propertyName): bool {
+            if (! $node instanceof Foreach_) {
+                return false;
+            }
+
+            if (! $node->byRef) {
+                return false;
+            }
+
+            if (! $node->expr instanceof PropertyFetch) {
+                return false;
+            }
+
+            return $this->isName($node->expr->var, 'this')
+                && $this->isName($node->expr, $propertyName);
+        });
     }
 
     private function isPromotedPropertyAssigned(Class_ $class, Param $param): bool


### PR DESCRIPTION
Skip making a property `readonly` when its array is mutated through a by-reference `foreach` (`foreach ($this->items as &$item)`).

Such a property is still being written to after its initial assignment, so marking it `readonly` would cause a "Cannot modify readonly property" runtime error.

```php
final class SomeClass
{
    private array $relativeDateStrings;

    public function __construct()
    {
        $this->relativeDateStrings = ['yesterday', 'today'];
        foreach ($this->relativeDateStrings as &$string) {
            $string = strtoupper($string);
        }
    }
}
```