### PR TITLE
[DeadCode] Skip string scalar sub type on RemoveReturnTagIncompatibleWithNativeTypeRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_subtype.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveReturnTagIncompatibleWithNativeTypeRector/Fixture/skip_subtype.php.inc
@@ -1,0 +1,54 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector\Fixture;
+
+final class SkipSubtype
+{
+    /**
+     * @return callable-string
+     */
+    public function getCallableString(): string
+    {
+        return 'trim';
+    }
+
+    /**
+     * @return non-empty-lowercase-string
+     */
+    public function getNonEmptyLowercaseString(): string
+    {
+        return 'abc';
+    }
+
+    /**
+     * @return non-empty-uppercase-string
+     */
+    public function getNonEmptyUppercaseString(): string
+    {
+        return 'ABC';
+    }
+
+    /**
+     * @return non-empty-literal-string
+     */
+    public function getNonEmptyLiteralString(): string
+    {
+        return '3v4l';
+    }
+
+    /**
+     * @return decimal-int-string
+     */
+    public function getDecimalIntString(): string
+    {
+        return '123';
+    }
+
+    /**
+     * @return non-decimal-int-string
+     */
+    public function getNonDecimalIntString(): string
+    {
+        return '+1';
+    }
+}

--- a/src/StaticTypeMapper/Mapper/ScalarStringToTypeMapper.php
+++ b/src/StaticTypeMapper/Mapper/ScalarStringToTypeMapper.php
@@ -6,6 +6,7 @@ namespace Rector\StaticTypeMapper\Mapper;
 
 use Nette\Utils\Strings;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\Accessory\AccessoryDecimalIntegerStringType;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
@@ -89,6 +90,42 @@ final class ScalarStringToTypeMapper
 
         if ($loweredScalarName === 'array-key') {
             return new UnionType([new IntegerType(), new StringType()]);
+        }
+
+        if ($loweredScalarName === 'callable-string') {
+            return TypeCombinator::intersect(new StringType(), new CallableType());
+        }
+
+        if ($loweredScalarName === 'non-empty-lowercase-string') {
+            return TypeCombinator::intersect(
+                new StringType(),
+                new AccessoryNonEmptyStringType(),
+                new AccessoryLowercaseStringType()
+            );
+        }
+
+        if ($loweredScalarName === 'non-empty-uppercase-string') {
+            return TypeCombinator::intersect(
+                new StringType(),
+                new AccessoryNonEmptyStringType(),
+                new AccessoryUppercaseStringType()
+            );
+        }
+
+        if ($loweredScalarName === 'non-empty-literal-string') {
+            return TypeCombinator::intersect(
+                new StringType(),
+                new AccessoryNonEmptyStringType(),
+                new AccessoryLiteralStringType()
+            );
+        }
+
+        if ($loweredScalarName === 'decimal-int-string') {
+            return TypeCombinator::intersect(new StringType(), new AccessoryDecimalIntegerStringType());
+        }
+
+        if ($loweredScalarName === 'non-decimal-int-string') {
+            return TypeCombinator::intersect(new StringType(), new AccessoryDecimalIntegerStringType(true));
         }
 
         foreach (self::SCALAR_NAME_BY_TYPE as $objectType => $scalarNames) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9814