### PR TITLE
[DeadCode] Add RemoveReturnTagIncompatibleWithNativeTypeRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/remove_object_return_over_array.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/remove_object_return_over_array.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class RemoveObjectReturnOverArray
+{
+    /**
+     * @return \stdClass
+     */
+    public function getItems(): array
+    {
+        return [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class RemoveObjectReturnOverArray
+{
+    public function getItems(): array
+    {
+        return [];
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/remove_object_return_over_string.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/remove_object_return_over_string.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class RemoveObjectReturnOverString
+{
+    /**
+     * @return \stdClass
+     */
+    public function getName(): string
+    {
+        return 'name';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class RemoveObjectReturnOverString
+{
+    public function getName(): string
+    {
+        return 'name';
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_generic_array_narrowing.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_generic_array_narrowing.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipGenericArrayNarrowing
+{
+    /**
+     * @return int[]
+     */
+    public function getInts(): array
+    {
+        return [1, 2];
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_narrowing_object_return.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_narrowing_object_return.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipNarrowingObjectReturn
+{
+    /**
+     * @return \stdClass
+     */
+    public function create(): object
+    {
+        return new \stdClass();
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_no_native_return_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_no_native_return_type.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipNoNativeReturnType
+{
+    /**
+     * @return \stdClass
+     */
+    public function getName()
+    {
+        return new \stdClass();
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_return_with_description.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_return_with_description.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipReturnWithDescription
+{
+    /**
+     * @return \stdClass the wrapped value
+     */
+    public function getName(): string
+    {
+        return 'name';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/RemoveReturnTagIncompatibleWithNativeTypeRectorTest.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/RemoveReturnTagIncompatibleWithNativeTypeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveReturnTagIncompatibleWithNativeTypeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveReturnTagIncompatibleWithNativeTypeRector::class]);

--- a/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\RemoveReturnTagIncompatibleWithNativeTypeRectorTest
+ */
+final class RemoveReturnTagIncompatibleWithNativeTypeRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly StaticTypeMapper $staticTypeMapper,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove @return docblock that contradicts the declared native return type',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    /**
+     * @return SomeObject
+     */
+    public function getName(): string
+    {
+        return $this->someObject->getName();
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function getName(): string
+    {
+        return $this->someObject->getName();
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class, Function_::class];
+    }
+
+    /**
+     * @param ClassMethod|Function_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        // no native return type to compare against
+        if ($node->returnType === null) {
+            return null;
+        }
+
+        // nothing to remove
+        if ($node->getComments() === []) {
+            return null;
+        }
+
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $returnTagValueNode = $phpDocInfo->getReturnTagValue();
+        if (! $returnTagValueNode instanceof ReturnTagValueNode) {
+            return null;
+        }
+
+        // keep any documented explanation
+        if ($returnTagValueNode->description !== '') {
+            return null;
+        }
+
+        $nativeReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
+        $docReturnType = $phpDocInfo->getReturnType();
+
+        // a subtype/narrowing is legitimate; only a contradiction is dead
+        if (! $nativeReturnType->isSuperTypeOf($docReturnType)->no()) {
+            return null;
+        }
+
+        if (! $phpDocInfo->removeByType(ReturnTagValueNode::class)) {
+            return null;
+        }
+
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+
+        return $node;
+    }
+}

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -19,6 +19,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveMixedDocblockOverruledByNativeTypeRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveNullTagValueNodeRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
@@ -120,6 +121,7 @@ final class DeadCodeLevel
         RemoveUselessReturnTagRector::class,
         RemoveDuplicatedReturnSelfDocblockRector::class,
         RemoveMixedDocblockOverruledByNativeTypeRector::class,
+        RemoveReturnTagIncompatibleWithNativeTypeRector::class,
         RemoveUselessUnionReturnDocblockRector::class,
         RemoveUselessReadOnlyTagRector::class,
         RemoveNonExistingVarAnnotationRector::class,


### PR DESCRIPTION
Adds `RemoveReturnTagIncompatibleWithNativeTypeRector` to the **DeadCode** set.

Removes a `@return` docblock whose type contradicts the declared native return type — the tag is dead/wrong and misleads readers and IDEs.

```diff
 final class SomeClass
 {
-    /**
-     * @return SomeObject
-     */
     public function getName(): string
     {
         return $this->someObject->getName();
     }
 }
```

## Safe by design

Removes only a true contradiction (`nativeType->isSuperTypeOf(docType)->no()`). Legitimate narrowing is kept.

| native | `@return` | action |
|--------|-----------|--------|
| `string` | `\stdClass` | remove |
| `array` | `\stdClass` | remove |
| `object` | `\stdClass` | keep (narrowing) |
| `array` | `int[]` | keep (generic narrowing) |
| `string` | `\stdClass` + description | keep |
| *(no native type)* | `\stdClass` | keep |

Complements `RemoveUselessReturnTagRector` (equal type) and `RemoveMixedDocblockOverruledByNativeTypeRector` (`mixed`); neither covers a contradicting class/scalar `@return`.