### PR TITLE
[CodeQuality] Keep parentheses around Ternary operand in SimplifyConditionsRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Identical/SimplifyConditionsRector/Fixture/keep_parentheses.php.inc
+++ b/rules-tests/CodeQuality/Rector/Identical/SimplifyConditionsRector/Fixture/keep_parentheses.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+function keepParentheses()
+{
+    if (! (1 < (1 ? 2 : 1))) {
+    }
+}
+
+?>
+-----
+<?php
+
+function keepParentheses()
+{
+    if (1 >= (1 ? 2 : 1)) {
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Identical/SimplifyConditionsRector.php
+++ b/rules/CodeQuality/Rector/Identical/SimplifyConditionsRector.php
@@ -11,7 +11,9 @@ use PhpParser\Node\Expr\BinaryOp\BooleanOr;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\Ternary;
 use Rector\NodeManipulator\BinaryOpManipulator;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Php71\ValueObject\TwoNodeMatch;
 use Rector\PhpParser\Node\AssignAndBinaryMap;
 use Rector\PhpParser\Node\Value\ValueResolver;
@@ -116,6 +118,14 @@ final class SimplifyConditionsRector extends AbstractRector
         $inversedBinaryClass = $this->assignAndBinaryMap->getInversed($binaryOp);
         if ($inversedBinaryClass === null) {
             return null;
+        }
+
+        if ($binaryOp->left instanceof Ternary) {
+            $binaryOp->left->setAttribute(AttributeKey::WRAPPED_IN_PARENTHESES, true);
+        }
+
+        if ($binaryOp->right instanceof Ternary) {
+            $binaryOp->right->setAttribute(AttributeKey::WRAPPED_IN_PARENTHESES, true);
         }
 
         return new $inversedBinaryClass($binaryOp->left, $binaryOp->right);


### PR DESCRIPTION
Fixes #8121.

`SimplifyConditionsRector` inverts a binary op when wrapped in a boolean not, e.g. `! (1 < X)` → `1 >= X`. When the operand `X` is a ternary, the format-preserving printer dropped the parentheses. Since the ternary has lower precedence than `>=`, the result changed meaning:

```php
// before (input) — evaluates false
if (! (1 < (1 ? 2 : 1))) {}

// produced — evaluates true (wrong)
if (1 >= 1 ? 2 : 1) {}
```

Now `createInversedBooleanOp()` sets `WRAPPED_IN_PARENTHESES` on ternary operands, matching the existing precedent in `UseIdenticalOverEqualWithSameTypeRector`, producing the correct:

```php
if (1 >= (1 ? 2 : 1)) {}
```

Bug report and failing fixture by @j-dobr in #8121.

Co-authored-by: Jan Dobrovodsky <jan.dobrovodsky@promedcs.com>