### PR TITLE
[CodeQuality] Skip inner function referenced as string callable in InnerFunctionToPrivateMethodRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InnerFunctionToPrivateMethodRector/Fixture/skip_string_callable.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InnerFunctionToPrivateMethodRector/Fixture/skip_string_callable.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InnerFunctionToPrivateMethodRector\Fixture;
+
+class SkipStringCallable
+{
+    public static function getOptions()
+    {
+        function sortByOrder(array $a, array $b): int
+        {
+            return strcmp((string) $a['label'], (string) $b['label']);
+        }
+
+        $options = [
+            ['value' => 'b', 'label' => 'Bravo'],
+            ['value' => 'a', 'label' => 'Alpha'],
+        ];
+
+        usort($options, 'sortByOrder');
+        return $options;
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/InnerFunctionToPrivateMethodRector.php
+++ b/rules/CodeQuality/Rector/Class_/InnerFunctionToPrivateMethodRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
@@ -133,6 +134,11 @@ CODE_SAMPLE
                 continue;
             }
 
+            // avoid breaking string callables, e.g. usort($items, 'functionName')
+            if ($this->isReferencedAsStringCallable($classMethod, $functionName)) {
+                continue;
+            }
+
             $existingMethodNames[] = $functionName;
             $innerFunctions[] = $stmt;
             unset($classMethod->stmts[$key]);
@@ -143,6 +149,24 @@ CODE_SAMPLE
         }
 
         return $innerFunctions;
+    }
+
+    private function isReferencedAsStringCallable(ClassMethod $classMethod, string $functionName): bool
+    {
+        $isReferenced = false;
+
+        $this->traverseNodesWithCallable($classMethod->stmts ?? [], function (Node $node) use (
+            $functionName,
+            &$isReferenced
+        ): null {
+            if ($node instanceof String_ && $node->value === $functionName) {
+                $isReferenced = true;
+            }
+
+            return null;
+        });
+
+        return $isReferenced;
     }
 
     private function createPrivateMethod(Function_ $innerFunction, bool $isStatic): ClassMethod


### PR DESCRIPTION
Fixes rectorphp/rector#9801

`InnerFunctionToPrivateMethodRector` only rewrites `FuncCall` references (`inner()`) when converting an inner function to a private method. If the inner function is referenced as a **string callable** (e.g. `usort($items, 'sortByOrder')`), that reference is a `String_` node and is left untouched — the function gets moved into a private method while the call site still points at a now non-existent global function. With `RemoveUnusedPrivateMethodRector` also enabled, the "unused" method is then deleted entirely.

This PR skips the transformation when the inner function name is referenced as a string within the method, keeping working code intact.

### Before

```php
class Demo
{
    public static function getOptions()
    {
        function sortByOrder(array $a, array $b): int
        {
            return strcmp((string) $a['label'], (string) $b['label']);
        }

        usort($options, 'sortByOrder');
        return $options;
    }
}
```

was rewritten to broken code — `sortByOrder()` moved to a private method, but `usort($options, 'sortByOrder')` still referencing the removed global function.

### After

No change — the inner function is left as-is, because it is referenced by string callable and cannot be safely rewritten.
