### PR TITLE
[CI] Remove dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,9 +1,0 @@
-version: 2
-
-updates:
-    -
-        package-ecosystem: github-actions
-        directory: "/"
-        open-pull-requests-limit: 5
-        schedule:
-            interval: monthly


### PR DESCRIPTION
Removes `.github/dependabot.yaml`. Dependabot no longer wanted for this repo.