### PR TITLE
Bump to StructArmed ^0.15 and enable MustBeFinalRule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "webmozart/assert": "^2.4"
     },
     "require-dev": {
-        "boundwize/structarmed": "^0.14",
+        "boundwize/structarmed": "^0.15",
         "nette/robot-loader": "^4.1",
         "php-parallel-lint/php-parallel-lint": "^1.4",
         "phpstan/extension-installer": "^1.4",

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/SomeShort.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/SomeShort.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNames;
 
-final class SomeShort
+class SomeShort
 {
 }

--- a/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/SomeShort.php
+++ b/rules-tests/Renaming/Rector/Name/RenameClassRector/FixtureAutoImportNames/SomeShort.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Renaming\Rector\Name\RenameClassRector\FixtureAutoImportNames;
 
-class SomeShort
+final class SomeShort
 {
 }

--- a/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
+++ b/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
@@ -31,7 +31,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see RFC https://wiki.php.net/rfc/first_class_callable_syntax
  * @see \Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\ArrayToFirstClassCallableRectorTest
  */
-class ArrayToFirstClassCallableRector extends AbstractRector implements MinPhpVersionInterface
+final class ArrayToFirstClassCallableRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
         private readonly ArrayCallableMethodMatcher $arrayCallableMethodMatcher,

--- a/src/PhpParser/Node/FileNode.php
+++ b/src/PhpParser/Node/FileNode.php
@@ -22,7 +22,7 @@ use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 /**
  * Inspired by https://github.com/phpstan/phpstan-src/commit/ed81c3ad0b9877e6122c79b4afda9d10f3994092
  */
-class FileNode extends Stmt
+final class FileNode extends Stmt
 {
     /**
      * Imports queued to be added on the next UseAddingPostRector run; scoped to this file

--- a/structarmed.php
+++ b/structarmed.php
@@ -26,6 +26,7 @@ return Architecture::define()
         ],
         'source.must_be_final' => [
             '*/Source/*',
+            '*/Source/*',
         ],
     ])
     ->withPreset(Preset::PSR4());

--- a/structarmed.php
+++ b/structarmed.php
@@ -26,7 +26,7 @@ return Architecture::define()
         ],
         'source.must_be_final' => [
             '*/Source/*',
-            '*/Source/*',
+            '*/Fixture*',
         ],
     ])
     ->withPreset(Preset::PSR4());

--- a/structarmed.php
+++ b/structarmed.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Preset\Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr4Preset;
+use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
 
 return Architecture::define()
+    ->rule(
+        'source.must_be_final',
+        new MustBeFinalRule(layer: 'Source'),
+    )
     ->skip([
         Psr4Preset::CLASSES_MUST_MATCH_COMPOSER => [
             // the namespace different is on purpose
@@ -18,6 +23,9 @@ return Architecture::define()
 
             // simulate under phpstan.phar
             __DIR__ . '/rules-tests/Php71/Rector/FuncCall/RemoveExtraParametersRector/Source/phpstan.phar',
+        ],
+        'source.must_be_final' => [
+            '*/Source/*',
         ],
     ])
     ->withPreset(Preset::PSR4());


### PR DESCRIPTION
StructArmed 0.15.0 introduce `ExtendedClassAwareRuleInterface` that makes its `MustBeFinalRule` safely be used to skip if there is class that extend target class.

This PR bump StructArmed to `^0.15` and apply the `MustBeFinalRule` with single command to fix.

```bash
vendor/bin/structarmed analyze --fix
```