### PR TITLE
[StaticTypeMapper] Map phpstan-special scalar types (literal-string, numeric-string, ...)

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_literal_string_narrowing.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_literal_string_narrowing.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipLiteralStringNarrowing
+{
+    /**
+     * @return literal-string
+     */
+    public function getTableAlias(): string
+    {
+        return 'n';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_lowercase_string_narrowing.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_lowercase_string_narrowing.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipLowercaseStringNarrowing
+{
+    /**
+     * @return lowercase-string
+     */
+    public function run(): string
+    {
+        return 'x';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_non_empty_string_narrowing.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_non_empty_string_narrowing.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipNonEmptyStringNarrowing
+{
+    /**
+     * @return non-empty-string
+     */
+    public function getName(): string
+    {
+        return 'name';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_non_falsy_string_narrowing.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_non_falsy_string_narrowing.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipNonFalsyStringNarrowing
+{
+    /**
+     * @return non-falsy-string
+     */
+    public function run(): string
+    {
+        return 'x';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_non_negative_int_narrowing.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_non_negative_int_narrowing.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipNonNegativeIntNarrowing
+{
+    /**
+     * @return non-negative-int
+     */
+    public function run(): int
+    {
+        return 0;
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_non_positive_int_narrowing.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_non_positive_int_narrowing.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipNonPositiveIntNarrowing
+{
+    /**
+     * @return non-positive-int
+     */
+    public function run(): int
+    {
+        return 0;
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_numeric_string_narrowing.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_numeric_string_narrowing.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipNumericStringNarrowing
+{
+    /**
+     * @return numeric-string
+     */
+    public function run(): string
+    {
+        return '1';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_uppercase_string_narrowing.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_uppercase_string_narrowing.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipUppercaseStringNarrowing
+{
+    /**
+     * @return uppercase-string
+     */
+    public function run(): string
+    {
+        return 'X';
+    }
+}

--- a/src/StaticTypeMapper/Mapper/ScalarStringToTypeMapper.php
+++ b/src/StaticTypeMapper/Mapper/ScalarStringToTypeMapper.php
@@ -7,7 +7,11 @@ namespace Rector\StaticTypeMapper\Mapper;
 use Nette\Utils\Strings;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
+use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
+use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
+use PHPStan\Type\Accessory\AccessoryNumericStringType;
+use PHPStan\Type\Accessory\AccessoryUppercaseStringType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
@@ -26,6 +30,7 @@ use PHPStan\Type\ResourceType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
 use PHPStan\Type\VoidType;
 
 final class ScalarStringToTypeMapper
@@ -37,6 +42,10 @@ final class ScalarStringToTypeMapper
         StringType::class => ['string'],
         AccessoryNonEmptyStringType::class => ['non-empty-string'],
         AccessoryLiteralStringType::class => ['literal-string'],
+        AccessoryNumericStringType::class => ['numeric-string'],
+        AccessoryNonFalsyStringType::class => ['non-falsy-string', 'truthy-string'],
+        AccessoryLowercaseStringType::class => ['lowercase-string'],
+        AccessoryUppercaseStringType::class => ['uppercase-string'],
         NonEmptyArrayType::class => ['non-empty-array'],
         ClassStringType::class => ['class-string'],
         FloatType::class => ['float', 'real', 'double'],
@@ -68,6 +77,18 @@ final class ScalarStringToTypeMapper
 
         if ($loweredScalarName === 'negative-int') {
             return IntegerRangeType::createAllSmallerThan(0);
+        }
+
+        if ($loweredScalarName === 'non-negative-int') {
+            return IntegerRangeType::fromInterval(0, null);
+        }
+
+        if ($loweredScalarName === 'non-positive-int') {
+            return IntegerRangeType::fromInterval(null, 0);
+        }
+
+        if ($loweredScalarName === 'array-key') {
+            return new UnionType([new IntegerType(), new StringType()]);
         }
 
         foreach (self::SCALAR_NAME_BY_TYPE as $objectType => $scalarNames) {

--- a/src/StaticTypeMapper/Mapper/ScalarStringToTypeMapper.php
+++ b/src/StaticTypeMapper/Mapper/ScalarStringToTypeMapper.php
@@ -6,6 +6,7 @@ namespace Rector\StaticTypeMapper\Mapper;
 
 use Nette\Utils\Strings;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
@@ -35,6 +36,7 @@ final class ScalarStringToTypeMapper
     private const array SCALAR_NAME_BY_TYPE = [
         StringType::class => ['string'],
         AccessoryNonEmptyStringType::class => ['non-empty-string'],
+        AccessoryLiteralStringType::class => ['literal-string'],
         NonEmptyArrayType::class => ['non-empty-array'],
         ClassStringType::class => ['class-string'],
         FloatType::class => ['float', 'real', 'double'],


### PR DESCRIPTION
Several PHPStan-special types were missing from `ScalarStringToTypeMapper`, so they fell through to a bogus `ObjectType('...')`. `RemoveReturnTagIncompatibleWithNativeTypeRector` then saw the native type as *not* a supertype of that bogus object and wrongly deleted the more precise docblock.

Mapping each to its real PHPStan type (same pattern as the existing `non-empty-string` / `class-string` mappings) makes them genuine subtypes, so the rule now keeps them.

## Newly mapped types

| PHPDoc type | Mapped to |
| --- | --- |
| `literal-string` | `AccessoryLiteralStringType` |
| `numeric-string` | `AccessoryNumericStringType` |
| `non-falsy-string`, `truthy-string` | `AccessoryNonFalsyStringType` |
| `lowercase-string` | `AccessoryLowercaseStringType` |
| `uppercase-string` | `AccessoryUppercaseStringType` |
| `non-negative-int` | `int<0, max>` |
| `non-positive-int` | `int<min, 0>` |
| `array-key` | `int\|string` |

## Before (rule wrongly removed the precise type)

```diff
-    /**
-     * @return literal-string
-     */
     public function getTableAlias(): string
     {
         return 'n';
     }
```

## After

```php
    /**
     * @return literal-string
     */
    public function getTableAlias(): string
    {
        return 'n';
    }
```

Docblock kept — `literal-string` (and the others above) are legitimate narrowings of their native type.