### PR TITLE
[DX] Add typeGuardedClasses() to guard against breaking method signature changes

### DIFF
--- a/rules-tests/TypeDeclaration/TypeGuardedClasses/Fixture/final_child_applied.php.inc
+++ b/rules-tests/TypeDeclaration/TypeGuardedClasses/Fixture/final_child_applied.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\TypeGuardedClasses\Fixture;
+
+use Rector\Tests\TypeDeclaration\TypeGuardedClasses\Source\GuardedRepository;
+
+final class FinalChildApplied extends GuardedRepository
+{
+    public function getData()
+    {
+        return [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\TypeGuardedClasses\Fixture;
+
+use Rector\Tests\TypeDeclaration\TypeGuardedClasses\Source\GuardedRepository;
+
+final class FinalChildApplied extends GuardedRepository
+{
+    public function getData(): array
+    {
+        return [];
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/TypeGuardedClasses/Fixture/skip_child_of_guarded.php.inc
+++ b/rules-tests/TypeDeclaration/TypeGuardedClasses/Fixture/skip_child_of_guarded.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\TypeGuardedClasses\Fixture;
+
+use Rector\Tests\TypeDeclaration\TypeGuardedClasses\Source\GuardedRepository;
+
+class SkipChildOfGuarded extends GuardedRepository
+{
+    public function getData()
+    {
+        return [];
+    }
+}

--- a/rules-tests/TypeDeclaration/TypeGuardedClasses/Source/GuardedRepository.php
+++ b/rules-tests/TypeDeclaration/TypeGuardedClasses/Source/GuardedRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\TypeGuardedClasses\Source;
+
+class GuardedRepository
+{
+    public function getData()
+    {
+        return [];
+    }
+}

--- a/rules-tests/TypeDeclaration/TypeGuardedClasses/TypeGuardedClassesTest.php
+++ b/rules-tests/TypeDeclaration/TypeGuardedClasses/TypeGuardedClassesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\TypeGuardedClasses;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TypeGuardedClassesTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/TypeGuardedClasses/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/TypeGuardedClasses/config/configured_rule.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\MixedType;
+use Rector\Config\RectorConfig;
+use Rector\Tests\TypeDeclaration\TypeGuardedClasses\Source\GuardedRepository;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->typeGuardedClasses([GuardedRepository::class]);
+
+    $rectorConfig->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
+        new AddReturnTypeDeclaration(
+            GuardedRepository::class,
+            'getData',
+            new ArrayType(new MixedType(), new MixedType())
+        ),
+    ]);
+};

--- a/rules/TypeDeclaration/Rector/ClassMethod/AbstractParamTypeByMethodCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AbstractParamTypeByMethodCallTypeRector.php
@@ -99,6 +99,11 @@ abstract class AbstractParamTypeByMethodCallTypeRector extends AbstractRector
 
     private function shouldSkipClassMethod(ClassMethod $classMethod): bool
     {
+        // user-guarded class: adding a param type here would break its child classes
+        if ($this->parentClassMethodTypeOverrideGuard->isTypeGuardedClass($classMethod)) {
+            return true;
+        }
+
         $isMissingParameterTypes = false;
         foreach ($classMethod->params as $param) {
             if ($param->type instanceof Node) {

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationRector.php
@@ -20,6 +20,7 @@ use Rector\Rector\AbstractRector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\TypeDeclaration\ValueObject\AddParamTypeDeclaration;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
@@ -40,6 +41,7 @@ final class AddParamTypeDeclarationRector extends AbstractRector implements Conf
         private readonly TypeComparator $typeComparator,
         private readonly PhpVersionProvider $phpVersionProvider,
         private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
     ) {
     }
 
@@ -84,6 +86,11 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $this->hasChanged = false;
+
+        // skip guarded classes, where adding a param type would break child classes
+        if ($this->parentClassMethodTypeOverrideGuard->isTypeGuardedClass($node)) {
+            return null;
+        }
 
         foreach ($node->getMethods() as $classMethod) {
             if ($this->shouldSkip($node, $classMethod)) {

--- a/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AddReturnTypeDeclarationRector.php
@@ -89,6 +89,11 @@ CODE_SAMPLE
     {
         $this->hasChanged = false;
 
+        // skip guarded classes, where adding a return type would break child classes
+        if ($this->parentClassMethodTypeOverrideGuard->isTypeGuardedClass($node)) {
+            return null;
+        }
+
         foreach ($this->methodReturnTypes as $methodReturnType) {
             $objectType = $methodReturnType->getObjectType();
             if (! $this->isObjectType($node, $objectType)) {

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -327,6 +327,20 @@ final class RectorConfig extends Container
     }
 
     /**
+     * Guard the listed classes and their descendants against method signature changes that would
+     * break child classes - e.g. adding a return type or a param type. Only non-final classes are
+     * guarded, as final classes cannot be extended.
+     *
+     * @param string[] $classes
+     */
+    public function typeGuardedClasses(array $classes): void
+    {
+        Assert::allString($classes);
+
+        SimpleParameterProvider::setParameter(Option::TYPE_GUARDED_CLASSES, $classes);
+    }
+
+    /**
      * @param string[] $extensions
      */
     public function fileExtensions(array $extensions): void

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -286,4 +286,10 @@ final class Option
      * @internal to allow process file without extension if explicitly registered
      */
     public const string FILES_WITHOUT_EXTENSION = 'files_without_extension';
+
+    /**
+     * @internal Use @see \Rector\Config\RectorConfig::typeGuardedClasses() instead
+     * @var string
+     */
+    public const string TYPE_GUARDED_CLASSES = 'type_guarded_classes';
 }

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -163,6 +163,11 @@ final class RectorConfigBuilder
     private ?bool $isTreatClassesAsFinal = null;
 
     /**
+     * @var string[]
+     */
+    private array $typeGuardedClasses = [];
+
+    /**
      * @var RegisteredService[]
      */
     private array $registerServices = [];
@@ -386,6 +391,10 @@ final class RectorConfigBuilder
 
         if ($this->isFluentNewLine !== null) {
             $rectorConfig->newLineOnFluentCall($this->isFluentNewLine);
+        }
+
+        if ($this->typeGuardedClasses !== []) {
+            $rectorConfig->typeGuardedClasses($this->typeGuardedClasses);
         }
 
         if ($this->isTreatClassesAsFinal !== null) {
@@ -1245,6 +1254,18 @@ final class RectorConfigBuilder
     public function withTreatClassesAsFinal(bool $isTreatClassesAsFinal = true): self
     {
         $this->isTreatClassesAsFinal = $isTreatClassesAsFinal;
+        return $this;
+    }
+
+    /**
+     * Guard the listed classes and their non-final descendants against method signature changes
+     * that would break child classes - e.g. adding a return type or a param type.
+     *
+     * @param string[] $typeGuardedClasses
+     */
+    public function withTypeGuardedClasses(array $typeGuardedClasses): self
+    {
+        $this->typeGuardedClasses = $typeGuardedClasses;
         return $this;
     }
 

--- a/src/VendorLocker/NodeVendorLocker/ClassMethodParamVendorLockResolver.php
+++ b/src/VendorLocker/NodeVendorLocker/ClassMethodParamVendorLockResolver.php
@@ -8,18 +8,25 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Reflection\ReflectionResolver;
+use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 
 final readonly class ClassMethodParamVendorLockResolver
 {
     public function __construct(
         private NodeNameResolver $nodeNameResolver,
         private ReflectionResolver $reflectionResolver,
+        private ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
     ) {
     }
 
     public function isVendorLocked(ClassMethod $classMethod): bool
     {
         if ($classMethod->isMagic()) {
+            return true;
+        }
+
+        // user-guarded class: adding a param type here would break its child classes
+        if ($this->parentClassMethodTypeOverrideGuard->isTypeGuardedClass($classMethod)) {
             return true;
         }
 

--- a/src/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
+++ b/src/VendorLocker/NodeVendorLocker/ClassMethodReturnTypeOverrideGuard.php
@@ -28,6 +28,11 @@ final readonly class ClassMethodReturnTypeOverrideGuard
 
     public function shouldSkipClassMethod(ClassMethod $classMethod, Scope $scope): bool
     {
+        // user-guarded class: adding a return type here would break its child classes
+        if ($this->parentClassMethodTypeOverrideGuard->isTypeGuardedClass($classMethod)) {
+            return true;
+        }
+
         if ($this->magicClassMethodAnalyzer->isUnsafeOverridden($classMethod)) {
             return true;
         }

--- a/src/VendorLocker/ParentClassMethodTypeOverrideGuard.php
+++ b/src/VendorLocker/ParentClassMethodTypeOverrideGuard.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Rector\VendorLocker;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Type;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\Reflection\ClassReflectionAnalyzer;
@@ -25,6 +28,39 @@ final readonly class ParentClassMethodTypeOverrideGuard
         private StaticTypeMapper $staticTypeMapper,
         private ClassReflectionAnalyzer $classReflectionAnalyzer
     ) {
+    }
+
+    /**
+     * Is the class user-guarded against method signature changes, via
+     * @see \Rector\Config\RectorConfig::typeGuardedClasses()
+     *
+     * A class is guarded when it - or any of its ancestors - is on the configured list and it is not
+     * final. Adding a return or param type to such a class is a breaking change for its child
+     * classes, so type-declaration rules must leave it untouched. Final classes are never guarded,
+     * as they cannot be extended.
+     */
+    public function isTypeGuardedClass(ClassLike|ClassMethod $node): bool
+    {
+        $guardedClasses = SimpleParameterProvider::provideArrayParameter(Option::TYPE_GUARDED_CLASSES);
+        if ($guardedClasses === []) {
+            return false;
+        }
+
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        // final classes cannot be extended, so adding a type is never a breaking change
+        if ($classReflection->isFinalByKeyword()) {
+            return false;
+        }
+
+        // covers the guarded class itself and all its descendants
+        return array_any(
+            $guardedClasses,
+            static fn (string $guardedClass): bool => $classReflection->is($guardedClass)
+        );
     }
 
     public function hasParentClassMethod(ClassMethod|MethodReflection $classMethod): bool


### PR DESCRIPTION
## What

New config option to protect classes whose method signatures must not change, because doing so would break subclasses in other packages/apps:

```php
return RectorConfig::configure()
    ->withTypeGuardedClasses([SomeContract::class, BaseController::class]);
```

Adding a **return type** or **param type** to a method is a breaking change for any child class that overrides it. When a class is listed here, type-declaration rules leave its method signatures untouched.

## Rules

- Applies to a listed class **and all its descendants** — resolved upward via `ClassReflection::is()`. Rector can't enumerate children at runtime, but a descendant *has* the guarded ancestor, so upward resolution covers the whole subtree.
- **Only non-final classes are guarded** — a `final` class can't be extended, so the change is always safe and still applied.
- When no classes are configured the guard short-circuits, so **existing behaviour is unchanged**.

## How it is wired

The check lives in `ParentClassMethodTypeOverrideGuard::isTypeGuardedClass()` and is applied at the shared choke points so it covers whole rule families, not just individual rules:

| Layer | Covers |
|---|---|
| `ClassMethodReturnTypeOverrideGuard::shouldSkipClassMethod()` | the return-type family (`ReturnTypeFromStrict*`, `Bool/Numeric/StringReturnTypeFrom*`, ...) |
| `ClassMethodParamVendorLockResolver::isVendorLocked()` | the param-type family routed through the param completer |
| `AddReturnTypeDeclarationRector` / `AddParamTypeDeclarationRector` | the configurable rules directly |

This reuses the existing vendor-lock layer, which already answers *"is it unsafe to change this method's type?"* — guarded classes are simply one more reason it is unsafe. (The existing guards handle the **upward** case: don't diverge from a parent contract. This adds the **downward** case: don't break unknown children.)

## Config API

- `RectorConfig::typeGuardedClasses(string[] $classes)`
- `RectorConfigBuilder::withTypeGuardedClasses(string[] $classes)`
- `Option::TYPE_GUARDED_CLASSES`

## Test

`rules-tests/TypeDeclaration/TypeGuardedClasses/` — a non-final child of a guarded class is skipped; a final child still gets the return type added.
