### PR TITLE
Skip require of files with top-level side effects in RemovePsr4AutoloadedIncludeRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Expression/RemovePsr4AutoloadedIncludeRector/Fixture/skip_class_with_function.php.inc
+++ b/rules-tests/DeadCode/Rector/Expression/RemovePsr4AutoloadedIncludeRector/Fixture/skip_class_with_function.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+require __DIR__ . '/../Source/src/ClassWithFunction.php';
+
+$classWithFunction = new \App\ClassWithFunction();
+
+?>

--- a/rules-tests/DeadCode/Rector/Expression/RemovePsr4AutoloadedIncludeRector/Fixture/skip_class_with_side_effect.php.inc
+++ b/rules-tests/DeadCode/Rector/Expression/RemovePsr4AutoloadedIncludeRector/Fixture/skip_class_with_side_effect.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+require __DIR__ . '/../Source/src/ClassWithInit.php';
+
+$classWithInit = new \App\ClassWithInit();
+
+?>

--- a/rules-tests/DeadCode/Rector/Expression/RemovePsr4AutoloadedIncludeRector/Source/src/ClassWithFunction.php
+++ b/rules-tests/DeadCode/Rector/Expression/RemovePsr4AutoloadedIncludeRector/Source/src/ClassWithFunction.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+final class ClassWithFunction
+{
+}
+
+function some_helper(): void
+{
+}

--- a/rules-tests/DeadCode/Rector/Expression/RemovePsr4AutoloadedIncludeRector/Source/src/ClassWithInit.php
+++ b/rules-tests/DeadCode/Rector/Expression/RemovePsr4AutoloadedIncludeRector/Source/src/ClassWithInit.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+final class ClassWithInit
+{
+    public static function init(): void
+    {
+    }
+}
+
+ClassWithInit::init();

--- a/rules/DeadCode/Rector/Expression/RemovePsr4AutoloadedIncludeRector.php
+++ b/rules/DeadCode/Rector/Expression/RemovePsr4AutoloadedIncludeRector.php
@@ -9,8 +9,14 @@ use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\Include_;
 use PhpParser\Node\Scalar\MagicConst\Dir;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Declare_;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Nop;
+use PhpParser\Node\Stmt\Use_;
 use PhpParser\NodeVisitor;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\FileSystem\JsonFileSystem;
@@ -164,6 +170,11 @@ CODE_SAMPLE
     {
         $stmts = $this->rectorParser->parseFile($filePath);
 
+        // the autoloader replays only type declarations, so top-level side effects, functions or constants keep the require load-bearing
+        if (! $this->containsOnlyTypeDeclarations($stmts)) {
+            return null;
+        }
+
         $classLikes = $this->betterNodeFinder->findInstanceOf($stmts, ClassLike::class);
 
         // require must define exactly one class, or removing it would drop the other definitions
@@ -173,6 +184,35 @@ CODE_SAMPLE
 
         // RichParser resolves names, so this is already the fully-qualified class name
         return $this->getName($classLikes[0]);
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function containsOnlyTypeDeclarations(array $stmts): bool
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof ClassLike || $stmt instanceof Use_ || $stmt instanceof GroupUse || $stmt instanceof Nop) {
+                continue;
+            }
+
+            // declare(strict_types=1); is fine, but the block form declare(...) { ... } executes its body
+            if ($stmt instanceof Declare_ && $stmt->stmts === null) {
+                continue;
+            }
+
+            if ($stmt instanceof Namespace_) {
+                if (! $this->containsOnlyTypeDeclarations($stmt->stmts)) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Adds the side-effect guard discussed in https://github.com/rectorphp/rector-src/pull/8149#issuecomment-4891657978 (thanks @samsonasik for the catch).

`resolveSingleDeclaredClassName()` now bails out unless the target file's top level contains only type declarations: class-likes, `use` statements, statement-form `declare`, and comments (`namespace` is checked recursively). Files with top-level function/const definitions or executed statements — e.g. `Cli::init();` after the class — keep their `require` load-bearing, since autoloading replays only the type declarations.

The guard is one extra condition in front of the existing checks, with existing code untouched, so it can only make the rule remove less, never more.

Fixtures:
- `skip_class_with_side_effect` — class followed by `ClassWithInit::init();` (the CodeIgniter-style case)
- `skip_class_with_function` — class plus a top-level function

Both fail (the `require` gets removed) without the guard.