### PR TITLE
[CodeQuality] Wrap assign on right side of binary op in LogicalToBooleanRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector/Fixture/assign_on_right.php.inc
+++ b/rules-tests/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector/Fixture/assign_on_right.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+true and $x = 42 and false;
+
+var_dump($x);
+
+?>
+-----
+<?php
+
+true && ($x = 42) && false;
+
+var_dump($x);
+
+?>

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -478,6 +478,12 @@ final class BetterStandardPrinter extends Standard
             $node->left->setAttribute(AttributeKey::ORIGINAL_NODE, null);
         }
 
+        if ($node->right instanceof Assign
+            && $this->origTokens instanceof TokenStream
+            && ! $this->origTokens->haveParens($node->right->getStartTokenPos(), $node->right->getEndTokenPos())) {
+            $node->right->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        }
+
         if ($node->left instanceof BinaryOp &&
             $node->left->getAttribute(AttributeKey::ORIGINAL_NODE) instanceof Node) {
             $node->left->setAttribute(AttributeKey::ORIGINAL_NODE, null);


### PR DESCRIPTION
Fixes rectorphp/rector#9797

`LogicalToBooleanRector` missed parentheses around an assignment sitting on the **right-hand side** of a boolean operator, producing code that is not equivalent to the input.

## Before

```php
true and $x = 42 and false;
```

was rewritten to:

```php
true && $x = 42 && false;
```

which PHP parses as `true && ($x = (42 && false))` — so `$x` is assigned `false` instead of `42`.

## After

```php
true && ($x = 42) && false;
```

## Cause

`BetterStandardPrinter::wrapBinaryOpWithBrackets()` already forced a reprint (adding parentheses) when the **left** operand of a binary op was an `Assign`, but had no symmetric handling for the **right** operand. Added the mirror check.

The left-hand case (already covered) stays correct:

```diff
-$f = false and true;
+($f = false) && true;
```
