### PR TITLE
[TypeDeclaration] Skip anonymous class return in NarrowObjectReturnTypeRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/Fixture/skip_anonymous_class_this_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/Fixture/skip_anonymous_class_this_return.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Source\Email;
+
+final class EmailFactory
+{
+    private function createEmail(): Email
+    {
+        return new class extends Email {
+            private int $id = 0;
+
+            public function getId(): int
+            {
+                return $this->id;
+            }
+
+            public function setId(int $id): Email
+            {
+                $this->id = $id;
+
+                return $this;
+            }
+        };
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/Source/Email.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector/Source/Email.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector\Source;
+
+class Email
+{
+}

--- a/rules/Privatization/TypeManipulator/ArrayTypeLeastCommonDenominatorResolver.php
+++ b/rules/Privatization/TypeManipulator/ArrayTypeLeastCommonDenominatorResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Privatization\TypeManipulator;
 
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;

--- a/rules/Privatization/TypeManipulator/ArrayTypeLeastCommonDenominatorResolver.php
+++ b/rules/Privatization/TypeManipulator/ArrayTypeLeastCommonDenominatorResolver.php
@@ -10,7 +10,6 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\VerbosityLevel;
 
 /**
  * Made with GPT-5
@@ -34,45 +33,6 @@ final class ArrayTypeLeastCommonDenominatorResolver
         foreach ($types as $type) {
             if (! $type instanceof ArrayType) {
                 return new MixedType();
-            }
-        }
-
-        // If all are ConstantArrayType and have the *same* ordered key list -> preserve shape.
-        $allConstantArrayTypes = array_reduce($types, fn ($c, $t): bool => $c && $t instanceof ConstantArrayType, true);
-        if ($allConstantArrayTypes) {
-            /** @var ConstantArrayType[] $consts */
-            $consts = $types;
-
-            // Compare key sets (by stringified key types)
-            $firstKeys = array_map(
-                fn (Type $type): string => $type->describe(VerbosityLevel::typeOnly()),
-                $consts[0]->getKeyTypes()
-            );
-            foreach ($consts as $c) {
-                $keys = array_map(
-                    fn (Type $type): string => $type->describe(VerbosityLevel::typeOnly()),
-                    $c->getKeyTypes()
-                );
-                if ($keys !== $firstKeys) {
-                    $allConstantArrayTypes = false;
-                    break;
-                }
-            }
-
-            if ($allConstantArrayTypes) {
-                $resultKeyTypes = $consts[0]->getKeyTypes();
-                $valueColumns = [];
-                foreach ($consts as $const) {
-                    $valueColumns[] = $const->getValueTypes();
-                }
-
-                $resultValueTypes = [];
-                foreach (array_keys($resultKeyTypes) as $i) {
-                    $col = array_column($valueColumns, $i);
-                    $resultValueTypes[] = $this->sharedArrayStructure(...$col);
-                }
-
-                return new ConstantArrayType($resultKeyTypes, $resultValueTypes);
             }
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector.php
@@ -304,6 +304,14 @@ CODE_SAMPLE
 
             $className = $classNames[0];
 
+            // skip anonymous classes, they have no usable name
+            if ($this->reflectionProvider->hasClass($className)) {
+                $returnedClassReflection = $this->reflectionProvider->getClass($className);
+                if ($returnedClassReflection->isAnonymous()) {
+                    return null;
+                }
+            }
+
             if ($returnedClass === null) {
                 $returnedClass = $className;
             } elseif ($returnedClass !== $className) {


### PR DESCRIPTION
Fixes narrowing a method return type to an anonymous class name.

When a method returns `$this` from inside an anonymous class, the rule narrowed the return type to the generated anonymous class name (e.g. `\AnonymousClass62d65...`), producing invalid, non-referenceable code.

```php
private function createEmail(): Email
{
    return new class extends Email {
        public function setId(int $id): Email
        {
            $this->id = $id;

            return $this; // was narrowed to \AnonymousClass...
        }
    };
}
```

Now anonymous classes are skipped, keeping the original (correct) `Email` type.