### PR TITLE
[TypeDeclaration] Skip trait methods on ParamTypeByMethodCallType rules

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ArrayParamTypeByMethodCallTypeRector/Fixture/skip_trait.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ArrayParamTypeByMethodCallTypeRector/Fixture/skip_trait.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ArrayParamTypeByMethodCallTypeRector\Fixture;
+
+trait SkipTrait
+{
+    public function go($value)
+    {
+        $this->use($value);
+    }
+
+    private function use(array $value): void
+    {
+    }
+}

--- a/rules/TypeDeclaration/Rector/ClassMethod/AbstractParamTypeByMethodCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/AbstractParamTypeByMethodCallTypeRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
 use PHPStan\Type\Type;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
@@ -99,6 +100,12 @@ abstract class AbstractParamTypeByMethodCallTypeRector extends AbstractRector
 
     private function shouldSkipClassMethod(ClassMethod $classMethod): bool
     {
+        // trait method can be used in a class that requires a contract type, adding a param type would break it
+        $scope = $classMethod->getAttribute(AttributeKey::SCOPE);
+        if ($scope instanceof Scope && $scope->isInTrait()) {
+            return true;
+        }
+
         // user-guarded class: adding a param type here would break its child classes
         if ($this->parentClassMethodTypeOverrideGuard->isTypeGuardedClass($classMethod)) {
             return true;


### PR DESCRIPTION
Trait methods may be composed into classes that implement an interface contract. A param type inferred from a call inside the trait itself is not safe to add: once the trait is used in a class where the method must match a wider contract signature, the added type breaks it.

Skip `ClassMethod` nodes whose scope is inside a trait.

```diff
 trait SomeTrait
 {
-    public function go($value)
+    public function go(array $value)  // wrong, breaks contract when trait used in class implementing an interface
     {
         $this->use($value);
     }

     private function use(array $value): void
     {
     }
 }
```

The skip lives in the shared `AbstractParamTypeByMethodCallTypeRector::shouldSkipClassMethod()`, so it covers all four rules built on it:

- `ArrayParamTypeByMethodCallTypeRector`
- `ObjectParamTypeByMethodCallTypeRector`
- `ScalarParamTypeByMethodCallTypeRector`
- `ParamTypeByMethodCallTypeRector`