### PR TITLE
[Php71] Skip magic @method on RemoveExtraParametersRector

### DIFF
--- a/rules-tests/Php71/Rector/FuncCall/RemoveExtraParametersRector/Fixture/skip_magic_method.php.inc
+++ b/rules-tests/Php71/Rector/FuncCall/RemoveExtraParametersRector/Fixture/skip_magic_method.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Php71\Rector\FuncCall\RemoveExtraParametersRector\Fixture;
+
+use Rector\Tests\Php71\Rector\FuncCall\RemoveExtraParametersRector\Source\TranslationEntityInterface;
+
+final class SkipMagicMethod
+{
+    public function run(TranslationEntityInterface $entity): bool
+    {
+        return $entity->isPublished(false);
+    }
+}

--- a/rules-tests/Php71/Rector/FuncCall/RemoveExtraParametersRector/Source/TranslationEntityInterface.php
+++ b/rules-tests/Php71/Rector/FuncCall/RemoveExtraParametersRector/Source/TranslationEntityInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php71\Rector\FuncCall\RemoveExtraParametersRector\Source;
+
+/**
+ * @method int|null getId()
+ * @method bool     isPublished()
+ */
+interface TranslationEntityInterface
+{
+    public function getLanguage(): ?string;
+}

--- a/rules/Php71/Rector/FuncCall/RemoveExtraParametersRector.php
+++ b/rules/Php71/Rector/FuncCall/RemoveExtraParametersRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
+use PHPStan\Reflection\Annotations\AnnotationMethodReflection;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\Php\PhpMethodReflection;
@@ -69,6 +70,11 @@ final class RemoveExtraParametersRector extends AbstractRector implements MinPhp
         }
 
         if ($functionLikeReflection === null) {
+            return null;
+        }
+
+        // magic @method has no real parameters to compare against
+        if ($functionLikeReflection instanceof AnnotationMethodReflection) {
             return null;
         }
 


### PR DESCRIPTION
A magic `@method` declared with no parameters has no real signature to compare arguments against. `RemoveExtraParametersRector` treated the annotated zero-param count as the maximum and wrongly stripped valid call arguments.

```php
/**
 * @method bool isPublished()
 */
interface TranslationEntityInterface
{
}
```

```diff
-$entity->isPublished(false);
+$entity->isPublished(false); // kept, was wrongly rewritten to isPublished()
```

Fix: skip `AnnotationMethodReflection` (magic `@method`) reflections, same spirit as the existing interface/abstract skips.