### PR TITLE
[CodeQuality] Skip same boolean in both branches in SimplifyIfReturnBoolRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/If_/SimplifyIfReturnBoolRector/Fixture/skip_same_bool_return.php.inc
+++ b/rules-tests/CodeQuality/Rector/If_/SimplifyIfReturnBoolRector/Fixture/skip_same_bool_return.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\If_\SimplifyIfReturnBoolRector\Fixture;
+
+function skipSameBoolReturnFalse(): false
+{
+    return false;
+}
+
+function skipSameBoolReturn(): bool
+{
+    if (! skipSameBoolReturnFalse()) {
+        return true;
+    }
+
+    return true;
+}

--- a/rules/CodeQuality/Rector/If_/SimplifyIfReturnBoolRector.php
+++ b/rules/CodeQuality/Rector/If_/SimplifyIfReturnBoolRector.php
@@ -141,6 +141,13 @@ CODE_SAMPLE
             return true;
         }
 
+        // both branches return the same boolean → condition is pointless, transform would be unsound
+        if ($this->valueResolver->isTrueOrFalse($return->expr) && $this->valueResolver->isTrue(
+            $returnedExpr
+        ) === $this->valueResolver->isTrue($return->expr)) {
+            return true;
+        }
+
         // negate + negate → skip for now
         if (! $this->valueResolver->isFalse($returnedExpr)) {
             return ! $this->valueResolver->isTrueOrFalse($return->expr);


### PR DESCRIPTION
Fixes rectorphp/rector#9798

When both the `if` branch and the trailing statement return the **same** boolean, the condition does not affect the result, yet `SimplifyIfReturnBoolRector` rewrote it using the condition — producing a wrong result and dropping the condition's side effect.

### Before (buggy output)

```php
function test(): bool
{
    if (! return_false()) {
        return true;
    }

    return true;
}
```

was rewritten to:

```php
function test(): bool
{
    return return_false(); // wrong — original always returns true
}
```

### After

Left unchanged — both branches return the same boolean, so the rule now bails out.

### Fix

`shouldSkipIfAndReturn()` now skips when the inner return and the trailing return are the same boolean value.
