### PR TITLE
[TypeDeclaration] Skip type-guarded trait methods in StrictArrayParamDimFetchRector

### DIFF
--- a/rules-tests/TypeDeclaration/TypeGuardedClasses/Fixture/skip_guarded_trait.php.inc
+++ b/rules-tests/TypeDeclaration/TypeGuardedClasses/Fixture/skip_guarded_trait.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\TypeGuardedClasses\Fixture;
+
+trait SkipGuardedTrait
+{
+    public function resolveItem($item)
+    {
+        return $item['name'];
+    }
+}

--- a/rules-tests/TypeDeclaration/TypeGuardedClasses/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/TypeGuardedClasses/config/configured_rule.php
@@ -7,10 +7,16 @@ use PHPStan\Type\MixedType;
 use Rector\Config\RectorConfig;
 use Rector\Tests\TypeDeclaration\TypeGuardedClasses\Source\GuardedRepository;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector;
 use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->typeGuardedClasses([GuardedRepository::class]);
+    $rectorConfig->typeGuardedClasses([
+        GuardedRepository::class,
+        'Rector\Tests\TypeDeclaration\TypeGuardedClasses\Fixture\SkipGuardedTrait',
+    ]);
+
+    $rectorConfig->rule(StrictArrayParamDimFetchRector::class);
 
     $rectorConfig->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
         new AddReturnTypeDeclaration(

--- a/rules/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector.php
@@ -95,6 +95,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node instanceof ClassMethod && $this->parentClassMethodTypeOverrideGuard->isTypeGuardedClass($node)) {
+            return null;
+        }
+
         foreach ($node->getParams() as $param) {
             if ($param->type instanceof Node) {
                 continue;


### PR DESCRIPTION
StrictArrayParamDimFetchRector added an `array` param type to trait methods even when the trait was listed in `withTypeGuardedClasses()`.

Root cause: the rule only checked `hasParentClassMethod()`, never `isTypeGuardedClass()`, so the guard did not apply.

- Add `isTypeGuardedClass()` bail-out to StrictArrayParamDimFetchRector
- The guard already resolves trait reflections correctly (`ClassReflection::is()` matches the trait by name, traits are never final), so no change to `ParentClassMethodTypeOverrideGuard` was needed
- Cover with a guarded-trait skip fixture in the TypeGuardedClasses suite