### PR TITLE
Fix codeception data provider detection

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddReturnDocblockDataProviderRector/Fixture/codeception_data_provider_method.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddReturnDocblockDataProviderRector/Fixture/codeception_data_provider_method.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddReturnDocblockDataProviderRector\Fixture;
+
+use Codeception\Attribute\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CodeceptionDataProviderAttribute extends TestCase
+{
+    #[DataProvider('provideData')]
+    public function testSomething()
+    {
+    }
+
+    public static function provideData()
+    {
+        return [
+            ['data1'],
+            ['data2'],
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddReturnDocblockDataProviderRector\Fixture;
+
+use Codeception\Attribute\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CodeceptionDataProviderAttribute extends TestCase
+{
+    #[DataProvider('provideData')]
+    public function testSomething()
+    {
+    }
+
+    /**
+     * @return string[][]
+     */
+    public static function provideData()
+    {
+        return [
+            ['data1'],
+            ['data2'],
+        ];
+    }
+}
+
+?>

--- a/rules/TypeDeclarationDocblocks/Enum/TestClassName.php
+++ b/rules/TypeDeclarationDocblocks/Enum/TestClassName.php
@@ -6,5 +6,7 @@ namespace Rector\TypeDeclarationDocblocks\Enum;
 
 final class TestClassName
 {
-    public const string DATA_PROVIDER = 'PHPUnit\Framework\Attributes\DataProvider';
+    public const string PHPUNIT_DATA_PROVIDER = 'PHPUnit\Framework\Attributes\DataProvider';
+
+    public const string CODECEPTION_DATA_PROVIDER = 'Codeception\Attribute\DataProvider';
 }

--- a/rules/TypeDeclarationDocblocks/NodeFinder/DataProviderMethodsFinder.php
+++ b/rules/TypeDeclarationDocblocks/NodeFinder/DataProviderMethodsFinder.php
@@ -15,6 +15,11 @@ use Rector\TypeDeclarationDocblocks\Enum\TestClassName;
 
 final readonly class DataProviderMethodsFinder
 {
+    private const array DATA_PROVIDER_ATTRIBUTES = [
+        TestClassName::PHPUNIT_DATA_PROVIDER,
+        TestClassName::CODECEPTION_DATA_PROVIDER,
+    ];
+
     public function __construct(
         private PhpDocInfoFactory $phpDocInfoFactory,
         private NodeNameResolver $nodeNameResolver
@@ -62,7 +67,7 @@ final readonly class DataProviderMethodsFinder
 
         foreach ($classMethod->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $attribute) {
-                if (! $this->nodeNameResolver->isName($attribute->name, TestClassName::DATA_PROVIDER)) {
+                if (! $this->nodeNameResolver->isNames($attribute->name, self::DATA_PROVIDER_ATTRIBUTES)) {
                     continue;
                 }
 


### PR DESCRIPTION
Hi guys! Added detection for [Codeception dataProviders](https://codeception.com/docs/AdvancedUsage#DataProvider-Attribute). In my projects these dataProviders are private, which triggers false positives for RemoveUnusedPrivateMethodRector