### PR TITLE
Fix scoper to clean up prefix under getRuleDefinition() method (part 2)

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -119,7 +119,7 @@ return [
 
             return Strings::replace(
                 $content,
-                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R        \);\R    \})#s',
+                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R\s*\);\R\s*\})#s',
                 static function (array $match) use ($prefix): string {
                     $body = str_replace($prefix . '\\', '', $match[2]);
                     $body = Strings::replace($body, '#^\s*namespace ' . preg_quote($prefix, '#') . ';\R\R?#m', '');

--- a/scoper.php
+++ b/scoper.php
@@ -119,7 +119,7 @@ return [
 
             return Strings::replace(
                 $content,
-                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R    \})#s',
+                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R        \);\R    \})#s',
                 static function (array $match) use ($prefix): string {
                     $body = str_replace($prefix . '\\', '', $match[2]);
                     $body = Strings::replace($body, '#^\s*namespace ' . preg_quote($prefix, '#') . ';\R\R?#m', '');

--- a/tests/Scoper/ScoperPatchersTest.php
+++ b/tests/Scoper/ScoperPatchersTest.php
@@ -61,7 +61,7 @@ CODE_SAMPLE
                     'new RectorPrefix202607\SomeVendor\ValueObject()'
                 ),
             ]
-        );
+          );
     }
 
     public function refactor(): void

--- a/tests/Scoper/ScoperPatchersTest.php
+++ b/tests/Scoper/ScoperPatchersTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Scoper;
 
-use Webmozart\Assert\Assert;
 use Closure;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
@@ -30,27 +29,38 @@ final class AddAssertArrayFromClassMethodDocblockRector
     {
         $metadata = 'RectorPrefix202607\Webmozart\Assert\Assert';
 
-        new ConfiguredCodeSample(
-            <<<'CODE_SAMPLE'
+        return new RuleDefinition(
+            'Demo',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
 <?php
 
 namespace RectorPrefix202607;
 
-use RectorPrefix202607\Webmozart\Assert\Assert;
+class SomeClass
+{
+    public function run()
+    {
+    }
+}
 CODE_SAMPLE
-            ,
-            <<<'CODE_SAMPLE'
+                    ,
+                    <<<'CODE_SAMPLE'
 <?php
+
+use RectorPrefix202607\Webmozart\Assert\Assert;
 
 \RectorPrefix202607\Webmozart\Assert\Assert::allString($items);
 CODE_SAMPLE
-            ,
-            []
-        );
-
-        new CodeSample(
-            'RectorPrefix202607\SomeVendor\ValueObject::class',
-            'new RectorPrefix202607\SomeVendor\ValueObject()'
+                    ,
+                    []
+                ),
+                new CodeSample(
+                    'RectorPrefix202607\SomeVendor\ValueObject::class',
+                    'new RectorPrefix202607\SomeVendor\ValueObject()'
+                ),
+            ]
         );
     }
 
@@ -71,7 +81,7 @@ PHP;
 
         $this->assertStringContainsString('use Webmozart\Assert\Assert;', (string) $content);
         $this->assertStringContainsString('use RectorPrefix202607\Webmozart\Assert\Assert;', (string) $content);
-        $this->assertStringContainsString(Assert::class . '::allString($items);', (string) $content);
+        $this->assertStringContainsString('\Webmozart\Assert\Assert::allString($items);', (string) $content);
         $this->assertStringContainsString("'SomeVendor\ValueObject::class'", (string) $content);
         $this->assertStringContainsString("'new SomeVendor\ValueObject()'", (string) $content);
         $this->assertStringContainsString('$metadata = \'Webmozart\Assert\Assert\';', (string) $content);


### PR DESCRIPTION
Continue of 

- https://github.com/rectorphp/rector-src/pull/8165