### PR TITLE
fix(dead-code): preserve generic `@return` tags in `RemoveReturnTagIn…

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_generic_fluent_builder.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_generic_fluent_builder.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+/**
+ * @template TPayload
+ * @template TDomainId
+ */
+final class SkipGenericFluentBuilder
+{
+    /**
+     * @return SkipGenericFluentBuilder<TPayload, TDomainId>
+     */
+    public function withFoo(): self
+    {
+        return $this;
+    }
+
+    /**
+     * @return SkipGenericFluentBuilder<TPayload, TDomainId>
+     */
+    public function withBar(): self
+    {
+        return $this;
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_generic_self_return.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_generic_self_return.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+/**
+ * @template TAdded
+ * @template TRemoved
+ */
+final readonly class SkipGenericSelfReturn
+{
+    /**
+     * @param list<TAdded> $added
+     * @param list<TRemoved> $removed
+     */
+    private function __construct(
+        public array $added,
+        public array $removed,
+    ) {
+    }
+
+    /**
+     * @param list<TAdded> $added
+     * @param list<TRemoved> $removed
+     *
+     * @return self<TAdded, TRemoved>
+     */
+    public static function create(array $added, array $removed): self
+    {
+        return new self($added, $removed);
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -100,6 +101,11 @@ CODE_SAMPLE
 
         // keep any documented explanation
         if ($returnTagValueNode->description !== '') {
+            return null;
+        }
+
+        // keep generic return types, because they carry template info the native type cannot express
+        if ($returnTagValueNode->type instanceof GenericTypeNode) {
             return null;
         }
 


### PR DESCRIPTION
This fixes `RemoveReturnTagIncompatibleWithNativeTypeRector` incorrectly stripping `@return self<T>` and `@return ClassName<T>` docblocks when the native return type is `self`.

## Problem

Given a templated class:

```php
/**
 * @template TAdded
 * @template TRemoved
 */
final readonly class Changes
{
    /**
     * @param list<TAdded> $added
     * @param list<TRemoved> $removed
     */
    private function __construct(
        public array $added,
        public array $removed,
    ) {
    }

    /**
     * @param list<TAdded> $added
     * @param list<TRemoved> $removed
     *
     * @return self<TAdded, TRemoved>
     */
    public static function create(array $added, array $removed): self
    {
        return new self($added, $removed);
    }
}
```

The rule would remove `@return self<TAdded, TRemoved>` because it considered it incompatible with the native `self` return type. However, the annotation is not redundant, because it narrows the return type with template parameters that PHP's native type system cannot express. PHPStan and Psalm rely on these annotations for generic type inference.

## Fix

Added an early bail-out when `$returnTagValueNode->type` is an instance of `GenericTypeNode`. This catches all `@return Foo<T>`, `@return self<T>`, and `@return static<T>` patterns at the PHPDoc AST level before any expensive type resolution occurs.