### PR TITLE
Keep generic static union docblock in `RemoveDuplicatedReturnSelfDocblockRector`

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/skip_generic_union_return_self.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector/Fixture/skip_generic_union_return_self.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector\Fixture;
+
+/**
+ * @template TFirst of scalar
+ */
+abstract readonly class SkipGenericUnionReturnSelf
+{
+    /**
+     * @return static<string|int>
+     */
+    public function get(): self
+    {
+        return $this;
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveDuplicatedReturnSelfDocblockRector.php
@@ -12,6 +12,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Generic\GenericStaticType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StaticType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
@@ -128,7 +129,7 @@ CODE_SAMPLE
         $docType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($typeNode, $classMethod);
 
         // generic narrowing, e.g. @return self<TValue, never> is not a plain duplicate of the native self type
-        if ($docType instanceof GenericObjectType) {
+        if ($docType instanceof GenericObjectType || $docType instanceof GenericStaticType) {
             return false;
         }
 


### PR DESCRIPTION
`RemoveDuplicatedReturnSelfDocblockRector` incorrectly strips `@return static<string|int>` docblocks when the native return type is self. The rule already preserved `GenericObjectType` annotations (e.g. `self<TValue, never>`) but did not account for `GenericStaticType`.

This adds a `GenericStaticType` check so that generic `@return static<...>` narrowing annotations are kept, and adds a fixture to cover the case.