### PR TITLE
[TypeDeclaration] Add PrivateMethodReturnTypeFromStrictNewArrayRector, split private methods out

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector/Fixture/private_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector/Fixture/private_method.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\PrivateMethodReturnTypeFromStrictNewArrayRector\Fixture;
+
+final class PrivateMethod
+{
+    private function run()
+    {
+        $values = [];
+
+        return $values;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\PrivateMethodReturnTypeFromStrictNewArrayRector\Fixture;
+
+final class PrivateMethod
+{
+    private function run(): array
+    {
+        $values = [];
+
+        return $values;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector/Fixture/private_method_list_doc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector/Fixture/private_method_list_doc.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\PrivateMethodReturnTypeFromStrictNewArrayRector\Fixture;
+
+final class PrivateMethodListDoc
+{
+    private function run()
+    {
+        $values = [];
+        $values[] = 'item';
+
+        return $values;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\PrivateMethodReturnTypeFromStrictNewArrayRector\Fixture;
+
+final class PrivateMethodListDoc
+{
+    /**
+     * @return list<'item'>
+     */
+    private function run(): array
+    {
+        $values = [];
+        $values[] = 'item';
+
+        return $values;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector/Fixture/skip_protected_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector/Fixture/skip_protected_method.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\PrivateMethodReturnTypeFromStrictNewArrayRector\Fixture;
+
+final class SkipProtectedMethod
+{
+    protected function run()
+    {
+        $values = [];
+
+        return $values;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector/Fixture/skip_public_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector/Fixture/skip_public_method.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\PrivateMethodReturnTypeFromStrictNewArrayRector\Fixture;
+
+final class SkipPublicMethod
+{
+    public function run()
+    {
+        $values = [];
+
+        return $values;
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector/PrivateMethodReturnTypeFromStrictNewArrayRectorTest.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector/PrivateMethodReturnTypeFromStrictNewArrayRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\PrivateMethodReturnTypeFromStrictNewArrayRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class PrivateMethodReturnTypeFromStrictNewArrayRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector/config/configured_rule.php
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\ClassMethod\PrivateMethodReturnTypeFromStrictNewArrayRector;
+
+return RectorConfig::configure()
+    ->withRules([PrivateMethodReturnTypeFromStrictNewArrayRector::class]);

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector/Fixture/skip_private_method.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector/Fixture/skip_private_method.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector\Fixture;
+
+final class SkipPrivateMethod
+{
+    private function run()
+    {
+        $values = [];
+
+        return $values;
+    }
+}

--- a/rules/CodeQuality/Rector/If_/ExplicitBoolCompareRector.php
+++ b/rules/CodeQuality/Rector/If_/ExplicitBoolCompareRector.php
@@ -276,11 +276,8 @@ CODE_SAMPLE
         return new NotIdentical($expr, $float);
     }
 
-    private function resolveNullable(
-        bool $isNegated,
-        Expr $expr,
-        ObjectType $objectType
-    ): BooleanNot|Instanceof_ {
+    private function resolveNullable(bool $isNegated, Expr $expr, ObjectType $objectType): BooleanNot|Instanceof_
+    {
         $fullyQualified = new FullyQualified($objectType->getClassName());
         $instanceof = new Instanceof_($expr, $fullyQualified);
 

--- a/rules/Naming/Matcher/VariableAndCallAssignMatcher.php
+++ b/rules/Naming/Matcher/VariableAndCallAssignMatcher.php
@@ -41,7 +41,10 @@ final readonly class VariableAndCallAssignMatcher
 
         $isVariableFoundInCallArgs = (bool) $this->betterNodeFinder->findFirst(
             $call->isFirstClassCallable() ? [] : $call->getArgs(),
-            fn (Node $subNode): bool => $subNode instanceof Variable && $this->nodeNameResolver->isName($subNode, $variableName)
+            fn (Node $subNode): bool => $subNode instanceof Variable && $this->nodeNameResolver->isName(
+                $subNode,
+                $variableName
+            )
         );
 
         if ($isVariableFoundInCallArgs) {

--- a/rules/Privatization/NodeManipulator/VisibilityManipulator.php
+++ b/rules/Privatization/NodeManipulator/VisibilityManipulator.php
@@ -188,10 +188,8 @@ final class VisibilityManipulator
     /**
      * @api
      */
-    private function addVisibilityFlag(
-        Class_|ClassMethod|Property|ClassConst|Param $node,
-        int $visibility
-    ): void {
+    private function addVisibilityFlag(Class_|ClassMethod|Property|ClassConst|Param $node, int $visibility): void
+    {
         $node->flags |= $visibility;
     }
 

--- a/rules/TypeDeclaration/NodeAnalyzer/StrictReturnNewArrayResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/StrictReturnNewArrayResolver.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\NodeAnalyzer;
+
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\PhpParser\Comparing\NodeComparator;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
+
+/**
+ * Shared array return type resolution for ReturnTypeFromStrictNewArrayRector
+ * and PrivateMethodReturnTypeFromStrictNewArrayRector.
+ */
+final readonly class StrictReturnNewArrayResolver
+{
+    public function __construct(
+        private PhpDocTypeChanger $phpDocTypeChanger,
+        private ReturnTypeInferer $returnTypeInferer,
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private BetterNodeFinder $betterNodeFinder,
+        private ReturnAnalyzer $returnAnalyzer,
+        private NodeComparator $nodeComparator,
+        private NodeTypeResolver $nodeTypeResolver,
+        private NodeNameResolver $nodeNameResolver
+    ) {
+    }
+
+    /**
+     * @return ClassMethod|Function_|null the passed node when an array return type was added, null otherwise
+     */
+    public function resolve(ClassMethod|Function_ $node): ClassMethod|Function_|null
+    {
+        // 1. is variable instantiated with array
+        $stmts = $node->stmts;
+        if ($stmts === null) {
+            return null;
+        }
+
+        $variables = $this->matchArrayAssignedVariable($stmts);
+        if ($variables === []) {
+            return null;
+        }
+
+        $returns = $this->betterNodeFinder->findReturnsScoped($node);
+        if (! $this->returnAnalyzer->hasOnlyReturnWithExpr($node, $returns)) {
+            return null;
+        }
+
+        $variables = $this->matchVariableNotOverriddenByNonArray($node, $variables);
+        if ($variables === []) {
+            return null;
+        }
+
+        if (count($returns) > 1) {
+            $returnType = $this->returnTypeInferer->inferFunctionLike($node);
+            return $this->processAddArrayReturnType($node, $returnType);
+        }
+
+        $onlyReturn = $returns[0];
+        if (! $onlyReturn->expr instanceof Variable) {
+            return null;
+        }
+
+        if (! $this->nodeComparator->isNodeEqual($onlyReturn->expr, $variables)) {
+            return null;
+        }
+
+        $returnType = $this->nodeTypeResolver->getNativeType($onlyReturn->expr);
+        return $this->processAddArrayReturnType($node, $returnType);
+    }
+
+    private function processAddArrayReturnType(
+        ClassMethod|Function_ $node,
+        Type $returnType
+    ): ClassMethod|Function_|null {
+        if (! $returnType->isArray()->yes()) {
+            return null;
+        }
+
+        // always returns array
+        $node->returnType = new Identifier('array');
+
+        // add more precise array type if suitable
+        if ($this->shouldAddReturnArrayDocType($returnType)) {
+            $this->changeReturnType($node, $returnType);
+        }
+
+        return $node;
+    }
+
+    private function changeReturnType(ClassMethod|Function_ $node, Type $arrayType): void
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+
+        // skip already filled type, on purpose
+        if (! $phpDocInfo->getReturnType() instanceof MixedType) {
+            return;
+        }
+
+        // can handle only exactly 1-type array
+        if ($arrayType instanceof ConstantArrayType && count($arrayType->getValueTypes()) !== 1) {
+            return;
+        }
+
+        $itemType = $arrayType->getIterableValueType();
+        if ($itemType instanceof IntersectionType) {
+            $narrowArrayType = $arrayType;
+        } else {
+            $narrowArrayType = new ArrayType(new MixedType(), $itemType);
+        }
+
+        if ($arrayType->isList()->yes()) {
+            $narrowArrayType = TypeCombinator::intersect($narrowArrayType, new AccessoryArrayListType());
+        }
+
+        $this->phpDocTypeChanger->changeReturnType($node, $phpDocInfo, $narrowArrayType);
+    }
+
+    /**
+     * @param Variable[] $variables
+     * @return Variable[]
+     */
+    private function matchVariableNotOverriddenByNonArray(ClassMethod|Function_ $functionLike, array $variables): array
+    {
+        // is variable overridden?
+        /** @var Assign[] $assigns */
+        $assigns = $this->betterNodeFinder->findInstancesOfInFunctionLikeScoped($functionLike, Assign::class);
+        foreach ($assigns as $assign) {
+            if (! $assign->var instanceof Variable) {
+                continue;
+            }
+
+            foreach ($variables as $key => $variable) {
+                if (! $this->nodeNameResolver->areNamesEqual($assign->var, $variable)) {
+                    continue;
+                }
+
+                if ($assign->expr instanceof Array_) {
+                    continue;
+                }
+
+                $nativeType = $this->nodeTypeResolver->getNativeType($assign->expr);
+                if (! $nativeType->isArray()->yes()) {
+                    unset($variables[$key]);
+                }
+            }
+        }
+
+        return $variables;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     * @return Variable[]
+     */
+    private function matchArrayAssignedVariable(array $stmts): array
+    {
+        $variables = [];
+        foreach ($stmts as $stmt) {
+            if (! $stmt instanceof Expression) {
+                continue;
+            }
+
+            if (! $stmt->expr instanceof Assign) {
+                continue;
+            }
+
+            $assign = $stmt->expr;
+            if (! $assign->var instanceof Variable) {
+                continue;
+            }
+
+            $nativeType = $this->nodeTypeResolver->getNativeType($assign->expr);
+            if ($nativeType->isArray()->yes()) {
+                $variables[] = $assign->var;
+            }
+        }
+
+        return $variables;
+    }
+
+    private function shouldAddReturnArrayDocType(Type $arrayType): bool
+    {
+        if ($arrayType instanceof ConstantArrayType) {
+            if ($arrayType->getIterableValueType() instanceof NeverType) {
+                return false;
+            }
+
+            // handle only simple arrays
+            if (! $arrayType->getIterableKeyType()->isInteger()->yes()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector.php
@@ -7,14 +7,11 @@ namespace Rector\TypeDeclaration\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
-use PhpParser\Node\Stmt\Function_;
-use PHPStan\Analyser\Scope;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -26,24 +23,21 @@ use PHPStan\Type\TypeCombinator;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\PhpParser\Node\BetterNodeFinder;
-use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnAnalyzer;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 use Rector\ValueObject\PhpVersion;
-use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector\ReturnTypeFromStrictNewArrayRectorTest
+ * @see \Rector\Tests\TypeDeclaration\Rector\ClassMethod\PrivateMethodReturnTypeFromStrictNewArrayRector\PrivateMethodReturnTypeFromStrictNewArrayRectorTest
  */
-final class ReturnTypeFromStrictNewArrayRector extends AbstractRector implements MinPhpVersionInterface
+final class PrivateMethodReturnTypeFromStrictNewArrayRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
-        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
         private readonly ReturnTypeInferer $returnTypeInferer,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly BetterNodeFinder $betterNodeFinder,
@@ -53,12 +47,14 @@ final class ReturnTypeFromStrictNewArrayRector extends AbstractRector implements
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Add strict return array type based on created empty array and returned', [
-            new CodeSample(
-                <<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Add strict return array type to private methods based on created empty array and returned',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run()
+    private function run()
     {
         $values = [];
 
@@ -67,11 +63,11 @@ final class SomeClass
 }
 CODE_SAMPLE
 
-                ,
-                <<<'CODE_SAMPLE'
+                    ,
+                    <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run(): array
+    private function run(): array
     {
         $values = [];
 
@@ -79,8 +75,9 @@ final class SomeClass
     }
 }
 CODE_SAMPLE
-            ),
-        ]);
+                ),
+            ]
+        );
     }
 
     /**
@@ -88,16 +85,15 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [ClassMethod::class, Function_::class];
+        return [ClassMethod::class];
     }
 
     /**
-     * @param ClassMethod|Function_ $node
+     * @param ClassMethod $node
      */
     public function refactor(Node $node): ?Node
     {
-        $scope = ScopeFetcher::fetch($node);
-        if ($this->shouldSkip($node, $scope)) {
+        if ($this->shouldSkip($node)) {
             return null;
         }
 
@@ -145,45 +141,35 @@ CODE_SAMPLE
         return PhpVersion::PHP_70;
     }
 
-    private function processAddArrayReturnType(
-        ClassMethod|Function_|Closure $node,
-        Type $returnType
-    ): ClassMethod|Function_|Closure|null {
+    private function processAddArrayReturnType(ClassMethod $classMethod, Type $returnType): ?ClassMethod
+    {
         if (! $returnType->isArray()->yes()) {
             return null;
         }
 
         // always returns array
-        $node->returnType = new Identifier('array');
+        $classMethod->returnType = new Identifier('array');
 
         // add more precise array type if suitable
         if ($this->shouldAddReturnArrayDocType($returnType)) {
-            $this->changeReturnType($node, $returnType);
+            $this->changeReturnType($classMethod, $returnType);
         }
 
-        return $node;
+        return $classMethod;
     }
 
-    private function shouldSkip(ClassMethod|Function_|Closure $node, Scope $scope): bool
+    private function shouldSkip(ClassMethod $classMethod): bool
     {
-        if ($node->returnType instanceof Node) {
+        if (! $classMethod->isPrivate()) {
             return true;
         }
 
-        // private methods are handled by PrivateMethodReturnTypeFromStrictNewArrayRector
-        if ($node instanceof ClassMethod && $node->isPrivate()) {
-            return true;
-        }
-
-        return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(
-            $node,
-            $scope
-        );
+        return $classMethod->returnType instanceof Node;
     }
 
-    private function changeReturnType(ClassMethod|Function_|Closure $node, Type $arrayType): void
+    private function changeReturnType(ClassMethod $classMethod, Type $arrayType): void
     {
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
 
         // skip already filled type, on purpose
         if (! $phpDocInfo->getReturnType() instanceof MixedType) {
@@ -206,20 +192,18 @@ CODE_SAMPLE
             $narrowArrayType = TypeCombinator::intersect($narrowArrayType, new AccessoryArrayListType());
         }
 
-        $this->phpDocTypeChanger->changeReturnType($node, $phpDocInfo, $narrowArrayType);
+        $this->phpDocTypeChanger->changeReturnType($classMethod, $phpDocInfo, $narrowArrayType);
     }
 
     /**
      * @param Variable[] $variables
      * @return Variable[]
      */
-    private function matchVariableNotOverriddenByNonArray(
-        ClassMethod|Function_ $functionLike,
-        array $variables
-    ): array {
+    private function matchVariableNotOverriddenByNonArray(ClassMethod $classMethod, array $variables): array
+    {
         // is variable overridden?
         /** @var Assign[] $assigns */
-        $assigns = $this->betterNodeFinder->findInstancesOfInFunctionLikeScoped($functionLike, Assign::class);
+        $assigns = $this->betterNodeFinder->findInstancesOfInFunctionLikeScoped($classMethod, Assign::class);
         foreach ($assigns as $assign) {
             if (! $assign->var instanceof Variable) {
                 continue;

--- a/rules/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/PrivateMethodReturnTypeFromStrictNewArrayRector.php
@@ -5,27 +5,9 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Expression;
-use PHPStan\Type\Accessory\AccessoryArrayListType;
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayType;
-use PHPStan\Type\IntersectionType;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\NeverType;
-use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
-use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
-use Rector\TypeDeclaration\NodeAnalyzer\ReturnAnalyzer;
-use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
+use Rector\TypeDeclaration\NodeAnalyzer\StrictReturnNewArrayResolver;
 use Rector\ValueObject\PhpVersion;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -37,11 +19,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class PrivateMethodReturnTypeFromStrictNewArrayRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly PhpDocTypeChanger $phpDocTypeChanger,
-        private readonly ReturnTypeInferer $returnTypeInferer,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ReturnAnalyzer $returnAnalyzer
+        private readonly StrictReturnNewArrayResolver $strictReturnNewArrayResolver
     ) {
     }
 
@@ -97,65 +75,12 @@ CODE_SAMPLE
             return null;
         }
 
-        // 1. is variable instantiated with array
-        $stmts = $node->stmts;
-        if ($stmts === null) {
-            return null;
-        }
-
-        $variables = $this->matchArrayAssignedVariable($stmts);
-        if ($variables === []) {
-            return null;
-        }
-
-        $returns = $this->betterNodeFinder->findReturnsScoped($node);
-        if (! $this->returnAnalyzer->hasOnlyReturnWithExpr($node, $returns)) {
-            return null;
-        }
-
-        $variables = $this->matchVariableNotOverriddenByNonArray($node, $variables);
-        if ($variables === []) {
-            return null;
-        }
-
-        if (count($returns) > 1) {
-            $returnType = $this->returnTypeInferer->inferFunctionLike($node);
-            return $this->processAddArrayReturnType($node, $returnType);
-        }
-
-        $onlyReturn = $returns[0];
-        if (! $onlyReturn->expr instanceof Variable) {
-            return null;
-        }
-
-        if (! $this->nodeComparator->isNodeEqual($onlyReturn->expr, $variables)) {
-            return null;
-        }
-
-        $returnType = $this->nodeTypeResolver->getNativeType($onlyReturn->expr);
-        return $this->processAddArrayReturnType($node, $returnType);
+        return $this->strictReturnNewArrayResolver->resolve($node);
     }
 
     public function provideMinPhpVersion(): int
     {
         return PhpVersion::PHP_70;
-    }
-
-    private function processAddArrayReturnType(ClassMethod $classMethod, Type $returnType): ?ClassMethod
-    {
-        if (! $returnType->isArray()->yes()) {
-            return null;
-        }
-
-        // always returns array
-        $classMethod->returnType = new Identifier('array');
-
-        // add more precise array type if suitable
-        if ($this->shouldAddReturnArrayDocType($returnType)) {
-            $this->changeReturnType($classMethod, $returnType);
-        }
-
-        return $classMethod;
     }
 
     private function shouldSkip(ClassMethod $classMethod): bool
@@ -165,112 +90,5 @@ CODE_SAMPLE
         }
 
         return $classMethod->returnType instanceof Node;
-    }
-
-    private function changeReturnType(ClassMethod $classMethod, Type $arrayType): void
-    {
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-
-        // skip already filled type, on purpose
-        if (! $phpDocInfo->getReturnType() instanceof MixedType) {
-            return;
-        }
-
-        // can handle only exactly 1-type array
-        if ($arrayType instanceof ConstantArrayType && count($arrayType->getValueTypes()) !== 1) {
-            return;
-        }
-
-        $itemType = $arrayType->getIterableValueType();
-        if ($itemType instanceof IntersectionType) {
-            $narrowArrayType = $arrayType;
-        } else {
-            $narrowArrayType = new ArrayType(new MixedType(), $itemType);
-        }
-
-        if ($arrayType->isList()->yes()) {
-            $narrowArrayType = TypeCombinator::intersect($narrowArrayType, new AccessoryArrayListType());
-        }
-
-        $this->phpDocTypeChanger->changeReturnType($classMethod, $phpDocInfo, $narrowArrayType);
-    }
-
-    /**
-     * @param Variable[] $variables
-     * @return Variable[]
-     */
-    private function matchVariableNotOverriddenByNonArray(ClassMethod $classMethod, array $variables): array
-    {
-        // is variable overridden?
-        /** @var Assign[] $assigns */
-        $assigns = $this->betterNodeFinder->findInstancesOfInFunctionLikeScoped($classMethod, Assign::class);
-        foreach ($assigns as $assign) {
-            if (! $assign->var instanceof Variable) {
-                continue;
-            }
-
-            foreach ($variables as $key => $variable) {
-                if (! $this->nodeNameResolver->areNamesEqual($assign->var, $variable)) {
-                    continue;
-                }
-
-                if ($assign->expr instanceof Array_) {
-                    continue;
-                }
-
-                $nativeType = $this->nodeTypeResolver->getNativeType($assign->expr);
-                if (! $nativeType->isArray()->yes()) {
-                    unset($variables[$key]);
-                }
-            }
-        }
-
-        return $variables;
-    }
-
-    /**
-     * @param Stmt[] $stmts
-     * @return Variable[]
-     */
-    private function matchArrayAssignedVariable(array $stmts): array
-    {
-        $variables = [];
-        foreach ($stmts as $stmt) {
-            if (! $stmt instanceof Expression) {
-                continue;
-            }
-
-            if (! $stmt->expr instanceof Assign) {
-                continue;
-            }
-
-            $assign = $stmt->expr;
-            if (! $assign->var instanceof Variable) {
-                continue;
-            }
-
-            $nativeType = $this->nodeTypeResolver->getNativeType($assign->expr);
-            if ($nativeType->isArray()->yes()) {
-                $variables[] = $assign->var;
-            }
-        }
-
-        return $variables;
-    }
-
-    private function shouldAddReturnArrayDocType(Type $arrayType): bool
-    {
-        if ($arrayType instanceof ConstantArrayType) {
-            if ($arrayType->getIterableValueType() instanceof NeverType) {
-                return false;
-            }
-
-            // handle only simple arrays
-            if (! $arrayType->getIterableKeyType()->isInteger()->yes()) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector.php
@@ -5,31 +5,12 @@ declare(strict_types=1);
 namespace Rector\TypeDeclaration\Rector\ClassMethod;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\Closure;
-use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
-use PHPStan\Type\Accessory\AccessoryArrayListType;
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayType;
-use PHPStan\Type\IntersectionType;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\NeverType;
-use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
-use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
-use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
-use Rector\TypeDeclaration\NodeAnalyzer\ReturnAnalyzer;
-use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
+use Rector\TypeDeclaration\NodeAnalyzer\StrictReturnNewArrayResolver;
 use Rector\ValueObject\PhpVersion;
 use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -42,12 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class ReturnTypeFromStrictNewArrayRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly PhpDocTypeChanger $phpDocTypeChanger,
         private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
-        private readonly ReturnTypeInferer $returnTypeInferer,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ReturnAnalyzer $returnAnalyzer
+        private readonly StrictReturnNewArrayResolver $strictReturnNewArrayResolver
     ) {
     }
 
@@ -101,43 +78,7 @@ CODE_SAMPLE
             return null;
         }
 
-        // 1. is variable instantiated with array
-        $stmts = $node->stmts;
-        if ($stmts === null) {
-            return null;
-        }
-
-        $variables = $this->matchArrayAssignedVariable($stmts);
-        if ($variables === []) {
-            return null;
-        }
-
-        $returns = $this->betterNodeFinder->findReturnsScoped($node);
-        if (! $this->returnAnalyzer->hasOnlyReturnWithExpr($node, $returns)) {
-            return null;
-        }
-
-        $variables = $this->matchVariableNotOverriddenByNonArray($node, $variables);
-        if ($variables === []) {
-            return null;
-        }
-
-        if (count($returns) > 1) {
-            $returnType = $this->returnTypeInferer->inferFunctionLike($node);
-            return $this->processAddArrayReturnType($node, $returnType);
-        }
-
-        $onlyReturn = $returns[0];
-        if (! $onlyReturn->expr instanceof Variable) {
-            return null;
-        }
-
-        if (! $this->nodeComparator->isNodeEqual($onlyReturn->expr, $variables)) {
-            return null;
-        }
-
-        $returnType = $this->nodeTypeResolver->getNativeType($onlyReturn->expr);
-        return $this->processAddArrayReturnType($node, $returnType);
+        return $this->strictReturnNewArrayResolver->resolve($node);
     }
 
     public function provideMinPhpVersion(): int
@@ -145,26 +86,7 @@ CODE_SAMPLE
         return PhpVersion::PHP_70;
     }
 
-    private function processAddArrayReturnType(
-        ClassMethod|Function_|Closure $node,
-        Type $returnType
-    ): ClassMethod|Function_|Closure|null {
-        if (! $returnType->isArray()->yes()) {
-            return null;
-        }
-
-        // always returns array
-        $node->returnType = new Identifier('array');
-
-        // add more precise array type if suitable
-        if ($this->shouldAddReturnArrayDocType($returnType)) {
-            $this->changeReturnType($node, $returnType);
-        }
-
-        return $node;
-    }
-
-    private function shouldSkip(ClassMethod|Function_|Closure $node, Scope $scope): bool
+    private function shouldSkip(ClassMethod|Function_ $node, Scope $scope): bool
     {
         if ($node->returnType instanceof Node) {
             return true;
@@ -179,114 +101,5 @@ CODE_SAMPLE
             $node,
             $scope
         );
-    }
-
-    private function changeReturnType(ClassMethod|Function_|Closure $node, Type $arrayType): void
-    {
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-
-        // skip already filled type, on purpose
-        if (! $phpDocInfo->getReturnType() instanceof MixedType) {
-            return;
-        }
-
-        // can handle only exactly 1-type array
-        if ($arrayType instanceof ConstantArrayType && count($arrayType->getValueTypes()) !== 1) {
-            return;
-        }
-
-        $itemType = $arrayType->getIterableValueType();
-        if ($itemType instanceof IntersectionType) {
-            $narrowArrayType = $arrayType;
-        } else {
-            $narrowArrayType = new ArrayType(new MixedType(), $itemType);
-        }
-
-        if ($arrayType->isList()->yes()) {
-            $narrowArrayType = TypeCombinator::intersect($narrowArrayType, new AccessoryArrayListType());
-        }
-
-        $this->phpDocTypeChanger->changeReturnType($node, $phpDocInfo, $narrowArrayType);
-    }
-
-    /**
-     * @param Variable[] $variables
-     * @return Variable[]
-     */
-    private function matchVariableNotOverriddenByNonArray(
-        ClassMethod|Function_ $functionLike,
-        array $variables
-    ): array {
-        // is variable overridden?
-        /** @var Assign[] $assigns */
-        $assigns = $this->betterNodeFinder->findInstancesOfInFunctionLikeScoped($functionLike, Assign::class);
-        foreach ($assigns as $assign) {
-            if (! $assign->var instanceof Variable) {
-                continue;
-            }
-
-            foreach ($variables as $key => $variable) {
-                if (! $this->nodeNameResolver->areNamesEqual($assign->var, $variable)) {
-                    continue;
-                }
-
-                if ($assign->expr instanceof Array_) {
-                    continue;
-                }
-
-                $nativeType = $this->nodeTypeResolver->getNativeType($assign->expr);
-                if (! $nativeType->isArray()->yes()) {
-                    unset($variables[$key]);
-                }
-            }
-        }
-
-        return $variables;
-    }
-
-    /**
-     * @param Stmt[] $stmts
-     * @return Variable[]
-     */
-    private function matchArrayAssignedVariable(array $stmts): array
-    {
-        $variables = [];
-        foreach ($stmts as $stmt) {
-            if (! $stmt instanceof Expression) {
-                continue;
-            }
-
-            if (! $stmt->expr instanceof Assign) {
-                continue;
-            }
-
-            $assign = $stmt->expr;
-            if (! $assign->var instanceof Variable) {
-                continue;
-            }
-
-            $nativeType = $this->nodeTypeResolver->getNativeType($assign->expr);
-            if ($nativeType->isArray()->yes()) {
-                $variables[] = $assign->var;
-            }
-        }
-
-        return $variables;
-    }
-
-    private function shouldAddReturnArrayDocType(Type $arrayType): bool
-    {
-        if ($arrayType instanceof ConstantArrayType) {
-            if ($arrayType->getIterableValueType() instanceof NeverType) {
-                return false;
-            }
-
-            // handle only simple arrays
-            if (! $arrayType->getIterableKeyType()->isInteger()->yes()) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -38,6 +38,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\NumericReturnTypeFromStrictScalarR
 use Rector\TypeDeclaration\Rector\ClassMethod\ObjectParamTypeByMethodCallTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByParentCallTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\PrivateMethodReturnTypeFromStrictNewArrayRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNullableTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromGetRepositoryDocblockRector;
@@ -98,6 +99,8 @@ final class TypeDeclarationLevel
 
         AddArrowFunctionReturnTypeRector::class,
         BoolReturnTypeFromBooleanConstReturnsRector::class,
+        // private methods first, as safest - no external contract
+        PrivateMethodReturnTypeFromStrictNewArrayRector::class,
         ReturnTypeFromStrictNewArrayRector::class,
 
         // scalar and array from constant

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -135,7 +135,10 @@ final readonly class BetterNodeFinder
     public function findFirstNonAnonymousClass(array $nodes): ?Node
     {
         // skip anonymous classes
-        return $this->findFirst($nodes, fn (Node $node): bool => $node instanceof Class_ && ! $this->classAnalyzer->isAnonymousClass($node));
+        return $this->findFirst(
+            $nodes,
+            fn (Node $node): bool => $node instanceof Class_ && ! $this->classAnalyzer->isAnonymousClass($node)
+        );
     }
 
     /**
@@ -298,6 +301,9 @@ final readonly class BetterNodeFinder
     {
         Assert::isAOf($type, Node::class);
 
-        return $this->nodeFinder->findFirst($nodes, fn (Node $node): bool => $node instanceof $type && $this->nodeNameResolver->isName($node, $name));
+        return $this->nodeFinder->findFirst(
+            $nodes,
+            fn (Node $node): bool => $node instanceof $type && $this->nodeNameResolver->isName($node, $name)
+        );
     }
 }


### PR DESCRIPTION
Splits private-method handling out of `ReturnTypeFromStrictNewArrayRector` into a dedicated, safer rule.

Private methods have no external contract (can't be overridden), so they're the safest case for adding a strict array return type. The new rule runs **above** the original in the type-declaration level order, and the original now skips private methods.

## New rule: `PrivateMethodReturnTypeFromStrictNewArrayRector`

Handles **private methods only**. Drops the `ClassMethodReturnTypeOverrideGuard` check the original needs, since private methods can't be overridden.

```diff
 final class SomeClass
 {
-    private function run()
+    private function run(): array
     {
         $values = [];

         return $values;
     }
 }
```

## Changed: `ReturnTypeFromStrictNewArrayRector`

Now skips private methods (handled by the new rule above); still covers functions and public/protected methods.

```diff
 private function shouldSkip(ClassMethod|Function_|Closure $node, Scope $scope): bool
 {
     if ($node->returnType instanceof Node) {
         return true;
     }

+    // private methods are handled by PrivateMethodReturnTypeFromStrictNewArrayRector
+    if ($node instanceof ClassMethod && $node->isPrivate()) {
+        return true;
+    }
+
     return $node instanceof ClassMethod && $this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod(...);
 }
```

New rule registered directly above the original in `TypeDeclarationLevel`.
