### PR TITLE
[TypeDeclaration] Add TypedPropertyFromGetRepositorySetUpRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Fixture/em_get_repository.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Fixture/em_get_repository.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Source\SomeEntityRepository;
+
+final class EmGetRepository extends TestCase
+{
+    /**
+     * @var SomeEntityRepository
+     */
+    private $someEntityRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->someEntityRepository = $this->em->getRepository(SomeEntity::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Source\SomeEntityRepository;
+
+final class EmGetRepository extends TestCase
+{
+    private \Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Source\SomeEntityRepository $someEntityRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->someEntityRepository = $this->em->getRepository(SomeEntity::class);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Fixture/skip_no_docblock.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Fixture/skip_no_docblock.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNoDocblock extends TestCase
+{
+    private $someEntityRepository;
+
+    protected function setUp(): void
+    {
+        $this->someEntityRepository = $this->em->getRepository(SomeEntity::class);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Fixture/skip_no_test_case.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Fixture/skip_no_test_case.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Source\SomeEntityRepository;
+
+final class SkipNoTestCase
+{
+    /**
+     * @var SomeEntityRepository
+     */
+    private $someEntityRepository;
+
+    protected function setUp(): void
+    {
+        $this->someEntityRepository = $this->em->getRepository(SomeEntity::class);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Fixture/skip_non_existing_class.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Fixture/skip_non_existing_class.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipNonExistingClass extends TestCase
+{
+    /**
+     * @var \Some\Non\Existing\Repository
+     */
+    private $someEntityRepository;
+
+    protected function setUp(): void
+    {
+        $this->someEntityRepository = $this->em->getRepository(SomeEntity::class);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Fixture/skip_not_get_repository.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Fixture/skip_not_get_repository.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Source\SomeEntityRepository;
+
+final class SkipNotGetRepository extends TestCase
+{
+    /**
+     * @var SomeEntityRepository
+     */
+    private $someEntityRepository;
+
+    protected function setUp(): void
+    {
+        $this->someEntityRepository = new SomeEntityRepository();
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Fixture/skip_public_property.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Fixture/skip_public_property.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Source\SomeEntityRepository;
+
+final class SkipPublicProperty extends TestCase
+{
+    /**
+     * @var SomeEntityRepository
+     */
+    public $someEntityRepository;
+
+    protected function setUp(): void
+    {
+        $this->someEntityRepository = $this->em->getRepository(SomeEntity::class);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Source/SomeEntityRepository.php
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/Source/SomeEntityRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\Source;
+
+final class SomeEntityRepository
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/TypedPropertyFromGetRepositorySetUpRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/TypedPropertyFromGetRepositorySetUpRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TypedPropertyFromGetRepositorySetUpRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector;
+use Rector\ValueObject\PhpVersionFeature;
+
+return RectorConfig::configure()
+    ->withRules([TypedPropertyFromGetRepositorySetUpRector::class])
+    ->withPhpVersion(PhpVersionFeature::TYPED_PROPERTIES);

--- a/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\ValueObject\MethodName;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector\TypedPropertyFromGetRepositorySetUpRectorTest
+ */
+final class TypedPropertyFromGetRepositorySetUpRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly ReflectionProvider $reflectionProvider
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add strict typed property to a private test case property based on its @var object type, when assigned via entity manager getRepository() fetch in setUp()',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    /**
+     * @var SomeEntityRepository
+     */
+    private $someEntityRepository;
+
+    protected function setUp(): void
+    {
+        $this->someEntityRepository = $this->em->getRepository(SomeEntity::class);
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    private SomeEntityRepository $someEntityRepository;
+
+    protected function setUp(): void
+    {
+        $this->someEntityRepository = $this->em->getRepository(SomeEntity::class);
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        $setUpClassMethod = $node->getMethod(MethodName::SET_UP);
+        if (! $setUpClassMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($node->getProperties() as $property) {
+            // type is already set
+            if ($property->type instanceof Node) {
+                continue;
+            }
+
+            if (! $property->isPrivate()) {
+                continue;
+            }
+
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            // exactly one property
+            if (count($property->props) !== 1) {
+                continue;
+            }
+
+            $propertyName = $this->getName($property->props[0]);
+            if (! $this->isAssignedViaGetRepositoryInSetUp($setUpClassMethod, $propertyName)) {
+                continue;
+            }
+
+            $propertyPhpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
+            if (! $propertyPhpDocInfo instanceof PhpDocInfo) {
+                continue;
+            }
+
+            $varType = $propertyPhpDocInfo->getVarType();
+            if (! $varType instanceof ObjectType) {
+                continue;
+            }
+
+            $propertyTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($varType, TypeKind::PROPERTY);
+            if (! $propertyTypeNode instanceof Name) {
+                continue;
+            }
+
+            // must be an existing object type
+            if (! $this->reflectionProvider->hasClass($propertyTypeNode->toString())) {
+                continue;
+            }
+
+            $property->type = $propertyTypeNode;
+            $this->removeVarTag($propertyPhpDocInfo, $property);
+
+            $hasChanged = true;
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::TYPED_PROPERTIES;
+    }
+
+    private function isAssignedViaGetRepositoryInSetUp(ClassMethod $setUpClassMethod, string $propertyName): bool
+    {
+        /** @var Assign[] $assigns */
+        $assigns = $this->betterNodeFinder->findInstanceOf($setUpClassMethod, Assign::class);
+
+        foreach ($assigns as $assign) {
+            if (! $assign->var instanceof PropertyFetch) {
+                continue;
+            }
+
+            $propertyFetch = $assign->var;
+            if (! $this->isName($propertyFetch->var, 'this')) {
+                continue;
+            }
+
+            if (! $this->isName($propertyFetch, $propertyName)) {
+                continue;
+            }
+
+            if ($this->isGetRepositoryCall($assign->expr)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isGetRepositoryCall(Expr $expr): bool
+    {
+        if (! $expr instanceof MethodCall) {
+            return false;
+        }
+
+        return $this->isName($expr->name, 'getRepository');
+    }
+
+    private function removeVarTag(PhpDocInfo $propertyPhpDocInfo, Property $property): void
+    {
+        $varTagValueNode = $propertyPhpDocInfo->getVarTagValueNode();
+        if (! $varTagValueNode instanceof VarTagValueNode) {
+            return;
+        }
+
+        $propertyPhpDocInfo->removeByType(VarTagValueNode::class);
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($property);
+    }
+}

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -18,6 +18,7 @@ use Rector\TypeDeclaration\Rector\Class_\ScalarTypedPropertyFromJMSSerializerAtt
 use Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromContainerGetSetUpRector;
 use Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromCreateMockAssignRector;
 use Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromDocblockSetUpDefinedRector;
+use Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromGetRepositorySetUpRector;
 use Rector\TypeDeclaration\Rector\Class_\TypedStaticPropertyInBehatContextRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddParamFromDimFetchKeyUseRector;
@@ -155,6 +156,7 @@ final class TypeDeclarationLevel
         PropertyTypeFromStrictSetterGetterRector::class,
         ParamTypeByMethodCallTypeRector::class,
         TypedPropertyFromContainerGetSetUpRector::class,
+        TypedPropertyFromGetRepositorySetUpRector::class,
         TypedPropertyFromAssignsRector::class,
         AddReturnTypeDeclarationBasedOnParentClassMethodRector::class,
         ReturnTypeFromStrictFluentReturnRector::class,


### PR DESCRIPTION
Mirrors #8120, but hooks into `$this->em->getRepository()` instead of `container->get()`.

When a private test-case property is assigned via an entity manager `getRepository()` call inside `setUp()` and has a `@var` object type, inline that `@var` type into a native property type declaration.

```diff
 final class SomeTest extends TestCase
 {
-    /**
-     * @var SomeEntityRepository
-     */
-    private $someEntityRepository;
+    private SomeEntityRepository $someEntityRepository;

     protected function setUp(): void
     {
         $this->someEntityRepository = $this->em->getRepository(SomeEntity::class);
     }
 }
```

Registered in `TypeDeclarationLevel` right after `TypedPropertyFromContainerGetSetUpRector` and before `TypedPropertyFromAssignsRector`.