### PR TITLE
[DeadCode] Skip PHPStan type alias on RemoveReturnTagIncompatibleWithNativeTypeRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_phpstan_type_alias.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_phpstan_type_alias.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+/**
+ * @phpstan-type Config array{
+ *     key: string,
+ *     hash: string,
+ * }
+ */
+final class SkipPHPStanTypeAlias
+{
+    /**
+     * @return Config
+     */
+    public function run(bool $param): array
+    {
+        return [
+            'key' => 'my-key',
+            'hash' => 'my-hash',
+        ];
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_phpstan_type_alias_in_union.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_phpstan_type_alias_in_union.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+/**
+ * @phpstan-type Config array{key: string}
+ */
+final class SkipPHPStanTypeAliasInUnion
+{
+    /**
+     * @return Config|null
+     */
+    public function provide(): ?array
+    {
+        return null;
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
@@ -7,10 +7,14 @@ namespace Rector\DeadCode\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -99,6 +103,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->isClassTypeAlias($node, $returnTagValueNode)) {
+            return null;
+        }
+
         $nativeReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
         $docReturnType = $phpDocInfo->getReturnType();
 
@@ -114,5 +122,27 @@ CODE_SAMPLE
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
 
         return $node;
+    }
+
+    private function isClassTypeAlias(Node $node, ReturnTagValueNode $returnTagValueNode): bool
+    {
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof Scope || ! $scope->isInClass()) {
+            return false;
+        }
+
+        $resolvedPhpDocBlock = $scope->getClassReflection()
+            ->getResolvedPhpDoc();
+        if (! $resolvedPhpDocBlock instanceof ResolvedPhpDocBlock) {
+            return false;
+        }
+
+        $typeAliases = $resolvedPhpDocBlock->getTypeAliasTags() + $resolvedPhpDocBlock->getTypeAliasImportTags();
+        if ($typeAliases === []) {
+            return false;
+        }
+
+        return $returnTagValueNode->type instanceof IdentifierTypeNode
+            && isset($typeAliases[$returnTagValueNode->type->name]);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9811