### PR TITLE
[DeadCode] Fix crash on float version arg in ConditionResolver

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/UnwrapFutureCompatibleIfPhpVersionRector/Fixture/float_version.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/UnwrapFutureCompatibleIfPhpVersionRector/Fixture/float_version.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector\Fixture;
+
+class FloatVersion
+{
+    public function run()
+    {
+        // current PHP: 10.0
+        if (version_compare(PHP_VERSION, 7.2, '<')) {
+            return 'is PHP 7.1-';
+        } else {
+            return 'is PHP 7.2+';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector\Fixture;
+
+class FloatVersion
+{
+    public function run()
+    {
+        // current PHP: 10.0
+        return 'is PHP 7.2+';
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/If_/UnwrapFutureCompatibleIfPhpVersionRector/Fixture/skip_bool_version.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/UnwrapFutureCompatibleIfPhpVersionRector/Fixture/skip_bool_version.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector\Fixture;
+
+class SkipBoolVersion
+{
+    public function run()
+    {
+        if (version_compare(PHP_VERSION, true, '<')) {
+            return 'a';
+        } else {
+            return 'b';
+        }
+    }
+}
+
+?>

--- a/rules/DeadCode/ConditionResolver.php
+++ b/rules/DeadCode/ConditionResolver.php
@@ -127,8 +127,17 @@ final readonly class ConditionResolver
             return $this->phpVersionProvider->provide();
         }
 
+        // version_compare() juggles the version to string first, e.g. 7.3 to "7.3"
+        if (is_float($version)) {
+            $version = (string) $version;
+        }
+
         if (is_string($version)) {
             return PhpVersionFactory::createIntVersion($version);
+        }
+
+        if (! is_int($version)) {
+            return null;
         }
 
         return $version;


### PR DESCRIPTION
Fixes rectorphp/rector#9820

`version_compare()` juggles its arguments to string, so passing a float version is valid PHP:

```php
$result = version_compare(PHP_VERSION, 7.3, '>=') ? "yay" : "nay";
```

`ConditionResolver::resolveArgumentValue()` returned the resolved value as-is from a `?int` method, so a float blew up:

```
Rector\DeadCode\ConditionResolver::resolveArgumentValue(): Return value must be of type ?int, float returned
```

This hits every run, not just `DeadCode` ones, as the core `PhpVersionConditionNodeVisitor` also uses the resolver — hence the "System error" in the report.

## Fix

Mirror what PHP does: juggle the float to string (`7.3` -> `"7.3"` -> `70300`) before parsing, and bail out on any remaining non-int value rather than returning it.

```diff
+        // version_compare() juggles the version to string first, e.g. 7.3 to "7.3"
+        if (is_float($version)) {
+            $version = (string) $version;
+        }
+
         if (is_string($version)) {
             return PhpVersionFactory::createIntVersion($version);
         }
 
+        if (! is_int($version)) {
+            return null;
+        }
+
         return $version;
```

The float version now resolves like its string counterpart, so `UnwrapFutureCompatibleIfPhpVersionRector` handles it:

```diff
 function floatArg()
 {
-    if (version_compare(PHP_VERSION, 7.3, '<')) {
-        return 'old';
-    } else {
-        return 'new';
-    }
+    return 'new';
 }
```

## Tests

- `float_version.php.inc` — float version resolves and unwraps, same as the `'7.2'` string fixture.
- `skip_bool_version.php.inc` — non-int, non-string, non-float arg bails out instead of crashing.