### PR TITLE
[Php56] Add missing parentheses for lower-precedence operands in PowToExpRector

### DIFF
--- a/rules-tests/Php56/Rector/FuncCall/PowToExpRector/Fixture/keep_bare_right_operand.php.inc
+++ b/rules-tests/Php56/Rector/FuncCall/PowToExpRector/Fixture/keep_bare_right_operand.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\Php56\Rector\FuncCall\PowToExpRector\Fixture;
+
+function keepBareRightOperand($a)
+{
+    echo pow(2, -3);
+    echo pow(2, ~3);
+    echo pow(2, (int) $a);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php56\Rector\FuncCall\PowToExpRector\Fixture;
+
+function keepBareRightOperand($a)
+{
+    echo 2 ** -3;
+    echo 2 ** ~3;
+    echo 2 ** (int) $a;
+}
+
+?>

--- a/rules-tests/Php56/Rector/FuncCall/PowToExpRector/Fixture/lower_precedence_operands.php.inc
+++ b/rules-tests/Php56/Rector/FuncCall/PowToExpRector/Fixture/lower_precedence_operands.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\Php56\Rector\FuncCall\PowToExpRector\Fixture;
+
+function lowerPrecedenceOperands($a)
+{
+    echo pow(~3, 4);
+    echo pow(!3, 4);
+    echo pow((int) "5x", 2);
+    echo pow($a += 4, 3);
+    echo pow($a ? 4 : 3, 2);
+    echo pow(2, $a ? 3 : 4);
+    echo pow(2, $a = 4);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php56\Rector\FuncCall\PowToExpRector\Fixture;
+
+function lowerPrecedenceOperands($a)
+{
+    echo (~3) ** 4;
+    echo (!3) ** 4;
+    echo ((int) "5x") ** 2;
+    echo ($a += 4) ** 3;
+    echo ($a ? 4 : 3) ** 2;
+    echo 2 ** ($a ? 3 : 4);
+    echo 2 ** ($a = 4);
+}
+
+?>

--- a/rules/Php56/Rector/FuncCall/PowToExpRector.php
+++ b/rules/Php56/Rector/FuncCall/PowToExpRector.php
@@ -5,23 +5,9 @@ declare(strict_types=1);
 namespace Rector\Php56\Rector\FuncCall;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\AssignOp;
-use PhpParser\Node\Expr\AssignRef;
 use PhpParser\Node\Expr\BinaryOp\Pow;
-use PhpParser\Node\Expr\BitwiseNot;
-use PhpParser\Node\Expr\BooleanNot;
-use PhpParser\Node\Expr\Cast;
-use PhpParser\Node\Expr\ErrorSuppress;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\Instanceof_;
-use PhpParser\Node\Expr\Print_;
-use PhpParser\Node\Expr\Ternary;
-use PhpParser\Node\Expr\UnaryMinus;
-use PhpParser\Node\Expr\UnaryPlus;
-use PhpParser\Node\Expr\Yield_;
-use PhpParser\Node\Expr\YieldFrom;
+use Rector\NodeAnalyzer\PowOperandAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
@@ -34,6 +20,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class PowToExpRector extends AbstractRector implements MinPhpVersionInterface
 {
+    public function __construct(
+        private readonly PowOperandAnalyzer $powOperandAnalyzer
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -70,11 +61,11 @@ final class PowToExpRector extends AbstractRector implements MinPhpVersionInterf
 
         // ** binds tighter than most operators, so operands with lower precedence must be
         // wrapped in parentheses to keep the original semantics, e.g. pow(~3, 4) => (~3) ** 4
-        if ($this->isLowerPrecedenceThanPowLeft($firstExpr)) {
+        if ($this->powOperandAnalyzer->isLowerPrecedenceAsLeftOperand($firstExpr)) {
             $firstExpr->setAttribute(AttributeKey::WRAPPED_IN_PARENTHESES, true);
         }
 
-        if ($this->isLowerPrecedenceThanPowRight($secondExpr)) {
+        if ($this->powOperandAnalyzer->isLowerPrecedenceAsRightOperand($secondExpr)) {
             $secondExpr->setAttribute(AttributeKey::WRAPPED_IN_PARENTHESES, true);
         }
 
@@ -84,46 +75,5 @@ final class PowToExpRector extends AbstractRector implements MinPhpVersionInterf
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::EXP_OPERATOR;
-    }
-
-    /**
-     * Operators that bind looser than ** on the left-hand side, so pow($operand, $y) would be
-     * misparsed without parentheses. Unary operators and casts are legal bare on the right-hand
-     * side of ** (2 ** -3), so they only need wrapping when used as the left operand.
-     */
-    private function isLowerPrecedenceThanPowLeft(Expr $expr): bool
-    {
-        // a plain Assign as left operand is already parenthesized by BetterStandardPrinter,
-        // wrapping it again here would produce a double set of parentheses
-        if ($expr instanceof Assign) {
-            return false;
-        }
-
-        if ($expr instanceof UnaryMinus
-            || $expr instanceof UnaryPlus
-            || $expr instanceof BitwiseNot
-            || $expr instanceof BooleanNot
-            || $expr instanceof ErrorSuppress
-            || $expr instanceof Cast
-            || $expr instanceof Instanceof_) {
-            return true;
-        }
-
-        return $this->isLowerPrecedenceThanPowRight($expr);
-    }
-
-    /**
-     * Operators that would otherwise swallow the ** expression on either side, e.g.
-     * pow(2, $a ? 3 : 4) must become 2 ** ($a ? 3 : 4), not 2 ** $a ? 3 : 4.
-     */
-    private function isLowerPrecedenceThanPowRight(Expr $expr): bool
-    {
-        return $expr instanceof Ternary
-            || $expr instanceof Assign
-            || $expr instanceof AssignRef
-            || $expr instanceof AssignOp
-            || $expr instanceof Print_
-            || $expr instanceof Yield_
-            || $expr instanceof YieldFrom;
     }
 }

--- a/rules/Php56/Rector/FuncCall/PowToExpRector.php
+++ b/rules/Php56/Rector/FuncCall/PowToExpRector.php
@@ -5,9 +5,23 @@ declare(strict_types=1);
 namespace Rector\Php56\Rector\FuncCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp;
+use PhpParser\Node\Expr\AssignRef;
 use PhpParser\Node\Expr\BinaryOp\Pow;
+use PhpParser\Node\Expr\BitwiseNot;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\Cast;
+use PhpParser\Node\Expr\ErrorSuppress;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Expr\Print_;
+use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\UnaryMinus;
+use PhpParser\Node\Expr\UnaryPlus;
+use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Expr\YieldFrom;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
@@ -54,8 +68,14 @@ final class PowToExpRector extends AbstractRector implements MinPhpVersionInterf
         $secondExpr = $node->getArgs()[1]
             ->value;
 
-        if ($firstExpr instanceof UnaryMinus) {
-            $firstExpr->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        // ** binds tighter than most operators, so operands with lower precedence must be
+        // wrapped in parentheses to keep the original semantics, e.g. pow(~3, 4) => (~3) ** 4
+        if ($this->isLowerPrecedenceThanPowLeft($firstExpr)) {
+            $firstExpr->setAttribute(AttributeKey::WRAPPED_IN_PARENTHESES, true);
+        }
+
+        if ($this->isLowerPrecedenceThanPowRight($secondExpr)) {
+            $secondExpr->setAttribute(AttributeKey::WRAPPED_IN_PARENTHESES, true);
         }
 
         return new Pow($firstExpr, $secondExpr);
@@ -64,5 +84,46 @@ final class PowToExpRector extends AbstractRector implements MinPhpVersionInterf
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::EXP_OPERATOR;
+    }
+
+    /**
+     * Operators that bind looser than ** on the left-hand side, so pow($operand, $y) would be
+     * misparsed without parentheses. Unary operators and casts are legal bare on the right-hand
+     * side of ** (2 ** -3), so they only need wrapping when used as the left operand.
+     */
+    private function isLowerPrecedenceThanPowLeft(Expr $expr): bool
+    {
+        // a plain Assign as left operand is already parenthesized by BetterStandardPrinter,
+        // wrapping it again here would produce a double set of parentheses
+        if ($expr instanceof Assign) {
+            return false;
+        }
+
+        if ($expr instanceof UnaryMinus
+            || $expr instanceof UnaryPlus
+            || $expr instanceof BitwiseNot
+            || $expr instanceof BooleanNot
+            || $expr instanceof ErrorSuppress
+            || $expr instanceof Cast
+            || $expr instanceof Instanceof_) {
+            return true;
+        }
+
+        return $this->isLowerPrecedenceThanPowRight($expr);
+    }
+
+    /**
+     * Operators that would otherwise swallow the ** expression on either side, e.g.
+     * pow(2, $a ? 3 : 4) must become 2 ** ($a ? 3 : 4), not 2 ** $a ? 3 : 4.
+     */
+    private function isLowerPrecedenceThanPowRight(Expr $expr): bool
+    {
+        return $expr instanceof Ternary
+            || $expr instanceof Assign
+            || $expr instanceof AssignRef
+            || $expr instanceof AssignOp
+            || $expr instanceof Print_
+            || $expr instanceof Yield_
+            || $expr instanceof YieldFrom;
     }
 }

--- a/src/NodeAnalyzer/PowOperandAnalyzer.php
+++ b/src/NodeAnalyzer/PowOperandAnalyzer.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeAnalyzer;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp;
+use PhpParser\Node\Expr\AssignRef;
+use PhpParser\Node\Expr\BitwiseNot;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\Cast;
+use PhpParser\Node\Expr\ErrorSuppress;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Expr\Print_;
+use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Expr\UnaryMinus;
+use PhpParser\Node\Expr\UnaryPlus;
+use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Expr\YieldFrom;
+
+/**
+ * The ** operator binds tighter than most operators, so an operand that binds looser must be
+ * wrapped in parentheses when placed next to it, e.g. pow(~3, 4) must become (~3) ** 4.
+ * @see \Rector\Tests\NodeAnalyzer\PowOperandAnalyzerTest
+ */
+final class PowOperandAnalyzer
+{
+    /**
+     * Operators that bind looser than ** on the left-hand side, so $operand ** $y would be
+     * misparsed without parentheses. Unary operators and casts are legal bare on the right-hand
+     * side of ** (2 ** -3), so they only need wrapping when used as the left operand.
+     */
+    public function isLowerPrecedenceAsLeftOperand(Expr $expr): bool
+    {
+        // a plain Assign as left operand is already parenthesized by BetterStandardPrinter,
+        // wrapping it again here would produce a double set of parentheses
+        if ($expr instanceof Assign) {
+            return false;
+        }
+
+        if ($expr instanceof UnaryMinus
+            || $expr instanceof UnaryPlus
+            || $expr instanceof BitwiseNot
+            || $expr instanceof BooleanNot
+            || $expr instanceof ErrorSuppress
+            || $expr instanceof Cast
+            || $expr instanceof Instanceof_) {
+            return true;
+        }
+
+        return $this->isLowerPrecedenceAsRightOperand($expr);
+    }
+
+    /**
+     * Operators that would otherwise swallow the ** expression on either side, e.g.
+     * pow(2, $a ? 3 : 4) must become 2 ** ($a ? 3 : 4), not 2 ** $a ? 3 : 4.
+     */
+    public function isLowerPrecedenceAsRightOperand(Expr $expr): bool
+    {
+        return $expr instanceof Ternary
+            || $expr instanceof Assign
+            || $expr instanceof AssignRef
+            || $expr instanceof AssignOp
+            || $expr instanceof Print_
+            || $expr instanceof Yield_
+            || $expr instanceof YieldFrom;
+    }
+}

--- a/tests/NodeAnalyzer/PowOperandAnalyzerTest.php
+++ b/tests/NodeAnalyzer/PowOperandAnalyzerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\NodeAnalyzer;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp\Plus as AssignPlus;
+use PhpParser\Node\Expr\BitwiseNot;
+use PhpParser\Node\Expr\Cast\Int_ as CastInt;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Expr\UnaryMinus;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\Int_;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Rector\NodeAnalyzer\PowOperandAnalyzer;
+
+final class PowOperandAnalyzerTest extends TestCase
+{
+    private PowOperandAnalyzer $powOperandAnalyzer;
+
+    protected function setUp(): void
+    {
+        $this->powOperandAnalyzer = new PowOperandAnalyzer();
+    }
+
+    #[DataProvider('provideLeftOperand')]
+    public function testLeftOperand(Expr $expr, bool $expected): void
+    {
+        $this->assertSame($expected, $this->powOperandAnalyzer->isLowerPrecedenceAsLeftOperand($expr));
+    }
+
+    #[DataProvider('provideRightOperand')]
+    public function testRightOperand(Expr $expr, bool $expected): void
+    {
+        $this->assertSame($expected, $this->powOperandAnalyzer->isLowerPrecedenceAsRightOperand($expr));
+    }
+
+    /**
+     * @return iterable<array{Expr, bool}>
+     */
+    public static function provideLeftOperand(): iterable
+    {
+        yield [new BitwiseNot(new Int_(3)), true];
+        yield [new UnaryMinus(new Int_(3)), true];
+        yield [new CastInt(new Variable('a')), true];
+        yield [new Instanceof_(new Variable('a'), new Name('DateTime')), true];
+        yield [new Ternary(new Variable('a'), new Int_(1), new Int_(2)), true];
+        yield [new AssignPlus(new Variable('a'), new Int_(4)), true];
+
+        // a plain Assign is already parenthesized by the printer on the left side
+        yield [new Assign(new Variable('a'), new Int_(4)), false];
+        yield [new Variable('a'), false];
+        yield [new Int_(3), false];
+    }
+
+    /**
+     * @return iterable<array{Expr, bool}>
+     */
+    public static function provideRightOperand(): iterable
+    {
+        yield [new Ternary(new Variable('a'), new Int_(1), new Int_(2)), true];
+        yield [new Assign(new Variable('a'), new Int_(4)), true];
+        yield [new AssignPlus(new Variable('a'), new Int_(4)), true];
+
+        // unary operators and casts are legal bare on the right side of **
+        yield [new BitwiseNot(new Int_(3)), false];
+        yield [new UnaryMinus(new Int_(3)), false];
+        yield [new CastInt(new Variable('a')), false];
+        yield [new Variable('a'), false];
+    }
+}


### PR DESCRIPTION
Fixes rectorphp/rector#9804

`PowToExpRector` converts `pow($a, $b)` to `$a ** $b`, but `**` binds tighter than most operators. When an operand binds looser, dropping the parentheses silently changes the result.

## Before

```php
pow(~3, 4);          // becomes ~3 ** 4        => ~(3 ** 4)   = -82  (want 256)
pow(!3, 4);          // becomes !3 ** 4        => !(3 ** 4)   = false (want 0)
pow((int) "5x", 2);  // becomes (int) "5x" ** 2 => (int)("5x" ** 2)
pow($a += 4, 3);     // becomes $a += 4 ** 3   => $a += (4 ** 3)
pow($a ? 4 : 3, 2);  // becomes $a ? 4 : 3 ** 2 => $a ? 4 : (3 ** 2)
pow(2, $a ? 3 : 4);  // becomes 2 ** $a ? 3 : 4 => (2 ** $a) ? 3 : 4
```

## After

```diff
-pow(~3, 4);          +(~3) ** 4;
-pow(!3, 4);          +(!3) ** 4;
-pow((int) "5x", 2);  +((int) "5x") ** 2;
-pow($a += 4, 3);     +($a += 4) ** 3;
-pow($a ? 4 : 3, 2);  +($a ? 4 : 3) ** 2;
-pow(2, $a ? 3 : 4);  +2 ** ($a ? 3 : 4);
```

Operands already legal bare on the right-hand side of `**` stay clean:

```diff
 pow(2, -3);   =>  2 ** -3;
 pow(2, ~3);   =>  2 ** ~3;
```

Handled operand types: unary `~ ! + -`, casts, `instanceof`, ternary, compound assignments (`+=` etc.), `print`, `yield`, `yield from`. Left and right operands are treated separately since unary/cast operands only need wrapping on the left.

Verified by evaluating original vs. transformed code in real PHP: identical output for every case.
