### PR TITLE
[TypeDeclaration] Skip variadic param in AddMethodCallBasedStrictParamTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/skip_variadic_param.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/AddMethodCallBasedStrictParamTypeRector/Fixture/skip_variadic_param.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector\Fixture;
+
+final class SkipVariadicParam
+{
+    public function run(): void
+    {
+        $this->createQueryBuilder('first', 'second');
+    }
+
+    private function createQueryBuilder(...$returnValues): void
+    {
+    }
+}

--- a/rules/TypeDeclaration/NodeAnalyzer/ClassMethodParamTypeCompleter.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/ClassMethodParamTypeCompleter.php
@@ -94,6 +94,12 @@ final readonly class ClassMethodParamTypeCompleter
         }
 
         $parameter = $classMethod->params[$position];
+
+        // skip variadic param, as resolved type belongs to single element, not the whole array
+        if ($parameter->variadic) {
+            return true;
+        }
+
         if ($parameter->type === null) {
             return false;
         }


### PR DESCRIPTION
Variadic params received a strict type that belongs to a single element, not the whole spread array:

```diff
-private function createQueryBuilder(...$returnValues): MockObject
+private function createQueryBuilder(string ...$returnValues): MockObject
```

The resolved type comes from individual passed args, so applying it to the variadic param is wrong. Skip variadic params in `ClassMethodParamTypeCompleter`.