### PR TITLE
[Privatization] Skip FinalizeTestCaseClassRector for classes without Test suffix

### DIFF
--- a/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/Fixture/skip_without_test_suffix.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/Fixture/skip_without_test_suffix.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\FinalizeTestCaseClassRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SomeReusableHelper extends TestCase
+{
+}

--- a/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/Fixture/some_class.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/Fixture/some_class.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\Privatization\Rector\Class_\FinalizeTestCaseClassRector\F
 
 use PHPUnit\Framework\TestCase;
 
-class SomeClass extends TestCase
+class SomeClassTest extends TestCase
 {
 }
 
@@ -16,7 +16,7 @@ namespace Rector\Tests\Privatization\Rector\Class_\FinalizeTestCaseClassRector\F
 
 use PHPUnit\Framework\TestCase;
 
-final class SomeClass extends TestCase
+final class SomeClassTest extends TestCase
 {
 }
 

--- a/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/Fixture/with_attribute_new_line.php.inc
+++ b/rules-tests/Privatization/Rector/Class_/FinalizeTestCaseClassRector/Fixture/with_attribute_new_line.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\Privatization\Rector\Class_\FinalizeTestCaseClassRector\F
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Advisor::class)]
-class WithAttributeNewLine extends TestCase
+class WithAttributeNewLineTest extends TestCase
 {
 }
 
@@ -18,7 +18,7 @@ namespace Rector\Tests\Privatization\Rector\Class_\FinalizeTestCaseClassRector\F
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Advisor::class)]
-final class WithAttributeNewLine extends TestCase
+final class WithAttributeNewLineTest extends TestCase
 {
 }
 

--- a/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
+++ b/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
@@ -74,6 +74,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // skip classes without "Test" suffix, as those are meant to be extended
+        if (! str_ends_with($className, 'Test')) {
+            return null;
+        }
+
         if (! $this->reflectionProvider->hasClass($className)) {
             return null;
         }


### PR DESCRIPTION
Classes without a `Test` suffix are typically abstract/base cases meant to be extended, so they should not be made `final`.

Adds a skip when the class name does not end with `Test`. Existing fixtures renamed to carry the `Test` suffix; new fixture covers the skip.