### PR TITLE
[DeadCode] Add RemoveUselessUnionReturnDocblockRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/Fixture/skip_array_native.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/Fixture/skip_array_native.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector\Fixture;
+
+final class SkipArrayNative
+{
+    /**
+     * @return int[]|string[]
+     */
+    public function run(): array
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/Fixture/skip_description.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/Fixture/skip_description.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector\Fixture;
+
+final class SkipDescription
+{
+    /**
+     * @return bool|mixed|string the escaped value
+     */
+    public function run(): false|string
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/Fixture/skip_more_specific_docblock.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/Fixture/skip_more_specific_docblock.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector\Fixture;
+
+final class SkipMoreSpecificDocblock
+{
+    /**
+     * @return \DateTime|\DateTimeImmutable
+     */
+    public function run(): object
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/Fixture/skip_no_native_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/Fixture/skip_no_native_type.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector\Fixture;
+
+final class SkipNoNativeType
+{
+    /**
+     * @return bool|mixed|string
+     */
+    public function run()
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/Fixture/union_over_single_native.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/Fixture/union_over_single_native.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector\Fixture;
+
+final class UnionOverSingleNative
+{
+    /**
+     * @return bool|float|mixed|string
+     */
+    private function escapeQueryValue(string $value): string
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector\Fixture;
+
+final class UnionOverSingleNative
+{
+    private function escapeQueryValue(string $value): string
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/Fixture/union_with_mixed.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/Fixture/union_with_mixed.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector\Fixture;
+
+final class UnionWithMixed
+{
+    /**
+     * @return bool|mixed|string
+     */
+    protected function setContactToSync(&$checkEmailsInSF, $lead): false|string
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector\Fixture;
+
+final class UnionWithMixed
+{
+    protected function setContactToSync(&$checkEmailsInSF, $lead): false|string
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/RemoveUselessUnionReturnDocblockRectorTest.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/RemoveUselessUnionReturnDocblockRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveUselessUnionReturnDocblockRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector;
+use Rector\ValueObject\PhpVersionFeature;
+
+return RectorConfig::configure()
+    ->withPhpVersion(PhpVersionFeature::UNION_TYPES)
+    ->withRules([RemoveUselessUnionReturnDocblockRector::class]);

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUselessUnionReturnDocblockRector.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector\RemoveUselessUnionReturnDocblockRectorTest
+ */
+final class RemoveUselessUnionReturnDocblockRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly StaticTypeMapper $staticTypeMapper,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove @return union docblock that is broader than a more specific, non-array native return type',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    /**
+     * @return bool|mixed|string
+     */
+    public function run(): false|string
+    {
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function run(): false|string
+    {
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class, Function_::class];
+    }
+
+    /**
+     * @param ClassMethod|Function_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->returnType === null) {
+            return null;
+        }
+
+        // skip as no comments
+        if ($node->getComments() === []) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $returnTagValueNode = $phpDocInfo->getReturnTagValue();
+        if (! $returnTagValueNode instanceof ReturnTagValueNode) {
+            return null;
+        }
+
+        // keep description, it carries info the native type cannot
+        if ($returnTagValueNode->description !== '') {
+            return null;
+        }
+
+        // only union docblock types are handled here
+        if (! $returnTagValueNode->type instanceof UnionTypeNode) {
+            return null;
+        }
+
+        $nativeReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
+
+        // keep array native type, the docblock may carry element types
+        if ($nativeReturnType->isArray()->yes()) {
+            return null;
+        }
+
+        $docblockReturnType = $phpDocInfo->getReturnType();
+
+        // the docblock adds nothing when it is broader than the native type
+        if (! $docblockReturnType->isSuperTypeOf($nativeReturnType)->yes()) {
+            return null;
+        }
+
+        if (! $phpDocInfo->removeByType(ReturnTagValueNode::class)) {
+            return null;
+        }
+
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+
+        return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::UNION_TYPES;
+    }
+}

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -28,6 +28,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveUselessAssignFromPropertyPromotionR
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnExprInConstructRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveVoidDocblockFromMagicMethodRector;
 use Rector\DeadCode\Rector\Closure\RemoveUnusedClosureVariableUseRector;
 use Rector\DeadCode\Rector\Concat\RemoveConcatAutocastRector;
@@ -119,6 +120,7 @@ final class DeadCodeLevel
         RemoveUselessReturnTagRector::class,
         RemoveDuplicatedReturnSelfDocblockRector::class,
         RemoveMixedDocblockOverruledByNativeTypeRector::class,
+        RemoveUselessUnionReturnDocblockRector::class,
         RemoveUselessReadOnlyTagRector::class,
         RemoveNonExistingVarAnnotationRector::class,
         RemoveUselessVarTagRector::class,


### PR DESCRIPTION
Adds a dead-code rule that removes a `@return` **union** docblock when a more specific, **non-array** native return type already covers it.

The docblock adds nothing once the native type is narrower-or-equal, so it is dead.

### Before
```php
/**
 * @return bool|mixed|string
 */
protected function setContactToSync($checkEmailsInSF, $lead): false|string
```

### After
```php
protected function setContactToSync($checkEmailsInSF, $lead): false|string
```

Also handles a union docblock over a single native type, e.g. `@return bool|float|mixed|string` over `: string`.

### Trigger
- `@return` type is a union node
- native return type is declared and **not** array/iterable (kept, may carry element types)
- the docblock type is a supertype of the native type (broader-or-equal)
- empty description (descriptions are kept)

Requires PHP 8.0 (`MinPhpVersionInterface` -> `UNION_TYPES`). Registered in the dead-code set via `DeadCodeLevel`.