### PR TITLE
[Php81] Skip array dim fetch args in NullToStrictStringFuncCallArgRector

### DIFF
--- a/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_array_dim_fetch_key.php.inc
+++ b/rules-tests/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector/Fixture/skip_array_dim_fetch_key.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector\Fixture;
+
+final class SkipArrayDimFetchKey
+{
+    public function run(array $data)
+    {
+        return str_replace('a', 'b', $data['key']);
+    }
+}

--- a/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
+++ b/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
@@ -6,6 +6,7 @@ namespace Rector\Php81\NodeManipulator;
 
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Cast\Int_ as CastInt_;
 use PhpParser\Node\Expr\Cast\String_ as CastString_;
 use PhpParser\Node\Expr\FuncCall;
@@ -120,6 +121,11 @@ final readonly class NullToStrictStringIntConverter
 
     private function shouldSkipValue(Expr $expr, Scope $scope, bool $isTrait, string $targetType): bool
     {
+        // array dim fetch value is mixed, null is not known - skip to avoid wrong (string) cast
+        if ($expr instanceof ArrayDimFetch) {
+            return true;
+        }
+
         if ($this->isPropertyFetchOnClassWithMagicGet($expr)) {
             return true;
         }


### PR DESCRIPTION
`NullToStrictStringFuncCallArgRector` now skips array dim fetch args (`$array['key']`).

Array dim fetch values are `mixed` — the `null` is not known, so casting to `(string)` may be wrong. Now explicitly skipped:

```diff
 public function run(array $data)
 {
-    return str_replace('a', 'b', (string) $data['key']);
+    return str_replace('a', 'b', $data['key']);
 }
```