### PR TITLE
Bump php-parser to ^5.8

### DIFF
--- a/compat-tests/composer.json
+++ b/compat-tests/composer.json
@@ -5,7 +5,7 @@
     "require-dev": {
         "php": "^8.2",
         "phpunit/phpunit": "10.*|11.*|12.*",
-        "nikic/php-parser": "5.4.*|5.5.*|5.6.*|5.7.*",
+        "nikic/php-parser": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
         "rector/rector": "dev-main as 2.4.4",
         "phpstan/phpstan": "^2.2",
         "driftingly/rector-laravel": "^2.4"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/inflector": "^2.1",
         "illuminate/container": "12.39.*",
         "nette/utils": "^4.1.4",
-        "nikic/php-parser": "^5.7",
+        "nikic/php-parser": "^5.8",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3",
         "phpstan/phpstan": "^2.2.2",

--- a/rules/Php70/EregToPcreTransformer.php
+++ b/rules/Php70/EregToPcreTransformer.php
@@ -245,6 +245,7 @@ final class EregToPcreTransformer
                         $cls .= $this->_ere2pcre_escape($a) . '\-';
                         break;
                     }
+
                     if (ord($a) > ord($b)) {
                         $errorMessage = sprintf('an invalid character range %d-%d"', (int) $a, (int) $b);
                         throw new InvalidEregException($errorMessage);

--- a/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector.php
+++ b/rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector.php
@@ -117,6 +117,7 @@ CODE_SAMPLE
                 $values = [];
                 break;
             }
+
             if ($value instanceof UnionType) {
                 $values = [...$values, ...$value->getTypes()];
             }
@@ -127,6 +128,7 @@ CODE_SAMPLE
                 $keys = [];
                 break;
             }
+
             if ($key instanceof UnionType) {
                 $keys = [...$keys, ...$key->getTypes()];
             }


### PR DESCRIPTION
nikic/php-parser 5.8 released https://github.com/nikic/PHP-Parser/releases/tag/v5.8.0

with introduce `PhpParser\Lexer\TokenEmulator\FnTokenEmulator` class that cause error:

https://github.com/rectorphp/rector-src/actions/runs/28725126768/job/85181084336#step:7:21

that preload.php add it:

- https://github.com/rectorphp/rector-src/pull/8143

we need new release for it.