### PR TITLE
Add test fixture for demonstrating behavior changing parentheses remo…

### DIFF
--- a/rules-tests/CodeQuality/Rector/Identical/SimplifyConditionsRector/Fixture/keep_parentheses.php.inc
+++ b/rules-tests/CodeQuality/Rector/Identical/SimplifyConditionsRector/Fixture/keep_parentheses.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+function keepParentheses()
+{
+    if (! (1 < (1 ? 2 : 1))) {
+    }
+}
+
+?>
+-----
+<?php
+
+function keepParentheses()
+{
+    if (1 >= (1 ? 2 : 1)) {
+    }
+}
+
+?>


### PR DESCRIPTION
This condition evaluates as **false**:

```php
if (! (1 < (1 ? 2 : 1))) {
}
```

But it is simplified into this, which, due to removal of parentheses around inner condition, evaluates as **true**:

```php
if (1 >= 1 ? 2 : 1) {
}
```

Added failing fixture (might not be minimal reproducer, but it illustrates it nicely).
