### PR TITLE
[CodeQuality] Skip abstract class on CompleteDynamicPropertiesRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/skip_abstract_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/skip_abstract_class.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector\Fixture;
+
+abstract class SkipAbstractClass
+{
+    public function set()
+    {
+        $this->value = 5;
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php
+++ b/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php
@@ -114,6 +114,11 @@ CODE_SAMPLE
             return true;
         }
 
+        // abstract class property might be accessed from child class
+        if ($class->isAbstract()) {
+            return true;
+        }
+
         $className = (string) $this->getName($class);
         if (! $this->reflectionProvider->hasClass($className)) {
             return true;


### PR DESCRIPTION
Abstract class dynamic property might be accessed from a child class, so we cannot safely complete it. Skip abstract classes.

```diff
 abstract class SomeClass
 {
     public function set()
     {
         $this->value = 5;
     }
 }
```

Before: rule added `public $value;` to the abstract class. Now it is skipped, since a child class may declare/use that property.