### PR TITLE
[DeadCode] Keep generic @var/@return self<...> narrowing annotations

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/skip_generic_return_self.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/skip_generic_return_self.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector\Fixture;
+
+/**
+ * @template TSuccessValue
+ * @template TFailureValue
+ */
+final class SkipGenericReturnSelf
+{
+    /**
+     * @return self<TSuccessValue, never>
+     */
+    public function success(): self
+    {
+        return $this;
+    }
+}

--- a/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/skip_generic_var_on_new_self.php.inc
+++ b/rules-tests/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/skip_generic_var_on_new_self.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector\Fixture;
+
+/**
+ * @template TSuccessValue
+ * @template TFailureValue
+ */
+final class SkipGenericVarOnNewSelf
+{
+    public static function success(mixed $value = null): self
+    {
+        /** @var self<TSuccessValue, never> */
+        return new self();
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StaticType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
@@ -125,6 +126,11 @@ CODE_SAMPLE
         ClassReflection $classReflection
     ): bool {
         $docType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($typeNode, $classMethod);
+
+        // generic narrowing, e.g. @return self<TValue, never> is not a plain duplicate of the native self type
+        if ($docType instanceof GenericObjectType) {
+            return false;
+        }
 
         // covers @return $this and @return static
         if ($docType instanceof StaticType) {

--- a/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
+++ b/rules/DeadCode/Rector/Node/RemoveNonExistingVarAnnotationRector.php
@@ -22,6 +22,7 @@ use PhpParser\Node\Stmt\Static_;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\While_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
@@ -157,7 +158,7 @@ CODE_SAMPLE
 
                 $variableName = ltrim($varTagValueNode->variableName, '$');
 
-                if ($variableName === '' && $this->isAllowedEmptyVariableName($stmt)) {
+                if ($variableName === '' && $this->isAllowedEmptyVariableName($stmt, $varTagValueNode)) {
                     continue;
                 }
 
@@ -252,12 +253,34 @@ CODE_SAMPLE
         return str_contains($varTagValueNode->description, '}');
     }
 
-    private function isAllowedEmptyVariableName(Stmt $stmt): bool
+    private function isAllowedEmptyVariableName(Stmt $stmt, VarTagValueNode $varTagValueNode): bool
     {
         if ($stmt instanceof Return_ && $stmt->expr instanceof CallLike && ! $stmt->expr instanceof New_) {
             return true;
         }
 
+        // generic/template narrowing over the instantiated class, e.g. /** @var self<TValue, never> */ return new self(...)
+        if ($stmt instanceof Return_ && $stmt->expr instanceof New_ && $this->isGenericTypeOfNewClass(
+            $stmt->expr,
+            $varTagValueNode
+        )) {
+            return true;
+        }
+
         return $stmt instanceof Expression && $stmt->expr instanceof Assign && $stmt->expr->var instanceof Variable;
+    }
+
+    private function isGenericTypeOfNewClass(New_ $new, VarTagValueNode $varTagValueNode): bool
+    {
+        if (! $varTagValueNode->type instanceof GenericTypeNode) {
+            return false;
+        }
+
+        $newClassName = $this->getName($new->class);
+        if ($newClassName === null) {
+            return false;
+        }
+
+        return strcasecmp($varTagValueNode->type->type->name, $newClassName) === 0;
     }
 }


### PR DESCRIPTION
Fixes rectorphp/rector#9793

Two DeadCode rules stripped **valid generic type annotations** that narrow the return type of a generic class via template specialization. The `@var self<...>` / `@return self<...>` add information that the native `self` type / `new self()` cannot express, so they must be kept.

## `RemoveNonExistingVarAnnotationRector`

An empty-name `@var` before `return new self(...)` was removed, because `New_` returns were explicitly excluded (a plain `@var array<...>` on `new stdClass` really is unwanted). Now it is kept when the `@var` is a **generic type over the instantiated class**.

```php
 final class Result
 {
     public static function success(mixed $value = null): self
     {
         /** @var self<TSuccessValue, never> */
         return new self(true, value: $value);
     }
 }
```

Before: the docblock was removed. After: kept.

A mismatched annotation such as `/** @var array<string, string> */ return new stdClass;` is still removed (base type `array` != `stdClass`).

## `RemoveDuplicatedReturnSelfDocblockRector`

`@return self<...>` maps to a `GenericObjectType` (subclass of `ObjectType`) whose class name equals the current class, so it was treated as a duplicate of the native `self` return type and removed. Generic doc types are now skipped.

```php
 final class Result
 {
     /**
      * @return self<TSuccessValue, never>
      */
     public function success(): self
     {
         return $this;
     }
 }
```

Before: the docblock was removed. After: kept. Bare `@return self` / `@return $this` / `@return static` are still removed as before.

## Tests

New skip fixtures for both rules covering the generic case.
