### PR TITLE
[TypeDeclaration] Handle getRepository() return via local variable in ReturnTypeFromGetRepositoryDocblockRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/get_repository_via_variable.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/get_repository_via_variable.php.inc
@@ -1,0 +1,54 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Source\EventRepository;
+
+final class GetRepositoryViaVariable
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @return EventRepository
+     */
+    public function getRepository()
+    {
+        /** @var EventRepository $repo */
+        $repo = $this->em->getRepository(Event::class);
+
+        $repo->setDispatcher($this->dispatcher);
+
+        return $repo;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Source\EventRepository;
+
+final class GetRepositoryViaVariable
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    public function getRepository(): \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Source\EventRepository
+    {
+        /** @var EventRepository $repo */
+        $repo = $this->em->getRepository(Event::class);
+
+        $repo->setDispatcher($this->dispatcher);
+
+        return $repo;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/skip_reassigned_variable.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector/Fixture/skip_reassigned_variable.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector\Source\EventRepository;
+
+final class SkipReassignedVariable
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @return EventRepository
+     */
+    public function getRepository()
+    {
+        $repo = $this->em->getRepository(Event::class);
+        $repo = someOther();
+
+        return $repo;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
@@ -141,16 +143,59 @@ CODE_SAMPLE
             return false;
         }
 
-        $methodCall = $returns[0]->expr;
-        if (! $methodCall instanceof MethodCall) {
-            return false;
+        $returnedExpr = $returns[0]->expr;
+
+        // direct return: return $this->em->getRepository(...);
+        if ($returnedExpr instanceof MethodCall) {
+            return $this->isGetRepositoryMethodCall($returnedExpr);
         }
 
+        // indirect return: $repo = $this->em->getRepository(...); ...; return $repo;
+        if ($returnedExpr instanceof Variable) {
+            $assignedMethodCall = $this->findVariableAssignMethodCall($classMethod, $returnedExpr);
+            if (! $assignedMethodCall instanceof MethodCall) {
+                return false;
+            }
+
+            return $this->isGetRepositoryMethodCall($assignedMethodCall);
+        }
+
+        return false;
+    }
+
+    private function isGetRepositoryMethodCall(MethodCall $methodCall): bool
+    {
         if (! $this->isName($methodCall->name, 'getRepository')) {
             return false;
         }
 
         return $this->isEntityManagerType($methodCall);
+    }
+
+    private function findVariableAssignMethodCall(ClassMethod $classMethod, Variable $variable): ?MethodCall
+    {
+        /** @var Assign[] $assigns */
+        $assigns = $this->betterNodeFinder->findInstanceOf($classMethod, Assign::class);
+
+        $methodCall = null;
+        foreach ($assigns as $assign) {
+            if (! $assign->var instanceof Variable) {
+                continue;
+            }
+
+            if (! $this->nodeComparator->areNodesEqual($assign->var, $variable)) {
+                continue;
+            }
+
+            // reassigned to something else, cannot be sure of the type
+            if (! $assign->expr instanceof MethodCall) {
+                return null;
+            }
+
+            $methodCall = $assign->expr;
+        }
+
+        return $methodCall;
     }
 
     private function isEntityManagerType(MethodCall $methodCall): bool


### PR DESCRIPTION
Extends `ReturnTypeFromGetRepositoryDocblockRector` to also add the return type when the repository is fetched into a local variable, mutated, then returned - not only when returned directly.

### Before

```php
final class LeadModel
{
    public function __construct(private \Doctrine\ORM\EntityManagerInterface $em)
    {
    }

    /**
     * @return LeadListRepository
     */
    public function getRepository()
    {
        /** @var LeadListRepository $repo */
        $repo = $this->em->getRepository(LeadList::class);

        $repo->setDispatcher($this->dispatcher);
        $repo->setTranslator($this->translator);

        return $repo;
    }
}
```

### After

```php
final class LeadModel
{
    public function __construct(private \Doctrine\ORM\EntityManagerInterface $em)
    {
    }

    public function getRepository(): LeadListRepository
    {
        /** @var LeadListRepository $repo */
        $repo = $this->em->getRepository(LeadList::class);

        $repo->setDispatcher($this->dispatcher);
        $repo->setTranslator($this->translator);

        return $repo;
    }
}
```

Bails out when the returned variable is reassigned to a non-`getRepository()` expression, to avoid a wrong type.
