### PR TITLE
[CodingStyle] Add AlternativeIfToBracketRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/If_/AlternativeIfToBracketRector/AlternativeIfToBracketRectorTest.php
+++ b/rules-tests/CodingStyle/Rector/If_/AlternativeIfToBracketRector/AlternativeIfToBracketRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodingStyle\Rector\If_\AlternativeIfToBracketRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AlternativeIfToBracketRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodingStyle/Rector/If_/AlternativeIfToBracketRector/Fixture/if_elseif_else.php.inc
+++ b/rules-tests/CodingStyle/Rector/If_/AlternativeIfToBracketRector/Fixture/if_elseif_else.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\If_\AlternativeIfToBracketRector\Fixture;
+
+function ifElseIf($a, $b)
+{
+    if ($a) :
+        $x = 1;
+    elseif ($b) :
+        $x = 2;
+    else :
+        $x = 3;
+    endif;
+
+    return $x;
+}
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\If_\AlternativeIfToBracketRector\Fixture;
+
+function ifElseIf($a, $b)
+{
+    if ($a) {
+        $x = 1;
+    } elseif ($b) {
+        $x = 2;
+    } else {
+        $x = 3;
+    }
+
+    return $x;
+}

--- a/rules-tests/CodingStyle/Rector/If_/AlternativeIfToBracketRector/Fixture/nested_if.php.inc
+++ b/rules-tests/CodingStyle/Rector/If_/AlternativeIfToBracketRector/Fixture/nested_if.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\If_\AlternativeIfToBracketRector\Fixture;
+
+function nestedIf($a, $b)
+{
+    if ($a) :
+        $x = 1;
+    else :
+        if ($b) :
+            $x = 2;
+        endif;
+    endif;
+
+    return $x;
+}
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\If_\AlternativeIfToBracketRector\Fixture;
+
+function nestedIf($a, $b)
+{
+    if ($a) {
+        $x = 1;
+    } else if ($b) {
+        $x = 2;
+    }
+
+    return $x;
+}

--- a/rules-tests/CodingStyle/Rector/If_/AlternativeIfToBracketRector/Fixture/simple_if.php.inc
+++ b/rules-tests/CodingStyle/Rector/If_/AlternativeIfToBracketRector/Fixture/simple_if.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\If_\AlternativeIfToBracketRector\Fixture;
+
+function simpleIf($value)
+{
+    if ($value) :
+        $result = 1;
+    endif;
+
+    return $result;
+}
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\If_\AlternativeIfToBracketRector\Fixture;
+
+function simpleIf($value)
+{
+    if ($value) {
+        $result = 1;
+    }
+
+    return $result;
+}

--- a/rules-tests/CodingStyle/Rector/If_/AlternativeIfToBracketRector/Fixture/skip_bracket.php.inc
+++ b/rules-tests/CodingStyle/Rector/If_/AlternativeIfToBracketRector/Fixture/skip_bracket.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\If_\AlternativeIfToBracketRector\Fixture;
+
+function skipBracket($a, $b)
+{
+    if ($a) {
+        $x = 1;
+    } elseif ($b) {
+        $x = 2;
+    } else {
+        $x = 3;
+    }
+
+    return $x;
+}

--- a/rules-tests/CodingStyle/Rector/If_/AlternativeIfToBracketRector/config/configured_rule.php
+++ b/rules-tests/CodingStyle/Rector/If_/AlternativeIfToBracketRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodingStyle\Rector\If_\AlternativeIfToBracketRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([AlternativeIfToBracketRector::class]);

--- a/rules/CodingStyle/Rector/If_/AlternativeIfToBracketRector.php
+++ b/rules/CodingStyle/Rector/If_/AlternativeIfToBracketRector.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Rector\If_;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Token;
+use Rector\Contract\Rector\HTMLAverseRectorInterface;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\CodingStyle\Rector\If_\AlternativeIfToBracketRector\AlternativeIfToBracketRectorTest
+ */
+final class AlternativeIfToBracketRector extends AbstractRector implements HTMLAverseRectorInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change alternative if/elseif/else/endif syntax to bracket syntax', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+if ($value) :
+    $result = 1;
+else :
+    $result = 2;
+endif;
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+if ($value) {
+    $result = 1;
+} else {
+    $result = 2;
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [If_::class];
+    }
+
+    /**
+     * @param If_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isAlternativeSyntax($node)) {
+            return null;
+        }
+
+        // force reprint of the whole if/elseif/else chain with bracket syntax
+        $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+
+        foreach ($node->elseifs as $elseif) {
+            $elseif->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        }
+
+        if ($node->else instanceof Node) {
+            $node->else->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        }
+
+        return $node;
+    }
+
+    private function isAlternativeSyntax(If_ $if): bool
+    {
+        $startTokenPos = $if->cond->getEndTokenPos();
+        if ($startTokenPos < 0) {
+            return false;
+        }
+
+        $oldTokens = $this->getFile()
+            ->getOldTokens();
+
+        for ($i = $startTokenPos + 1; isset($oldTokens[$i]); ++$i) {
+            $token = $oldTokens[$i];
+            if (! $token instanceof Token) {
+                continue;
+            }
+
+            if ($token->text === ':') {
+                return true;
+            }
+
+            if ($token->text === '{') {
+                return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -83,6 +83,7 @@ use Rector\CodeQuality\Rector\Ternary\SwitchNegatedTernaryRector;
 use Rector\CodeQuality\Rector\Ternary\TernaryEmptyArrayArrayDimFetchToCoalesceRector;
 use Rector\CodeQuality\Rector\Ternary\TernaryImplodeToImplodeRector;
 use Rector\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector;
+use Rector\CodingStyle\Rector\If_\AlternativeIfToBracketRector;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\Php52\Rector\Property\VarToPublicPropertyRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
@@ -186,6 +187,7 @@ final class CodeQualityLevel
         DisallowedEmptyRuleFixerRector::class,
         LocallyCalledStaticMethodToNonStaticRector::class,
         NumberCompareToMaxFuncCallRector::class,
+        AlternativeIfToBracketRector::class,
         CompleteMissingIfElseBracketRector::class,
         RemoveUselessIsObjectCheckRector::class,
         ConvertStaticToSelfRector::class,


### PR DESCRIPTION
Follow-up to #8157.

Adds `AlternativeIfToBracketRector` (CodingStyle) that converts the alternative `if`/`elseif`/`else`/`endif` control syntax to bracket syntax. Complements #8157, where `ShortenElseIfRector` now *skips* alternative syntax rather than producing broken mixed output — this rule lets you normalize such files to braces instead.

### Change

```diff
-if ($value) :
+if ($value) {
     $result = 1;
-else :
+} else {
     $result = 2;
-endif;
+}
```

Full chain:

```diff
-if ($a) :
+if ($a) {
     $x = 1;
-elseif ($b) :
+} elseif ($b) {
     $x = 2;
-else :
+} else {
     $x = 3;
-endif;
+}
```

### How

Detects alternative syntax with the same `getOldTokens()` scan used by the sibling `CompleteMissingIfElseBracketRector` (a `:` before `{` after the condition), then clears `ORIGINAL_NODE` on the `if`, its `elseif`s and `else` to force a bracket reprint. Bracket syntax is left untouched. Implements `HTMLAverseRectorInterface` so template files mixing inline HTML are skipped.
