### PR TITLE
Fix scoper to clean up prefix under getRuleDefinition() method (part 4)

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -119,7 +119,7 @@ return [
 
             return Strings::replace(
                 $content,
-                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R\s*\]?\);\R\s*\})#s',
+                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(;\R\s*\})#s',
                 static function (array $ruleDefinitionMatch) use ($prefix): string {
                     $ruleDefinitionContent = Strings::replace(
                         $ruleDefinitionMatch[2],

--- a/scoper.php
+++ b/scoper.php
@@ -119,7 +119,7 @@ return [
 
             return Strings::replace(
                 $content,
-                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R[^\r\n]*[\]\)]+;\R\s*\})#s',
+                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R[^\r\n]*[\]\)]{2,};\R\s*\})#s',
                 static function (array $ruleDefinitionMatch) use ($prefix): string {
                     $ruleDefinitionContent = Strings::replace(
                         $ruleDefinitionMatch[2],

--- a/scoper.php
+++ b/scoper.php
@@ -119,7 +119,7 @@ return [
 
             return Strings::replace(
                 $content,
-                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R\s*\]?\);\R\s*\})#s',
+                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R\s*[\]\)]+;\R\s*\})#s',
                 static function (array $ruleDefinitionMatch) use ($prefix): string {
                     $ruleDefinitionContent = Strings::replace(
                         $ruleDefinitionMatch[2],

--- a/scoper.php
+++ b/scoper.php
@@ -119,7 +119,7 @@ return [
 
             return Strings::replace(
                 $content,
-                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R\s*[\]\)]+;\R\s*\})#s',
+                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R[^\r\n]*[\]\)]+;\R\s*\})#s',
                 static function (array $ruleDefinitionMatch) use ($prefix): string {
                     $ruleDefinitionContent = Strings::replace(
                         $ruleDefinitionMatch[2],

--- a/scoper.php
+++ b/scoper.php
@@ -119,7 +119,7 @@ return [
 
             return Strings::replace(
                 $content,
-                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(;\R\s*\})#s',
+                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R\s*\}\R\R\s*public function )#s',
                 static function (array $ruleDefinitionMatch) use ($prefix): string {
                     $ruleDefinitionContent = Strings::replace(
                         $ruleDefinitionMatch[2],

--- a/scoper.php
+++ b/scoper.php
@@ -119,7 +119,7 @@ return [
 
             return Strings::replace(
                 $content,
-                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R\s*\}\R\R\s*public function )#s',
+                '#(public function getRuleDefinition\(\): RuleDefinition\s+\{\R)(.*?)(\R\s*\]?\);\R\s*\})#s',
                 static function (array $ruleDefinitionMatch) use ($prefix): string {
                     $ruleDefinitionContent = Strings::replace(
                         $ruleDefinitionMatch[2],

--- a/tests/Scoper/ScoperPatchersTest.php
+++ b/tests/Scoper/ScoperPatchersTest.php
@@ -129,6 +129,10 @@ CODE_SAMPLE
             , ''),
         ]);
     }
+
+    public function refactor(): void
+    {
+    }
 }
 PHP
         );

--- a/tests/Scoper/ScoperPatchersTest.php
+++ b/tests/Scoper/ScoperPatchersTest.php
@@ -27,13 +27,7 @@ final class AddAssertArrayFromClassMethodDocblockRector
 {
     public function getRuleDefinition(): RuleDefinition
     {
-        $metadata = 'RectorPrefix202607\Webmozart\Assert\Assert';
-
-        return new RuleDefinition(
-            'Demo',
-            [
-                new ConfiguredCodeSample(
-                    <<<'CODE_SAMPLE'
+        return new RuleDefinition('Demo', [new ConfiguredCodeSample(<<<'CODE_SAMPLE'
 <?php
 
 namespace RectorPrefix202607;
@@ -46,8 +40,7 @@ class SomeClass
 }
 \class_alias('SomeClass', 'SomeClass', \false);
 CODE_SAMPLE
-                    ,
-                    <<<'CODE_SAMPLE'
+, <<<'CODE_SAMPLE'
 <?php
 
 namespace RectorPrefix202607;
@@ -63,15 +56,7 @@ class SomeClass
 }
 \class_alias('SomeClass', 'SomeClass', \false);
 CODE_SAMPLE
-                    ,
-                    []
-                ),
-                new CodeSample(
-                    'RectorPrefix202607\SomeVendor\ValueObject::class',
-                    'new RectorPrefix202607\SomeVendor\ValueObject()'
-                ),
-            ]
-          );
+        , [AssertClassName::WEBMOZART])]);
     }
 
     public function refactor(): void
@@ -111,8 +96,6 @@ PHP;
         $this->assertStringContainsString('use RectorPrefix202607\Webmozart\Assert\Assert;', (string) $content);
         $this->assertStringContainsString('use Webmozart\Assert\Assert;', $codeSampleContent);
         $this->assertStringContainsString('\Webmozart\Assert\Assert::allString($items);', $codeSampleContent);
-        $this->assertStringContainsString("'SomeVendor\ValueObject::class'", (string) $content);
-        $this->assertStringContainsString('$metadata = \'Webmozart\Assert\Assert\';', (string) $content);
         $this->assertStringContainsString('\RectorPrefix202607\SomeVendor\Runtime::class;', (string) $content);
         $this->assertStringNotContainsString('namespace RectorPrefix202607;', $codeSampleContent);
         $this->assertStringNotContainsString('use RectorPrefix202607\Webmozart\Assert\Assert;', $codeSampleContent);

--- a/tests/Scoper/ScoperPatchersTest.php
+++ b/tests/Scoper/ScoperPatchersTest.php
@@ -129,10 +129,6 @@ CODE_SAMPLE
             , ''),
         ]);
     }
-
-    public function refactor(): void
-    {
-    }
 }
 PHP
         );

--- a/tests/Scoper/ScoperPatchersTest.php
+++ b/tests/Scoper/ScoperPatchersTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Scoper;
 
+use Webmozart\Assert\Assert;
 use Closure;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
@@ -95,7 +96,7 @@ PHP;
 
         $this->assertStringContainsString('use RectorPrefix202607\Webmozart\Assert\Assert;', (string) $content);
         $this->assertStringContainsString('use Webmozart\Assert\Assert;', $codeSampleContent);
-        $this->assertStringContainsString('\Webmozart\Assert\Assert::allString($items);', $codeSampleContent);
+        $this->assertStringContainsString(Assert::class . '::allString($items);', $codeSampleContent);
         $this->assertStringContainsString('\RectorPrefix202607\SomeVendor\Runtime::class;', (string) $content);
         $this->assertStringNotContainsString('namespace RectorPrefix202607;', $codeSampleContent);
         $this->assertStringNotContainsString('use RectorPrefix202607\Webmozart\Assert\Assert;', $codeSampleContent);


### PR DESCRIPTION
Continue of:

- https://github.com/rectorphp/rector-src/pull/8167