### PR TITLE
[TypeDeclaration] Add ReturnTypeFromGetRepositoryDocblockRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/get_repository.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/get_repository.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Source\EventRepository;
+
+final class GetRepository
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @return EventRepository
+     */
+    public function getRepository()
+    {
+        return $this->em->getRepository(Event::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Source\EventRepository;
+
+final class GetRepository
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    public function getRepository(): \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Source\EventRepository
+    {
+        return $this->em->getRepository(Event::class);
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/skip_already_typed.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/skip_already_typed.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Source\EventRepository;
+
+final class SkipAlreadyTyped
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    public function getRepository(): EventRepository
+    {
+        return $this->em->getRepository(Event::class);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/skip_no_docblock.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/skip_no_docblock.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+final class SkipNoDocblock
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    public function getRepository()
+    {
+        return $this->em->getRepository(Event::class);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/skip_non_existing_repository.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/skip_non_existing_repository.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+final class SkipNonExistingRepository
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @return \App\NonExisting\MissingRepository
+     */
+    public function getRepository()
+    {
+        return $this->em->getRepository(Event::class);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/skip_not_entity_manager.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/skip_not_entity_manager.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Fixture;
+
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Source\EventRepository;
+
+final class SkipNotEntityManager
+{
+    public function __construct(private \stdClass $registry)
+    {
+    }
+
+    /**
+     * @return EventRepository
+     */
+    public function getRepository()
+    {
+        return $this->registry->getRepository(Event::class);
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/ReturnTypeFromGetRepositoryDocblockRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/ReturnTypeFromGetRepositoryDocblockRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReturnTypeFromGetRepositoryDocblockRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Source/EventRepository.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Source/EventRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Source;
+
+final class EventRepository
+{
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector;
+
+return RectorConfig::configure()
+    ->withRules([ReturnTypeFromGetRepositoryDocblockRector::class]);

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\ReturnTypeFromGetRepositoryDocblockRectorTest
+ */
+final class ReturnTypeFromGetRepositoryDocblockRector extends AbstractRector
+{
+    private const string ENTITY_MANAGER_INTERFACE = 'Doctrine\ORM\EntityManagerInterface';
+
+    public function __construct(
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add repository return type declaration based on @return docblock, when a method returns entity manager getRepository() fetch',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+final class EventModel
+{
+    public function __construct(private \Doctrine\ORM\EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @return \App\Repository\EventRepository
+     */
+    public function getRepository()
+    {
+        return $this->em->getRepository(Event::class);
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+final class EventModel
+{
+    public function __construct(private \Doctrine\ORM\EntityManagerInterface $em)
+    {
+    }
+
+    public function getRepository(): \App\Repository\EventRepository
+    {
+        return $this->em->getRepository(Event::class);
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        // return type is already set
+        if ($node->returnType instanceof Node) {
+            return null;
+        }
+
+        if (! $this->isGetRepositoryReturnOnly($node)) {
+            return null;
+        }
+
+        $scope = ScopeFetcher::fetch($node);
+        if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($node, $scope)) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $returnType = $phpDocInfo->getReturnType();
+        if (! $returnType instanceof ObjectType) {
+            return null;
+        }
+
+        $returnTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType, TypeKind::RETURN);
+        if (! $returnTypeNode instanceof Name) {
+            return null;
+        }
+
+        // must be an existing repository class
+        if (! $this->reflectionProvider->hasClass($returnTypeNode->toString())) {
+            return null;
+        }
+
+        $node->returnType = $returnTypeNode;
+        $this->removeReturnTag($phpDocInfo, $node);
+
+        return $node;
+    }
+
+    private function isGetRepositoryReturnOnly(ClassMethod $classMethod): bool
+    {
+        $returns = $this->betterNodeFinder->findReturnsScoped($classMethod);
+        if (count($returns) !== 1) {
+            return false;
+        }
+
+        $methodCall = $returns[0]->expr;
+        if (! $methodCall instanceof MethodCall) {
+            return false;
+        }
+
+        if (! $this->isName($methodCall->name, 'getRepository')) {
+            return false;
+        }
+
+        return $this->isEntityManagerType($methodCall);
+    }
+
+    private function isEntityManagerType(MethodCall $methodCall): bool
+    {
+        $callerType = $this->nodeTypeResolver->getType($methodCall->var);
+        if (! $callerType instanceof ObjectType) {
+            return false;
+        }
+
+        if ($callerType->getClassName() === self::ENTITY_MANAGER_INTERFACE) {
+            return true;
+        }
+
+        return $callerType->isInstanceOf(self::ENTITY_MANAGER_INTERFACE)
+            ->yes();
+    }
+
+    private function removeReturnTag(PhpDocInfo $phpDocInfo, ClassMethod $classMethod): void
+    {
+        $returnTagValueNode = $phpDocInfo->getReturnTagValue();
+        if (! $returnTagValueNode instanceof ReturnTagValueNode) {
+            return;
+        }
+
+        $phpDocInfo->removeByType(ReturnTagValueNode::class);
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($classMethod);
+    }
+}

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -40,6 +40,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByParentCallTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNullableTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromMockObjectRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnCastRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnDirectArrayRector;
@@ -188,5 +189,8 @@ final class TypeDeclarationLevel
         NarrowArrayAnyAllNullableParamTypeRector::class,
         AddArrayAnyAllClosureParamTypeRector::class,
         ClosureReturnTypeFromAssertInstanceOfRector::class,
+
+        // docblock @return into native return type, intentionally last
+        ReturnTypeFromGetRepositoryDocblockRector::class,
     ];
 }


### PR DESCRIPTION
Adds `ReturnTypeFromGetRepositoryDocblockRector`.

Moves a `@return` docblock type into a **native return type** when a method's sole return is an `EntityManagerInterface::getRepository()` fetch.

```diff
 final class EventModel
 {
     public function __construct(private \Doctrine\ORM\EntityManagerInterface $em)
     {
     }

-    /**
-     * @return \Mautic\CampaignBundle\Entity\EventRepository
-     */
-    public function getRepository()
+    public function getRepository(): \Mautic\CampaignBundle\Entity\EventRepository
     {
         return $this->em->getRepository(Event::class);
     }
 }
```

### Guards
- skips if a native return type is already present
- exactly one scoped `return`, whose expr is a `getRepository()` method call
- caller must be (or implement) `Doctrine\ORM\EntityManagerInterface`
- `@return` must resolve to a plain, **existing** class (`ReflectionProvider::hasClass`); generic / non-existing types are skipped
- `ClassMethodReturnTypeOverrideGuard` prevents breaking parent/child signatures
- the now-redundant `@return` tag is removed
