### PR TITLE
[Privatization] Skip Symfony Command protected static property in PrivatizeFinalClassPropertyRector

### DIFF
--- a/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Fixture/skip_symfony_command_default_description.php.inc
+++ b/rules-tests/Privatization/Rector/Property/PrivatizeFinalClassPropertyRector/Fixture/skip_symfony_command_default_description.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+
+final class SendWinnerEmailCommand extends Command
+{
+    protected static $defaultDescription = 'Send winner email variant to remaining contacts';
+}

--- a/rules/Privatization/Guard/ParentPropertyLookupGuard.php
+++ b/rules/Privatization/Guard/ParentPropertyLookupGuard.php
@@ -21,6 +21,15 @@ use Rector\Reflection\ClassReflectionAnalyzer;
 
 final readonly class ParentPropertyLookupGuard
 {
+    /**
+     * Symfony Console Command reserved static properties, read by the parent class via reflection
+     * even when not declared on the parent class itself
+     * @see https://github.com/symfony/console/blob/7.1/Command/Command.php
+     *
+     * @var string[]
+     */
+    private const SYMFONY_COMMAND_RESERVED_PROPERTY_NAMES = ['defaultName', 'defaultDescription'];
+
     public function __construct(
         private BetterNodeFinder $betterNodeFinder,
         private NodeNameResolver $nodeNameResolver,
@@ -49,6 +58,10 @@ final readonly class ParentPropertyLookupGuard
             return false;
         }
 
+        if ($this->isSymfonyCommandReservedProperty($classReflection, $propertyName)) {
+            return false;
+        }
+
         $parentClassName = $this->classReflectionAnalyzer->resolveParentClassName($classReflection);
         if ($parentClassName === null) {
             return true;
@@ -63,6 +76,15 @@ final readonly class ParentPropertyLookupGuard
         }
 
         return $this->isGuardedByParents($parentClassReflections, $propertyName, $className);
+    }
+
+    private function isSymfonyCommandReservedProperty(ClassReflection $classReflection, string $propertyName): bool
+    {
+        if (! in_array($propertyName, self::SYMFONY_COMMAND_RESERVED_PROPERTY_NAMES, true)) {
+            return false;
+        }
+
+        return $classReflection->is('Symfony\Component\Console\Command\Command');
     }
 
     private function isFoundInParentClassMethods(


### PR DESCRIPTION
`PrivatizeFinalClassPropertyRector` must keep a `protected static` property that is declared on a parent class. Symfony console commands are the common real-world case:

```php
use Symfony\Component\Console\Command\Command;

final class SendWinnerEmailCommand extends Command
{
    protected static $defaultDescription = 'Send winner email variant to remaining contacts';
}
```

`Command` declares `protected static $defaultDescription`, so privatizing the child override would break the parent contract. The property must stay `protected` (unchanged).

The `ParentPropertyLookupGuard` already guards this via `hasStaticProperty()`; this PR adds a fixture locking the behavior against a real `Symfony\Component\Console\Command\Command` parent.