### PR TITLE
[TypeDeclaration] Add TypedPropertyFromContainerGetSetUpRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/skip_no_docblock.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/skip_no_docblock.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService;
+
+final class SkipNoDocblock extends TestCase
+{
+    private $someService;
+
+    protected function setUp(): void
+    {
+        $this->someService = static::getContainer()->get(SomeService::class);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/skip_no_test_case.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/skip_no_test_case.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService;
+
+final class SkipNoTestCase
+{
+    /**
+     * @var SomeService
+     */
+    private $someService;
+
+    protected function setUp(): void
+    {
+        $this->someService = static::getContainer()->get(SomeService::class);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/skip_non_existing_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/skip_non_existing_class.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNonExistingClass extends TestCase
+{
+    /**
+     * @var \Some\Non\Existing\Service
+     */
+    private $someService;
+
+    protected function setUp(): void
+    {
+        $this->someService = static::getContainer()->get('some_service');
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/skip_not_container_fetch.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/skip_not_container_fetch.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService;
+
+final class SkipNotContainerFetch extends TestCase
+{
+    /**
+     * @var SomeService
+     */
+    private $someService;
+
+    protected function setUp(): void
+    {
+        $this->someService = new SomeService();
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/skip_public_property.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/skip_public_property.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService;
+
+final class SkipPublicProperty extends TestCase
+{
+    /**
+     * @var SomeService
+     */
+    public $someService;
+
+    protected function setUp(): void
+    {
+        $this->someService = static::getContainer()->get(SomeService::class);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/skip_scalar_type.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/skip_scalar_type.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipScalarType extends TestCase
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = static::getContainer()->get('some_parameter');
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/static_get_container_get.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/static_get_container_get.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService;
+
+final class StaticGetContainerGet extends TestCase
+{
+    /**
+     * @var SomeService
+     */
+    private $someService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->someService = static::getContainer()->get(SomeService::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService;
+
+final class StaticGetContainerGet extends TestCase
+{
+    private \Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService $someService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->someService = static::getContainer()->get(SomeService::class);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/this_container_get.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/this_container_get.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService;
+
+final class ThisContainerGet extends TestCase
+{
+    /**
+     * @var SomeService
+     */
+    private $someService;
+
+    protected function setUp(): void
+    {
+        $this->someService = $this->container->get('some_service');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService;
+
+final class ThisContainerGet extends TestCase
+{
+    private \Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService $someService;
+
+    protected function setUp(): void
+    {
+        $this->someService = $this->container->get('some_service');
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/this_get.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Fixture/this_get.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService;
+
+final class ThisGet extends TestCase
+{
+    /**
+     * @var SomeService
+     */
+    private $someService;
+
+    protected function setUp(): void
+    {
+        $this->someService = $this->get(SomeService::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService;
+
+final class ThisGet extends TestCase
+{
+    private \Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source\SomeService $someService;
+
+    protected function setUp(): void
+    {
+        $this->someService = $this->get(SomeService::class);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Source/SomeService.php
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/Source/SomeService.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\Source;
+
+final class SomeService
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/TypedPropertyFromContainerGetSetUpRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/TypedPropertyFromContainerGetSetUpRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TypedPropertyFromContainerGetSetUpRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector;
+use Rector\ValueObject\PhpVersionFeature;
+
+return RectorConfig::configure()
+    ->withRules([TypedPropertyFromContainerGetSetUpRector::class])
+    ->withPhpVersion(PhpVersionFeature::TYPED_PROPERTIES);

--- a/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\ValueObject\MethodName;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector\TypedPropertyFromContainerGetSetUpRectorTest
+ */
+final class TypedPropertyFromContainerGetSetUpRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly ReflectionProvider $reflectionProvider
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add strict typed property to a private test case property based on its @var object type, when assigned via container fetch in setUp()',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @var SomeService
+     */
+    private $someService;
+
+    protected function setUp(): void
+    {
+        $this->someService = static::getContainer()->get(SomeService::class);
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    private SomeService $someService;
+
+    protected function setUp(): void
+    {
+        $this->someService = static::getContainer()->get(SomeService::class);
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        $setUpClassMethod = $node->getMethod(MethodName::SET_UP);
+        if (! $setUpClassMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($node->getProperties() as $property) {
+            // type is already set
+            if ($property->type instanceof Node) {
+                continue;
+            }
+
+            if (! $property->isPrivate()) {
+                continue;
+            }
+
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            // exactly one property
+            if (count($property->props) !== 1) {
+                continue;
+            }
+
+            $propertyName = $this->getName($property->props[0]);
+            if (! $this->isAssignedViaContainerGetInSetUp($setUpClassMethod, $propertyName)) {
+                continue;
+            }
+
+            $propertyPhpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
+            if (! $propertyPhpDocInfo instanceof PhpDocInfo) {
+                continue;
+            }
+
+            $varType = $propertyPhpDocInfo->getVarType();
+            if (! $varType instanceof ObjectType) {
+                continue;
+            }
+
+            $propertyTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($varType, TypeKind::PROPERTY);
+            if (! $propertyTypeNode instanceof Name) {
+                continue;
+            }
+
+            // must be an existing object type
+            if (! $this->reflectionProvider->hasClass($propertyTypeNode->toString())) {
+                continue;
+            }
+
+            $property->type = $propertyTypeNode;
+            $this->removeVarTag($propertyPhpDocInfo, $property);
+
+            $hasChanged = true;
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::TYPED_PROPERTIES;
+    }
+
+    private function isAssignedViaContainerGetInSetUp(ClassMethod $setUpClassMethod, string $propertyName): bool
+    {
+        /** @var Assign[] $assigns */
+        $assigns = $this->betterNodeFinder->findInstanceOf($setUpClassMethod, Assign::class);
+
+        foreach ($assigns as $assign) {
+            if (! $assign->var instanceof PropertyFetch) {
+                continue;
+            }
+
+            $propertyFetch = $assign->var;
+            if (! $this->isName($propertyFetch->var, 'this')) {
+                continue;
+            }
+
+            if (! $this->isName($propertyFetch, $propertyName)) {
+                continue;
+            }
+
+            if ($this->isContainerGetCall($assign->expr)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isContainerGetCall(Expr $expr): bool
+    {
+        if (! $expr instanceof MethodCall) {
+            return false;
+        }
+
+        if (! $this->isName($expr->name, 'get')) {
+            return false;
+        }
+
+        $caller = $expr->var;
+
+        // static::getContainer()->get(...) or $this->getContainer()->get(...)
+        if ($caller instanceof StaticCall || $caller instanceof MethodCall) {
+            return $this->isName($caller->name, 'getContainer');
+        }
+
+        // $this->container->get(...)
+        if ($caller instanceof PropertyFetch) {
+            return $this->isName($caller, 'container');
+        }
+
+        // $this->get(...)
+        return $caller instanceof Variable && $this->isName($caller, 'this');
+    }
+
+    private function removeVarTag(PhpDocInfo $propertyPhpDocInfo, Property $property): void
+    {
+        $varTagValueNode = $propertyPhpDocInfo->getVarTagValueNode();
+        if (! $varTagValueNode instanceof VarTagValueNode) {
+            return;
+        }
+
+        $propertyPhpDocInfo->removeByType(VarTagValueNode::class);
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($property);
+    }
+}

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -15,6 +15,7 @@ use Rector\TypeDeclaration\Rector\Class_\ObjectTypedPropertyFromJMSSerializerAtt
 use Rector\TypeDeclaration\Rector\Class_\PropertyTypeFromStrictSetterGetterRector;
 use Rector\TypeDeclaration\Rector\Class_\ReturnTypeFromStrictTernaryRector;
 use Rector\TypeDeclaration\Rector\Class_\ScalarTypedPropertyFromJMSSerializerAttributeTypeRector;
+use Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector;
 use Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromCreateMockAssignRector;
 use Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromDocblockSetUpDefinedRector;
 use Rector\TypeDeclaration\Rector\Class_\TypedStaticPropertyInBehatContextRector;
@@ -153,6 +154,7 @@ final class TypeDeclarationLevel
         MergeDateTimePropertyTypeDeclarationRector::class,
         PropertyTypeFromStrictSetterGetterRector::class,
         ParamTypeByMethodCallTypeRector::class,
+        TypedPropertyFromContainerGetSetUpRector::class,
         TypedPropertyFromAssignsRector::class,
         AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
         ReturnTypeFromStrictFluentReturnRector::class,


### PR DESCRIPTION
Adds a new rule that promotes a private test-case property to a strict typed property based on its `@var` object type, when the property is assigned via a container fetch in `setUp()`.

Only applies when **all** hold:
- class is a PHPUnit test case
- property is `private`, non-static, untyped, single
- has a `@var` tag whose type is an **existing** object type
- assigned in `setUp()` via a container `->get()` fetch (`static::getContainer()->get()`, `$this->container->get()`, `$this->get()`)

The `@var` tag is removed after promotion.

```diff
 final class BulkNotificationTest extends MauticMysqlTestCase
 {
-    /**
-     * @var BulkNotification
-     */
-    private $bulkNotification;
+    private BulkNotification $bulkNotification;

     protected function setUp(): void
     {
         parent::setUp();
         $this->bulkNotification = static::getContainer()->get('mautic.integrations.sync.notification.bulk_notification');
     }
 }
```

Registered in `TypeDeclarationLevel` just above `TypedPropertyFromAssignsRector` so it applies sooner.