### PR TITLE
[TypeDeclaration] Map accessory string intersection to string in union return type

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/int_or_numeric_string.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnUnionTypeRector/Fixture/int_or_numeric_string.php.inc
@@ -1,0 +1,57 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+
+final class IntOrNumericString
+{
+    private function getAssetSize(): int
+    {
+        return 1000;
+    }
+
+    public function getTotalFilesize($assets)
+    {
+        if (empty($assets)) {
+            return 0;
+        }
+
+        $size = $this->getAssetSize($assets);
+
+        if ($size) {
+            $size = (string) $size;
+        }
+
+        return $size;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnUnionTypeRector\Fixture;
+
+final class IntOrNumericString
+{
+    private function getAssetSize(): int
+    {
+        return 1000;
+    }
+
+    public function getTotalFilesize($assets): int|string
+    {
+        if (empty($assets)) {
+            return 0;
+        }
+
+        $size = $this->getAssetSize($assets);
+
+        if ($size) {
+            $size = (string) $size;
+        }
+
+        return $size;
+    }
+}
+
+?>

--- a/src/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
+++ b/src/PHPStanStaticTypeMapper/TypeMapper/IntersectionTypeMapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\PHPStanStaticTypeMapper\TypeMapper;
 
 use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use PHPStan\PhpDocParser\Ast\Node as AstNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
@@ -91,6 +92,11 @@ final readonly class IntersectionTypeMapper implements TypeMapperInterface
      */
     public function mapToPhpParserNode(Type $type, string $typeKind): ?Node
     {
+        // accessory string types, e.g. "numeric-string&non-falsy-string", are just "string"
+        if ($type->isString()->yes()) {
+            return new Identifier('string');
+        }
+
         if (! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::INTERSECTION_TYPES)) {
             return null;
         }


### PR DESCRIPTION
## Problem

`ReturnUnionTypeRector` failed to add a return type to methods like:

```php
private function getAssetSize(): int { /* ... */ }

public function getTotalFilesize($assets)
{
    if (empty($assets)) {
        return 0;
    }

    $size = $this->getAssetSize($assets);

    if ($size) {
        $size = (string) $size;
    }

    return $size;
}
```

PHPStan infers the native return type as `0 | (numeric-string & non-falsy-string)` — i.e. `int | string`. But `IntersectionTypeMapper::mapToPhpParserNode()` only handled **object** intersections; the string-accessory member (`numeric-string & non-falsy-string`) hit the `! $type instanceof ObjectType` branch and returned `null`, which aborted the whole `UnionTypeMapper`. Net result: no return type was added at all.

## Fix

A pure-string intersection is just `string`. Map it directly before the object handling:

```php
if ($type->isString()->yes()) {
    return new Identifier('string');
}
```

Now the rule adds `int|string` as expected.

## Test

Added fixture `int_or_numeric_string.php.inc` mirroring the real-world shape.