### PR TITLE
[TypeDeclaration] Skip property fetch on array dim fetch in StrictArrayParamDimFetchRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector/Fixture/skip_instanceof_param.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector/Fixture/skip_instanceof_param.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector\Source\Lead;
+
+class SkipInstanceofParam
+{
+    public function populateCompanyData($entity)
+    {
+        if ($entity instanceof Lead) {
+            $fields = $entity->getPrimaryCompany();
+        } else {
+            $fields = $entity['primaryCompany'];
+        }
+
+        return $fields;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector/Fixture/skip_property_fetch_on_dim_fetch.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector/Fixture/skip_property_fetch_on_dim_fetch.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector\Fixture;
+
+class SkipPropertyFetchOnDimFetch
+{
+    /**
+     * @param object $object
+     */
+    private function getDataForObject($object): mixed
+    {
+        foreach ($object as $key => $value) {
+            if (0 === $key) {
+                continue;
+            }
+
+            $object[0]->$key = $value;
+        }
+
+        return $object[0];
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector/Source/Lead.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector/Source/Lead.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\StrictArrayParamDimFetchRector\Source;
+
+final class Lead
+{
+    /**
+     * @return mixed[]
+     */
+    public function getPrimaryCompany(): array
+    {
+        return [];
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/StrictArrayParamDimFetchRector.php
@@ -16,7 +16,10 @@ use PhpParser\Node\Expr\Cast\Array_;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Empty_;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Identifier;
@@ -244,6 +247,14 @@ CODE_SAMPLE
             return true;
         }
 
+        if ($this->isPropertyFetchedOnArrayDimFetch($node, $paramName)) {
+            return true;
+        }
+
+        if ($this->isInstanceofParam($node, $paramName)) {
+            return true;
+        }
+
         return $this->isReassignAndUseAsArg($node, $paramName);
     }
 
@@ -286,6 +297,28 @@ CODE_SAMPLE
         }
 
         return $node instanceof Array_ && $node->expr instanceof Variable && $this->isName($node->expr, $paramName);
+    }
+
+    private function isPropertyFetchedOnArrayDimFetch(Node $node, string $paramName): bool
+    {
+        if (! $node instanceof PropertyFetch && ! $node instanceof StaticPropertyFetch) {
+            return false;
+        }
+
+        $fetchedOn = $node instanceof PropertyFetch ? $node->var : $node->class;
+        if (! $fetchedOn instanceof ArrayDimFetch) {
+            return false;
+        }
+
+        return $fetchedOn->var instanceof Variable && $this->isName($fetchedOn->var, $paramName);
+    }
+
+    private function isInstanceofParam(Node $node, string $paramName): bool
+    {
+        return $node instanceof Instanceof_ && $node->expr instanceof Variable && $this->isName(
+            $node->expr,
+            $paramName
+        );
     }
 
     private function isMethodCall(string $paramName, ?Node $node): bool


### PR DESCRIPTION
Fix false positive: property fetch on `$param[0]->$key` means the param holds an object, not an array itself, so no `array` type should be added.

```php
/**
 * @param object $object
 */
private function getDataForObject($object): mixed
{
    foreach ($object as $key => $value) {
        if (0 === $key) {
            continue;
        }

        $object[0]->$key = $value;
    }

    return $object[0];
}
```

Guard added in `shouldStop()`: stops when a `PropertyFetch`/`StaticPropertyFetch` targets `$param[...]`.