### PR TITLE
[TypeDeclarationDocblocks] Add NarrowArrayCollectionUnionReturnDocblockRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector/Fixture/array_collection_union.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector/Fixture/array_collection_union.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector\Fixture;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+final class ArrayCollectionUnion
+{
+    private $successful;
+
+    /**
+     * @return LeadEventLog[]|ArrayCollection
+     */
+    public function getSuccessful(): ArrayCollection
+    {
+        return $this->successful;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector\Fixture;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+final class ArrayCollectionUnion
+{
+    private $successful;
+
+    /**
+     * @return ArrayCollection<int, LeadEventLog>
+     */
+    public function getSuccessful(): ArrayCollection
+    {
+        return $this->successful;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector/Fixture/reversed_order.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector/Fixture/reversed_order.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector\Fixture;
+
+use Doctrine\Common\Collections\Collection;
+
+final class ReversedOrder
+{
+    private $items;
+
+    /**
+     * @return Collection|Item[]
+     */
+    public function getItems(): Collection
+    {
+        return $this->items;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector\Fixture;
+
+use Doctrine\Common\Collections\Collection;
+
+final class ReversedOrder
+{
+    private $items;
+
+    /**
+     * @return Collection<int, Item>
+     */
+    public function getItems(): Collection
+    {
+        return $this->items;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector/Fixture/skip_already_generic.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector/Fixture/skip_already_generic.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector\Fixture;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+final class SkipAlreadyGeneric
+{
+    private $successful;
+
+    /**
+     * @return ArrayCollection<int, LeadEventLog>
+     */
+    public function getSuccessful(): ArrayCollection
+    {
+        return $this->successful;
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector/Fixture/skip_non_collection_union.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector/Fixture/skip_non_collection_union.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector\Fixture;
+
+final class SkipNonCollectionUnion
+{
+    private $values;
+
+    /**
+     * @return LeadEventLog[]|SomeIterator
+     */
+    public function getValues(): iterable
+    {
+        return $this->values;
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector/NarrowArrayCollectionUnionReturnDocblockRectorTest.php
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector/NarrowArrayCollectionUnionReturnDocblockRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class NarrowArrayCollectionUnionReturnDocblockRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector;
+
+return RectorConfig::configure()
+    ->withRules([NarrowArrayCollectionUnionReturnDocblockRector::class]);

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/NarrowArrayCollectionUnionReturnDocblockRector.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclarationDocblocks\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector\NarrowArrayCollectionUnionReturnDocblockRectorTest
+ */
+final class NarrowArrayCollectionUnionReturnDocblockRector extends AbstractRector
+{
+    /**
+     * @var string[]
+     */
+    private const array COLLECTION_SHORT_NAMES = ['Collection', 'ArrayCollection'];
+
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly DocBlockUpdater $docBlockUpdater,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change @return "Type[]|ArrayCollection" union docblock to a generic "ArrayCollection<int, Type>"',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Doctrine\Common\Collections\ArrayCollection;
+
+class SomeClass
+{
+    /**
+     * @return LeadEventLog[]|ArrayCollection
+     */
+    public function getSuccessful(): ArrayCollection
+    {
+        return $this->successful;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Doctrine\Common\Collections\ArrayCollection;
+
+class SomeClass
+{
+    /**
+     * @return ArrayCollection<int, LeadEventLog>
+     */
+    public function getSuccessful(): ArrayCollection
+    {
+        return $this->successful;
+    }
+}
+CODE_SAMPLE
+                ),
+            ],
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class, Function_::class];
+    }
+
+    /**
+     * @param ClassMethod|Function_ $node
+     */
+    public function refactor(Node $node): null|ClassMethod|Function_
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $returnTagValueNode = $phpDocInfo->getReturnTagValue();
+        if (! $returnTagValueNode instanceof ReturnTagValueNode) {
+            return null;
+        }
+
+        if (! $returnTagValueNode->type instanceof UnionTypeNode) {
+            return null;
+        }
+
+        $genericTypeNode = $this->matchGenericCollectionTypeNode($returnTagValueNode->type);
+        if (! $genericTypeNode instanceof GenericTypeNode) {
+            return null;
+        }
+
+        $returnTagValueNode->type = $genericTypeNode;
+
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+
+        return $node;
+    }
+
+    private function matchGenericCollectionTypeNode(UnionTypeNode $unionTypeNode): ?GenericTypeNode
+    {
+        if (count($unionTypeNode->types) !== 2) {
+            return null;
+        }
+
+        $arrayItemTypeNode = null;
+        $collectionIdentifierTypeNode = null;
+
+        foreach ($unionTypeNode->types as $typeNode) {
+            if ($typeNode instanceof ArrayTypeNode && $typeNode->type instanceof IdentifierTypeNode) {
+                $arrayItemTypeNode = $typeNode->type;
+                continue;
+            }
+
+            if ($typeNode instanceof IdentifierTypeNode && $this->isCollectionIdentifier($typeNode)) {
+                $collectionIdentifierTypeNode = $typeNode;
+            }
+        }
+
+        if (! $arrayItemTypeNode instanceof IdentifierTypeNode) {
+            return null;
+        }
+
+        if (! $collectionIdentifierTypeNode instanceof IdentifierTypeNode) {
+            return null;
+        }
+
+        $genericTypeNodes = [new IdentifierTypeNode('int'), $arrayItemTypeNode];
+        return new GenericTypeNode($collectionIdentifierTypeNode, $genericTypeNodes);
+    }
+
+    private function isCollectionIdentifier(IdentifierTypeNode $identifierTypeNode): bool
+    {
+        $shortName = $this->resolveShortName($identifierTypeNode->name);
+        return in_array($shortName, self::COLLECTION_SHORT_NAMES, true);
+    }
+
+    private function resolveShortName(string $name): string
+    {
+        $name = ltrim($name, '\\');
+
+        $lastBackslashPosition = strrpos($name, '\\');
+        if ($lastBackslashPosition === false) {
+            return $name;
+        }
+
+        return substr($name, $lastBackslashPosition + 1);
+    }
+}

--- a/src/Config/Level/TypeDeclarationDocblocksLevel.php
+++ b/src/Config/Level/TypeDeclarationDocblocksLevel.php
@@ -24,6 +24,7 @@ use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForDimFe
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForJsonArrayRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockGetterReturnArrayFromPropertyDocblockVarRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockReturnArrayFromDirectArrayInstanceRector;
+use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector;
 
 final class TypeDeclarationDocblocksLevel
 {
@@ -62,6 +63,7 @@ final class TypeDeclarationDocblocksLevel
 
         // return
         DocblockGetterReturnArrayFromPropertyDocblockVarRector::class,
+        NarrowArrayCollectionUnionReturnDocblockRector::class,
 
         // run latter after other rules, as more generic
         AddReturnDocblockForDimFetchArrayFromAssignsRector::class,


### PR DESCRIPTION
Adds a docblock rule that rewrites a `Type[]|ArrayCollection` `@return` union into a generic collection type.

### Before
```php
/**
 * @return LeadEventLog[]|ArrayCollection
 */
public function getSuccessful(): ArrayCollection
{
    return $this->successful;
}
```

### After
```php
/**
 * @return ArrayCollection<int, LeadEventLog>
 */
public function getSuccessful(): ArrayCollection
{
    return $this->successful;
}
```

- Matches a 2-type `@return` union of an array shape (`Type[]`) and a collection identifier (`Collection` / `ArrayCollection`, in any order).
- Key type is assumed `int`.
- Registered in `TypeDeclarationDocblocksLevel`.
- Covered with fixtures (transform, reversed order, skip already-generic, skip non-collection union).