### PR TITLE
[TypeDeclaration] Add AddClosureParamTypeFromVariableCallRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/AddClosureParamTypeFromVariableCallRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/AddClosureParamTypeFromVariableCallRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddClosureParamTypeFromVariableCallRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Fixture/object_param.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Fixture/object_param.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Source\Item;
+
+final class ObjectParam
+{
+    public function run(): void
+    {
+        $printItem = function ($item) {
+            echo $item->name;
+        };
+
+        $printItem(new Item());
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Source\Item;
+
+final class ObjectParam
+{
+    public function run(): void
+    {
+        $printItem = function (\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Source\Item $item) {
+            echo $item->name;
+        };
+
+        $printItem(new Item());
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Fixture/recursive_form_view.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Fixture/recursive_form_view.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Source\FormView;
+
+final class RecursiveFormView
+{
+    public function setFormTheme(FormView $formView): void
+    {
+        $findThemes = function ($formView) use (&$findThemes): void {
+            $child = $formView['child'];
+            $findThemes($child);
+        };
+
+        $findThemes($formView);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Source\FormView;
+
+final class RecursiveFormView
+{
+    public function setFormTheme(FormView $formView): void
+    {
+        $findThemes = function (\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Source\FormView $formView) use (&$findThemes): void {
+            $child = $formView['child'];
+            $findThemes($child);
+        };
+
+        $findThemes($formView);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Fixture/skip_already_typed.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Fixture/skip_already_typed.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Source\Item;
+
+final class SkipAlreadyTyped
+{
+    public function run(): void
+    {
+        $printItem = function (Item $item) {
+            echo $item->name;
+        };
+
+        $printItem(new Item());
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Fixture/skip_conflicting_types.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Fixture/skip_conflicting_types.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Source\Item;
+use Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Source\Other;
+
+final class SkipConflictingTypes
+{
+    public function run(): void
+    {
+        $printItem = function ($item) {
+            var_dump($item);
+        };
+
+        $printItem(new Item());
+        $printItem(new Other());
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Fixture/skip_scalar_arg.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Fixture/skip_scalar_arg.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Fixture;
+
+final class SkipScalarArg
+{
+    public function run(): void
+    {
+        $printValue = function ($value) {
+            echo $value;
+        };
+
+        $printValue('hello');
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Source/FormView.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Source/FormView.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Source;
+
+/**
+ * @implements \ArrayAccess<string, self>
+ */
+final class FormView implements \ArrayAccess
+{
+    public function offsetExists($offset): bool
+    {
+        return true;
+    }
+
+    public function offsetGet($offset): self
+    {
+        return $this;
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+    }
+
+    public function offsetUnset($offset): void
+    {
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Source/Item.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Source/Item.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Source;
+
+final class Item
+{
+    public string $name = 'item';
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Source/Other.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/Source/Other.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\Source;
+
+final class Other
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector;
+
+return RectorConfig::configure()
+    ->withRules([AddClosureParamTypeFromVariableCallRector::class]);

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeFromVariableCallRector.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\FunctionLike;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\NodeVisitor;
+use PHPStan\Type\ObjectType;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector\AddClosureParamTypeFromVariableCallRectorTest
+ */
+final class AddClosureParamTypeFromVariableCallRector extends AbstractRector
+{
+    public function __construct(
+        private readonly StaticTypeMapper $staticTypeMapper
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add closure param object type based on the argument the assigned closure variable is called with',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$printItem = function ($item) {
+    echo $item->name;
+};
+
+$printItem(new Item());
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$printItem = function (Item $item) {
+    echo $item->name;
+};
+
+$printItem(new Item());
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class, Function_::class, Closure::class];
+    }
+
+    /**
+     * @param ClassMethod|Function_|Closure $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->stmts === null) {
+            return null;
+        }
+
+        $closuresByVariableName = $this->collectAssignedClosures($node->stmts);
+        if ($closuresByVariableName === []) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($closuresByVariableName as $variableName => $closure) {
+            $argumentTypesByPosition = $this->collectCallArgumentTypes($node->stmts, $variableName);
+
+            foreach ($closure->getParams() as $position => $param) {
+                if (! isset($argumentTypesByPosition[$position])) {
+                    continue;
+                }
+
+                if ($this->refactorClosureParam($param, $argumentTypesByPosition[$position])) {
+                    $hasChanged = true;
+                }
+            }
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param Node\Stmt[] $stmts
+     * @return array<string, Closure>
+     */
+    private function collectAssignedClosures(array $stmts): array
+    {
+        $closuresByVariableName = [];
+
+        $this->traverseNodesWithCallable($stmts, function (Node $node) use (&$closuresByVariableName): int|null {
+            // do not descend into nested scopes
+            if ($node instanceof Class_ || $node instanceof FunctionLike) {
+                return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+            }
+
+            if (! $node instanceof Assign) {
+                return null;
+            }
+
+            if (! $node->var instanceof Variable) {
+                return null;
+            }
+
+            if (! $node->expr instanceof Closure) {
+                return null;
+            }
+
+            $variableName = $this->getName($node->var);
+            if ($variableName === null) {
+                return null;
+            }
+
+            $closuresByVariableName[$variableName] = $node->expr;
+            return null;
+        });
+
+        return $closuresByVariableName;
+    }
+
+    /**
+     * @param Node\Stmt[] $stmts
+     * @return array<int, ObjectType>
+     */
+    private function collectCallArgumentTypes(array $stmts, string $variableName): array
+    {
+        $objectTypesByPosition = [];
+        $blockedPositions = [];
+
+        $this->traverseNodesWithCallable($stmts, function (Node $node) use (
+            $variableName,
+            &$objectTypesByPosition,
+            &$blockedPositions
+        ): int|null {
+            // do not descend into nested scopes, e.g. recursive self-calls
+            if ($node instanceof Class_ || $node instanceof FunctionLike) {
+                return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+            }
+
+            if (! $node instanceof FuncCall || $node->isFirstClassCallable()) {
+                return null;
+            }
+
+            if (! $node->name instanceof Variable || ! $this->isName($node->name, $variableName)) {
+                return null;
+            }
+
+            foreach ($node->getArgs() as $position => $arg) {
+                if ($arg->unpack) {
+                    $blockedPositions[$position] = true;
+                    continue;
+                }
+
+                $argType = $this->getType($arg->value);
+                if (! $argType instanceof ObjectType) {
+                    $blockedPositions[$position] = true;
+                    continue;
+                }
+
+                // conflicting object types across calls → skip this position
+                if (isset($objectTypesByPosition[$position])
+                    && $objectTypesByPosition[$position]->getClassName() !== $argType->getClassName()) {
+                    $blockedPositions[$position] = true;
+                    continue;
+                }
+
+                $objectTypesByPosition[$position] = $argType;
+            }
+
+            return null;
+        });
+
+        foreach (array_keys($blockedPositions) as $position) {
+            unset($objectTypesByPosition[$position]);
+        }
+
+        return $objectTypesByPosition;
+    }
+
+    private function refactorClosureParam(Param $param, ObjectType $objectType): bool
+    {
+        if ($param->type instanceof Node) {
+            return false;
+        }
+
+        if ($param->variadic) {
+            return false;
+        }
+
+        $paramTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($objectType, TypeKind::PARAM);
+        if (! $paramTypeNode instanceof Node) {
+            return false;
+        }
+
+        $param->type = $paramTypeNode;
+        return true;
+    }
+}

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -174,6 +174,7 @@ final class TypeDeclarationLevel
         ScalarTypedPropertyFromJMSSerializerAttributeTypeRector::class,
 
         // array parameter from dim fetch assign inside
+        AddClosureParamTypeFromVariableCallRector::class,
         StrictArrayParamDimFetchRector::class,
         AddParamFromDimFetchKeyUseRector::class,
         AddParamStringTypeFromSprintfUseRector::class,
@@ -187,6 +188,5 @@ final class TypeDeclarationLevel
         NarrowArrayAnyAllNullableParamTypeRector::class,
         AddArrayAnyAllClosureParamTypeRector::class,
         ClosureReturnTypeFromAssertInstanceOfRector::class,
-        AddClosureParamTypeFromVariableCallRector::class,
     ];
 }

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -70,6 +70,7 @@ use Rector\TypeDeclaration\Rector\Function_\AddFunctionVoidReturnTypeWhereNoRetu
 use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayReduceRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromIterableMethodCallRector;
+use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeFromVariableCallRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddParamTypeSplFixedArrayRector;
 use Rector\TypeDeclaration\Rector\FunctionLike\AddReturnTypeDeclarationFromYieldsRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
@@ -186,5 +187,6 @@ final class TypeDeclarationLevel
         NarrowArrayAnyAllNullableParamTypeRector::class,
         AddArrayAnyAllClosureParamTypeRector::class,
         ClosureReturnTypeFromAssertInstanceOfRector::class,
+        AddClosureParamTypeFromVariableCallRector::class,
     ];
 }


### PR DESCRIPTION
Complements #8141. Where #8141 *stops* the wrong `array` type on recursive closures walking an `ArrayAccess` tree, this new rule *adds* the correct object type from the call site.

## What it does

When a closure is assigned to a variable and that variable is invoked with a concrete object argument, the object type is added to the matching closure param:

```php
$printItem = function ($item) {   // =>  function (Item $item)
    echo $item->name;
};

$printItem(new Item());
```

Real-world case (Symfony `FormView`):

```diff
-$findThemes = function ($formView) use (&$findThemes) {
+$findThemes = function (FormView $formView) use (&$findThemes) { 
    $child = $formView['child'];
    $findThemes($child);
};

$findThemes($formView); // $formView : FormView
```

## Scope (conservative)

- Only **concrete object types** are added; scalar / array / conflicting-object arguments are skipped (arrays are already handled by `StrictArrayParamDimFetchRector`).
- Nested scopes are not descended into, so a recursive self-call (whose argument is derived inside the closure and thus untyped) does not pollute the inferred type.
- Params already typed or variadic are left untouched.

Covered by fixtures: object param added, recursive FormView, skip already-typed, skip scalar arg, skip conflicting types.