### PR TITLE
[DeadCode] Add RemoveDeadInstanceOfAssertRector

### DIFF
--- a/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/Fixture/promoted_property.php.inc
+++ b/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/Fixture/promoted_property.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Source\UserRepository;
+
+final class PromotedProperty
+{
+    public function __construct(
+        private UserRepository $userRepository
+    ) {
+    }
+
+    public function run(): void
+    {
+        assert($this->userRepository instanceof UserRepository);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Source\UserRepository;
+
+final class PromotedProperty
+{
+    public function __construct(
+        private UserRepository $userRepository
+    ) {
+    }
+
+    public function run(): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/Fixture/skip_nullable_property.php.inc
+++ b/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/Fixture/skip_nullable_property.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Source\UserRepository;
+
+final class SkipNullableProperty
+{
+    public function __construct(
+        private ?UserRepository $userRepository = null
+    ) {
+    }
+
+    public function run(): void
+    {
+        assert($this->userRepository instanceof UserRepository);
+    }
+}

--- a/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/Fixture/skip_untyped_property.php.inc
+++ b/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/Fixture/skip_untyped_property.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Source\UserRepository;
+
+final class SkipUntypedProperty
+{
+    private $userRepository;
+
+    public function run(): void
+    {
+        assert($this->userRepository instanceof UserRepository);
+    }
+}

--- a/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/Fixture/skip_with_message.php.inc
+++ b/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/Fixture/skip_with_message.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Source\UserRepository;
+
+final class SkipWithMessage
+{
+    public function __construct(
+        private UserRepository $userRepository
+    ) {
+    }
+
+    public function run(): void
+    {
+        assert($this->userRepository instanceof UserRepository, 'must be set');
+    }
+}

--- a/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/Fixture/typed_variable.php.inc
+++ b/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/Fixture/typed_variable.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Source\UserRepository;
+
+function typedVariable(UserRepository $userRepository): void
+{
+    assert($userRepository instanceof UserRepository);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Source\UserRepository;
+
+function typedVariable(UserRepository $userRepository): void
+{
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/RemoveDeadInstanceOfAssertRectorTest.php
+++ b/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/RemoveDeadInstanceOfAssertRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveDeadInstanceOfAssertRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/Source/UserRepository.php
+++ b/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/Source/UserRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\Source;
+
+final class UserRepository
+{
+}

--- a/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveDeadInstanceOfAssertRector::class]);

--- a/rules/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector.php
+++ b/rules/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\StmtsAwareInterface;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Nop;
+use Rector\PhpParser\Enum\NodeGroup;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector\RemoveDeadInstanceOfAssertRectorTest
+ */
+final class RemoveDeadInstanceOfAssertRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove assert() with instanceof check on a value whose type is already known',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function __construct(
+        private UserRepository $userRepository
+    ) {
+    }
+
+    public function run(): void
+    {
+        assert($this->userRepository instanceof UserRepository);
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function __construct(
+        private UserRepository $userRepository
+    ) {
+    }
+
+    public function run(): void
+    {
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return NodeGroup::STMTS_AWARE;
+    }
+
+    /**
+     * @param StmtsAware $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->stmts === null) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($node->stmts as $key => $stmt) {
+            if (! $stmt instanceof Expression) {
+                continue;
+            }
+
+            if (! $this->isDeadInstanceOfAssert($stmt->expr)) {
+                continue;
+            }
+
+            $docComment = $stmt->getDocComment();
+            if ($docComment instanceof Doc) {
+                $nop = new Nop();
+                $nop->setDocComment($docComment);
+                $node->stmts[$key] = $nop;
+            } else {
+                unset($node->stmts[$key]);
+            }
+
+            $hasChanged = true;
+        }
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        $node->stmts = array_values($node->stmts);
+
+        return $node;
+    }
+
+    private function isDeadInstanceOfAssert(Expr $expr): bool
+    {
+        if (! $expr instanceof FuncCall) {
+            return false;
+        }
+
+        if ($expr->isFirstClassCallable()) {
+            return false;
+        }
+
+        if (! $this->isName($expr, 'assert')) {
+            return false;
+        }
+
+        // single-arg assert only; keep asserts that carry a description message
+        if (count($expr->getArgs()) !== 1) {
+            return false;
+        }
+
+        $instanceof = $expr->getArgs()[0]
+            ->value;
+        if (! $instanceof instanceof Instanceof_) {
+            return false;
+        }
+
+        // only property fetch or variable value
+        if (! $instanceof->expr instanceof PropertyFetch && ! $instanceof->expr instanceof Variable) {
+            return false;
+        }
+
+        if (! $instanceof->class instanceof Name) {
+            return false;
+        }
+
+        $classType = $this->nodeTypeResolver->getType($instanceof->class);
+        $exprType = $this->nodeTypeResolver->getType($instanceof->expr);
+        if ($classType->equals($exprType)) {
+            return true;
+        }
+        return $classType->isSuperTypeOf($exprType)
+            ->yes();
+    }
+}

--- a/rules/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector.php
+++ b/rules/DeadCode/Rector/StmtsAwareInterface/RemoveDeadInstanceOfAssertRector.php
@@ -148,6 +148,7 @@ CODE_SAMPLE
         if ($classType->equals($exprType)) {
             return true;
         }
+
         return $classType->isSuperTypeOf($exprType)
             ->yes();
     }

--- a/rules/Privatization/Guard/ParentPropertyLookupGuard.php
+++ b/rules/Privatization/Guard/ParentPropertyLookupGuard.php
@@ -28,7 +28,7 @@ final readonly class ParentPropertyLookupGuard
      *
      * @var string[]
      */
-    private const SYMFONY_COMMAND_RESERVED_PROPERTY_NAMES = ['defaultName', 'defaultDescription'];
+    private const array SYMFONY_COMMAND_RESERVED_PROPERTY_NAMES = ['defaultName', 'defaultDescription'];
 
     public function __construct(
         private BetterNodeFinder $betterNodeFinder,

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -64,6 +64,7 @@ use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
 use Rector\DeadCode\Rector\Stmt\RemoveConditionExactReturnRector;
 use Rector\DeadCode\Rector\Stmt\RemoveNextSameValueConditionRector;
 use Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector;
+use Rector\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector;
 use Rector\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector;
 use Rector\DeadCode\Rector\Ternary\RemoveUselessTernaryRector;
 use Rector\DeadCode\Rector\Ternary\TernaryToBooleanOrFalseToBooleanAndRector;
@@ -104,6 +105,7 @@ final class DeadCodeLevel
         RemoveFilterVarOnExactTypeRector::class,
 
         RemoveTypedPropertyDeadInstanceOfRector::class,
+        RemoveDeadInstanceOfAssertRector::class,
         TernaryToBooleanOrFalseToBooleanAndRector::class,
         RemoveUselessTernaryRector::class,
         RemoveDoubleAssignRector::class,


### PR DESCRIPTION
Adds a new dead-code rule that removes redundant `assert($value instanceof X)` statements when the value's type is already known to be `X` (or a subtype).

Covers property fetches and variables.

```diff
 final class SomeClass
 {
     public function __construct(
         private UserRepository $userRepository
     ) {
     }

     public function run(): void
     {
-        assert($this->userRepository instanceof UserRepository);
     }
 }
```

Kept (not changed):

```php
// nullable property - instanceof is not always true
assert($this->userRepository instanceof UserRepository); // ?UserRepository

// untyped property - type unknown
assert($this->userRepository instanceof UserRepository); // private $userRepository

// carries a description message - preserved
assert($this->userRepository instanceof UserRepository, 'must be set');
```

Registered in `DeadCodeLevel`.