### PR TITLE
[CodeQuality] Preserve parentheses around right-side assign in LogicalToBooleanRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector/Fixture/assign_with_existing_parentheses.php.inc
+++ b/rules-tests/CodeQuality/Rector/LogicalAnd/LogicalToBooleanRector/Fixture/assign_with_existing_parentheses.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+true and ($x = 42) and false;
+
+var_dump($x);
+
+?>
+-----
+<?php
+
+true && ($x = 42) && false;
+
+var_dump($x);
+
+?>

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -478,9 +478,7 @@ final class BetterStandardPrinter extends Standard
             $node->left->setAttribute(AttributeKey::ORIGINAL_NODE, null);
         }
 
-        if ($node->right instanceof Assign
-            && $this->origTokens instanceof TokenStream
-            && ! $this->origTokens->haveParens($node->right->getStartTokenPos(), $node->right->getEndTokenPos())) {
+        if ($node->right instanceof Assign && $this->origTokens instanceof TokenStream) {
             $node->right->setAttribute(AttributeKey::ORIGINAL_NODE, null);
         }
 


### PR DESCRIPTION
Fixes rectorphp/rector#9799

`LogicalToBooleanRector` dropped the parentheses around an assignment sitting on the **right/nested side** of a boolean operator, silently changing semantics.

## Before

```php
true and ($x = 42) and false;
```

was rewritten to:

```php
true && $x = 42 && false;
```

which PHP parses as `true && ($x = (42 && false))` — so `$x` becomes `false` instead of `42`.

## After

```php
true && ($x = 42) && false;
```

## Cause

`BetterStandardPrinter::wrapBinaryOpWithBrackets()` reprinted the right operand only when `!haveParens`. But the source parens in `($x = 42)` live in the **parent** node's token range, not the `Assign` node's — so `haveParens` reports `true`, the reprint is skipped, and the newly pretty-printed `&&` node drops them anyway.

Reprint the right `Assign` unconditionally. The pretty-printer is context-aware and only adds parentheses when semantically needed:

```diff
-is_int(1) and $x = 5;
+is_int(1) && $x = 5;        // no following op -> stays paren-free

-true and $x = 42 and false;
+true && ($x = 42) && false; // following && -> parens added
```

Left-operand handling keeps its `!haveParens` guard: removing it double-wraps cases like `($c = $x) ?? $d` whose parent node preserves its own token gaps.
