### PR TITLE
[CodeQuality] Skip alternative syntax (if/endif) in ShortenElseIfRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/If_/ShortenElseIfRector/Fixture/skip_alternative_syntax.php.inc
+++ b/rules-tests/CodeQuality/Rector/If_/ShortenElseIfRector/Fixture/skip_alternative_syntax.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\If_\ShortenElseIfRector\Fixture;
+
+function skipAlternativeSyntax($n, $c, $x, $e, $d)
+{
+    if ($n == $c) :
+        $a = 1;
+    else :
+        if ($x || $n <= $e) :
+            $a = 2;
+        elseif ($d && ! $x) :
+            $a = 3;
+        endif;
+    endif;
+
+    return $a;
+}

--- a/rules-tests/CodeQuality/Rector/If_/ShortenElseIfRector/Fixture/skip_inner_alternative_syntax.php.inc
+++ b/rules-tests/CodeQuality/Rector/If_/ShortenElseIfRector/Fixture/skip_inner_alternative_syntax.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\If_\ShortenElseIfRector\Fixture;
+
+function skipInnerAlternativeSyntax($cond1, $cond2)
+{
+    if ($cond1) {
+        $a = 1;
+    } else {
+        if ($cond2) :
+            $a = 2;
+        endif;
+    }
+
+    return $a;
+}

--- a/rules/CodeQuality/Rector/If_/ShortenElseIfRector.php
+++ b/rules/CodeQuality/Rector/If_/ShortenElseIfRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\ElseIf_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Nop;
+use PhpParser\Token;
 use Rector\Contract\Rector\HTMLAverseRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
@@ -89,6 +90,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // alternative syntax (if/else/endif) cannot be merged to elseif without producing mixed brace/colon syntax
+        if ($this->isAlternativeSyntax($node) || $this->isAlternativeSyntax($if)) {
+            return null;
+        }
+
         // Try to shorten the nested if before transforming it to elseif
         $refactored = $this->shortenElseIf($if);
 
@@ -113,5 +119,33 @@ CODE_SAMPLE
         $node->elseifs = array_merge($node->elseifs, $if->elseifs);
 
         return $node;
+    }
+
+    private function isAlternativeSyntax(If_ $if): bool
+    {
+        $startTokenPos = $if->cond->getEndTokenPos();
+        if ($startTokenPos < 0) {
+            return false;
+        }
+
+        $oldTokens = $this->getFile()
+            ->getOldTokens();
+
+        for ($i = $startTokenPos + 1; isset($oldTokens[$i]); ++$i) {
+            $token = $oldTokens[$i];
+            if (! $token instanceof Token) {
+                continue;
+            }
+
+            if ($token->text === ':') {
+                return true;
+            }
+
+            if ($token->text === '{') {
+                return false;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Fixes rectorphp/rector#9803

`ShortenElseIfRector` produced invalid PHP when a file used the alternative control syntax (`if:` / `else:` / `endif`). It merged `else { if }` into `elseif` regardless of syntax style: the freshly created `ElseIf_` node prints braces while the surrounding unchanged nodes keep their colons, yielding mixed brace/colon output that fails to parse (and drops the trailing `endif`).

### Before (broken output)

```php
if ($n == $c) {
    $a = 1;
} elseif ($x || $n <= $e) {
    $a = 2;
} elseif ($d && ! $x) :
    $a = 3;
```

> PHP Parse error: syntax error, unexpected token `:`

### After

Files using alternative syntax are skipped, both when the outer `if` uses it and when only the nested `if` does. Normal brace syntax is unchanged:

```diff
 if ($cond1) {
     return $action1;
-} else {
-    if ($cond2) {
-        return $action2;
-    }
+} elseif ($cond2) {
+    return $action2;
 }
```

Detection reuses the same `getOldTokens()` token-scan approach as the sibling `CompleteMissingIfElseBracketRector`: scan tokens after the condition and skip if `:` appears before `{`.

Two `skip_*` fixtures added (full alternative syntax + brace-outer/alt-inner).
