### PR TITLE
Fix scoper to clean up prefix under getRuleDefinition() method

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -107,6 +107,28 @@ return [
             );
         },
 
+        // keep public documentation examples readable
+        static function (string $filePath, string $prefix, string $content): string {
+            if (! \str_contains($filePath, 'rules/')) {
+                return $content;
+            }
+
+            if (! \str_ends_with($filePath, 'Rector.php')) {
+                return $content;
+            }
+
+            return Strings::replace(
+                $content,
+                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R    \})#s',
+                static function (array $match) use ($prefix): string {
+                    $body = str_replace($prefix . '\\', '', $match[2]);
+                    $body = Strings::replace($body, '#^\s*namespace ' . preg_quote($prefix, '#') . ';\R\R?#m', '');
+
+                    return $match[1] . $body . $match[3];
+                }
+            );
+        },
+
         // un-prefix composer plugin
         static function (string $filePath, string $prefix, string $content): string {
             if (! \str_ends_with($filePath, 'vendor/rector/extension-installer/src/Plugin.php')) {

--- a/tests/Scoper/ScoperPatchersTest.php
+++ b/tests/Scoper/ScoperPatchersTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Scoper;
+
+use Closure;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder;
+
+final class ScoperPatchersTest extends TestCase
+{
+    private static bool $isFinderAliased = false;
+
+    public function testKeepsPrefixedClassesInGetRuleDefinitionUnprefixed(): void
+    {
+        $scoperConfig = $this->provideScoperConfig();
+
+        $content = <<<'PHP'
+<?php
+
+namespace Rector\Assert\Rector\ClassMethod;
+
+use RectorPrefix202607\Webmozart\Assert\Assert;
+
+final class AddAssertArrayFromClassMethodDocblockRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        $metadata = 'RectorPrefix202607\Webmozart\Assert\Assert';
+
+        new ConfiguredCodeSample(
+            <<<'CODE_SAMPLE'
+<?php
+
+namespace RectorPrefix202607;
+
+use RectorPrefix202607\Webmozart\Assert\Assert;
+CODE_SAMPLE
+            ,
+            <<<'CODE_SAMPLE'
+<?php
+
+\RectorPrefix202607\Webmozart\Assert\Assert::allString($items);
+CODE_SAMPLE
+            ,
+            []
+        );
+
+        new CodeSample(
+            'RectorPrefix202607\SomeVendor\ValueObject::class',
+            'new RectorPrefix202607\SomeVendor\ValueObject()'
+        );
+    }
+
+    public function refactor(): void
+    {
+        \RectorPrefix202607\SomeVendor\Runtime::class;
+    }
+}
+PHP;
+
+        foreach ($scoperConfig['patchers'] as $patcher) {
+            $content = $patcher->__invoke(
+                __DIR__ . '/../../rules/Assert/Rector/ClassMethod/AddAssertArrayFromClassMethodDocblockRector.php',
+                'RectorPrefix202607',
+                $content
+            );
+        }
+
+        $this->assertStringContainsString('use Webmozart\Assert\Assert;', $content);
+        $this->assertStringContainsString('use RectorPrefix202607\Webmozart\Assert\Assert;', $content);
+        $this->assertStringContainsString('\Webmozart\Assert\Assert::allString($items);', $content);
+        $this->assertStringContainsString("'SomeVendor\ValueObject::class'", $content);
+        $this->assertStringContainsString("'new SomeVendor\ValueObject()'", $content);
+        $this->assertStringContainsString('$metadata = \'Webmozart\Assert\Assert\';', $content);
+        $this->assertStringContainsString('\RectorPrefix202607\SomeVendor\Runtime::class;', $content);
+        $this->assertStringNotContainsString('namespace RectorPrefix202607;', $content);
+    }
+
+    public function testRemovesPrefixedNamespaceInGetRuleDefinitionWithWindowsLineEndings(): void
+    {
+        $scoperConfig = $this->provideScoperConfig();
+
+        $content = str_replace(
+            "\n",
+            "\r\n",
+            <<<'PHP'
+<?php
+
+final class SomeRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new CodeSample(
+            '<?php
+namespace RectorPrefix202607;
+
+RectorPrefix202607\SomeVendor\ValueObject::class;'
+        );
+    }
+}
+PHP
+        );
+
+        foreach ($scoperConfig['patchers'] as $patcher) {
+            $content = $patcher->__invoke(
+                __DIR__ . '/../../rules/Some/Rector/SomeRector.php',
+                'RectorPrefix202607',
+                $content
+            );
+        }
+
+        $this->assertStringNotContainsString('namespace RectorPrefix202607;', $content);
+        $this->assertStringContainsString('SomeVendor\ValueObject::class;', $content);
+    }
+
+    /**
+     * @return array{patchers: list<Closure(string, string, string): string>}
+     */
+    private function provideScoperConfig(): array
+    {
+        if (! self::$isFinderAliased) {
+            class_alias(Finder::class, 'Isolated\Symfony\Component\Finder\Finder');
+            self::$isFinderAliased = true;
+        }
+
+        return require __DIR__ . '/../../scoper.php';
+    }
+}

--- a/tests/Scoper/ScoperPatchersTest.php
+++ b/tests/Scoper/ScoperPatchersTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Scoper;
 
+use Webmozart\Assert\Assert;
 use Closure;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
@@ -68,14 +69,14 @@ PHP;
             );
         }
 
-        $this->assertStringContainsString('use Webmozart\Assert\Assert;', $content);
-        $this->assertStringContainsString('use RectorPrefix202607\Webmozart\Assert\Assert;', $content);
-        $this->assertStringContainsString('\Webmozart\Assert\Assert::allString($items);', $content);
-        $this->assertStringContainsString("'SomeVendor\ValueObject::class'", $content);
-        $this->assertStringContainsString("'new SomeVendor\ValueObject()'", $content);
-        $this->assertStringContainsString('$metadata = \'Webmozart\Assert\Assert\';', $content);
-        $this->assertStringContainsString('\RectorPrefix202607\SomeVendor\Runtime::class;', $content);
-        $this->assertStringNotContainsString('namespace RectorPrefix202607;', $content);
+        $this->assertStringContainsString('use Webmozart\Assert\Assert;', (string) $content);
+        $this->assertStringContainsString('use RectorPrefix202607\Webmozart\Assert\Assert;', (string) $content);
+        $this->assertStringContainsString(Assert::class . '::allString($items);', (string) $content);
+        $this->assertStringContainsString("'SomeVendor\ValueObject::class'", (string) $content);
+        $this->assertStringContainsString("'new SomeVendor\ValueObject()'", (string) $content);
+        $this->assertStringContainsString('$metadata = \'Webmozart\Assert\Assert\';', (string) $content);
+        $this->assertStringContainsString('\RectorPrefix202607\SomeVendor\Runtime::class;', (string) $content);
+        $this->assertStringNotContainsString('namespace RectorPrefix202607;', (string) $content);
     }
 
     public function testRemovesPrefixedNamespaceInGetRuleDefinitionWithWindowsLineEndings(): void
@@ -111,8 +112,8 @@ PHP
             );
         }
 
-        $this->assertStringNotContainsString('namespace RectorPrefix202607;', $content);
-        $this->assertStringContainsString('SomeVendor\ValueObject::class;', $content);
+        $this->assertStringNotContainsString('namespace RectorPrefix202607;', (string) $content);
+        $this->assertStringContainsString('SomeVendor\ValueObject::class;', (string) $content);
     }
 
     /**


### PR DESCRIPTION
Ref https://getrector.com/rule-detail/add-assert-array-from-class-method-docblock-rector

<img width="1165" height="599" alt="Screenshot 2026-07-10 at 18 03 47" src="https://github.com/user-attachments/assets/3676198f-ca16-46ff-820f-f9c81cf7dd10" />

This PR tries to ensure no prefixed code under `getRuleDefinition()` method.
