### PR TITLE
[Console] Support "-v" as alias for "--version"

### DIFF
--- a/src/Console/ConsoleApplication.php
+++ b/src/Console/ConsoleApplication.php
@@ -44,6 +44,13 @@ final class ConsoleApplication extends Application
     #[Override]
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
+        // support "-v" as an alias for "--version", as "verbose" option is removed
+        if ($input->hasParameterOption('-v', true)) {
+            $output->writeln($this->getLongVersion());
+
+            return ExitCode::SUCCESS;
+        }
+
         $this->enableXdebug($input);
 
         $shouldFollowByNewline = false;


### PR DESCRIPTION
Makes `-v` display the Rector version, same as `--version` / `-V`.

The `--verbose` option (which normally owns the `-v` shortcut) is removed in `ConsoleApplication`, so `-v` was previously an unknown option and errored out. This wires it to print the version.

```bash
# before
bin/rector -v
# The "-v" option does not exist.

# after
bin/rector -v
Rector 2.x.x
```