### PR TITLE
 skip @ return this on RemoveReturnTagIncompatibleWithNativeTypeRector on Traits

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_this_return_in_trait.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_this_return_in_trait.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Source\RouteInterface;
+
+trait SkipThisReturnInTrait
+{
+    /**
+     * @return $this
+     */
+    public function withVerbs(): RouteInterface
+    {
+        return clone $this;
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Source/RouteInterface.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Source/RouteInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Source;
+
+interface RouteInterface
+{
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
@@ -116,13 +116,15 @@ CODE_SAMPLE
             return null;
         }
 
+        $nativeReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
         $classReflection = $scope->getClassReflection();
         if ($scope->isInClass() && $classReflection->isTrait()
-            && $returnTagValueNode->type instanceof ThisTypeNode) {
+            && $returnTagValueNode->type instanceof ThisTypeNode
+            && $nativeReturnType instanceof ObjectType
+        ) {
             return null;
         }
 
-        $nativeReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
         if ($this->isReturnTemplate($phpDocInfo, $returnTagValueNode)) {
             return null;
         }

--- a/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
@@ -13,10 +13,10 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ThisTypeNode;
+use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -112,7 +112,7 @@ CODE_SAMPLE
         }
 
         $scope = ScopeFetcher::fetch($node);
-        if ($this->isClassTypeAlias($scope, $node, $returnTagValueNode)) {
+        if ($this->isClassTypeAlias($scope, $returnTagValueNode)) {
             return null;
         }
 
@@ -145,7 +145,7 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function isClassTypeAlias(Scope $scope, Node $node, ReturnTagValueNode $returnTagValueNode): bool
+    private function isClassTypeAlias(Scope $scope, ReturnTagValueNode $returnTagValueNode): bool
     {
         if (! $scope->isInClass()) {
             return false;

--- a/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
@@ -12,10 +12,12 @@ use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\ThisTypeNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -109,7 +111,14 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->isClassTypeAlias($node, $returnTagValueNode)) {
+        $scope = ScopeFetcher::fetch($node);
+        if ($this->isClassTypeAlias($scope, $node, $returnTagValueNode)) {
+            return null;
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if ($scope->isInClass() && $classReflection->isTrait()
+            && $returnTagValueNode->type instanceof ThisTypeNode) {
             return null;
         }
 
@@ -134,10 +143,9 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function isClassTypeAlias(Node $node, ReturnTagValueNode $returnTagValueNode): bool
+    private function isClassTypeAlias(Scope $scope, Node $node, ReturnTagValueNode $returnTagValueNode): bool
     {
-        $scope = $node->getAttribute(AttributeKey::SCOPE);
-        if (! $scope instanceof Scope || ! $scope->isInClass()) {
+        if (! $scope->isInClass()) {
             return false;
         }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector.php
@@ -13,6 +13,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ThisTypeNode;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -118,7 +119,7 @@ CODE_SAMPLE
 
         $nativeReturnType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
         $classReflection = $scope->getClassReflection();
-        if ($scope->isInClass() && $classReflection->isTrait()
+        if ($classReflection instanceof ClassReflection && $classReflection->isTrait()
             && $returnTagValueNode->type instanceof ThisTypeNode
             && $nativeReturnType instanceof ObjectType
         ) {


### PR DESCRIPTION
This is valid code:

```php
trait SkipThisReturnInTrait
{
    /**
     * @return $this
     */
    public function withVerbs(): RouteInterface
    {
        return clone $this;
    }
}
```

Removing `@return $this` cause error when it return object type.

```xml
<file name="src/AnnotatedRoutes/src/RouteLocatorListener.php">
 <error line="74" column="75" severity="error" message="UndefinedMethod: Method Spiral\Router\AbstractRoute::withMiddleware does not exist"/>
</file>
```

checked on spiral framework:

- https://github.com/spiral/framework/pull/1293

