### PR TITLE
Fix scoper to clean up prefix under getRuleDefinition() method (part 5)

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -127,7 +127,7 @@ return [
                         static function (array $codeSampleMatch) use ($prefix): string {
                             $body = str_replace($prefix . '\\', '', $codeSampleMatch[3]);
                             $body = Strings::replace($body, '#^[ \t]*namespace ' . preg_quote($prefix, '#') . ';\R\R?#m', '');
-                            $body = Strings::replace($body, '#^[ \t]*\\\\class_alias\(.*?\);\R?#m', '');
+                            $body = Strings::replace($body, '#\R[ \t]*\\\\class_alias\(.*?\);$#', '');
 
                             return $codeSampleMatch[1] . $body . $codeSampleMatch[4];
                         }

--- a/tests/Scoper/ScoperPatchersTest.php
+++ b/tests/Scoper/ScoperPatchersTest.php
@@ -102,6 +102,10 @@ PHP;
         $this->assertStringNotContainsString('use RectorPrefix202607\Webmozart\Assert\Assert;', $codeSampleContent);
         $this->assertStringNotContainsString('\class_alias', $codeSampleContent);
         $this->assertStringContainsString('\RectorPrefix202607\ShouldStayPrefixed::run();', (string) $content);
+
+        foreach ($matches[1] as $codeSample) {
+            $this->assertStringEndsNotWith("\n", $codeSample);
+        }
     }
 
     public function testRemovesPrefixedNamespaceInGetRuleDefinitionWithWindowsLineEndings(): void


### PR DESCRIPTION
Continue of:

- https://github.com/rectorphp/rector-src/pull/8168

to clean up new line.