### PR TITLE
Bump phpstan/phpdoc-parser to ^2.3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "nette/utils": "^4.1.4",
         "nikic/php-parser": "^5.8",
         "ondram/ci-detector": "^4.2",
-        "phpstan/phpdoc-parser": "^2.3",
+        "phpstan/phpdoc-parser": "^2.3.3",
         "phpstan/phpstan": "^2.2.2",
         "react/event-loop": "^1.6",
         "react/promise": "^3.3",


### PR DESCRIPTION
phpstan/phpdoc-parser 2.3.3 released: 

https://github.com/phpstan/phpdoc-parser/releases/tag/2.3.3

with addition of new class: `PureUnlessParameterIsPassedTagValueNode` that make `preload.php` regenerated:

- https://github.com/rectorphp/rector-src/pull/8173

This PR ensure it compatible.