### PR TITLE
[DeadCode] Add RemoveDoubleSelfAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveDoubleSelfAssignRector/Fixture/fixture.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveDoubleSelfAssignRector/Fixture/fixture.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveDoubleSelfAssignRector\Fixture;
+
+$validator = $validator = createValidator();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveDoubleSelfAssignRector\Fixture;
+
+$validator = createValidator();
+
+?>

--- a/rules-tests/DeadCode/Rector/Assign/RemoveDoubleSelfAssignRector/Fixture/skip_different_variable.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveDoubleSelfAssignRector/Fixture/skip_different_variable.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveDoubleSelfAssignRector\Fixture;
+
+$first = $second = createValidator();

--- a/rules-tests/DeadCode/Rector/Assign/RemoveDoubleSelfAssignRector/RemoveDoubleSelfAssignRectorTest.php
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveDoubleSelfAssignRector/RemoveDoubleSelfAssignRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveDoubleSelfAssignRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveDoubleSelfAssignRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/Assign/RemoveDoubleSelfAssignRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveDoubleSelfAssignRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Assign\RemoveDoubleSelfAssignRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveDoubleSelfAssignRector::class]);

--- a/rules/DeadCode/Rector/Assign/RemoveDoubleSelfAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveDoubleSelfAssignRector.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\Assign;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Variable;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\Assign\RemoveDoubleSelfAssignRector\RemoveDoubleSelfAssignRectorTest
+ */
+final class RemoveDoubleSelfAssignRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Remove duplicated self assign of the same variable', [
+            new CodeSample(
+                '$validator = $validator = Validation::createValidator();',
+                '$validator = Validation::createValidator();'
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Assign::class];
+    }
+
+    /**
+     * @param Assign $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node->var instanceof Variable) {
+            return null;
+        }
+
+        if (! $node->expr instanceof Assign) {
+            return null;
+        }
+
+        $innerAssign = $node->expr;
+        if (! $innerAssign->var instanceof Variable) {
+            return null;
+        }
+
+        if (! $this->nodeComparator->areNodesEqual($node->var, $innerAssign->var)) {
+            return null;
+        }
+
+        return $innerAssign;
+    }
+}

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -8,6 +8,7 @@ use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\DeadCode\Rector\Array_\RemoveDuplicatedArrayKeyRector;
 use Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector;
+use Rector\DeadCode\Rector\Assign\RemoveDoubleSelfAssignRector;
 use Rector\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector;
 use Rector\DeadCode\Rector\Block\ReplaceBlockToItsStmtsRector;
 use Rector\DeadCode\Rector\BooleanAnd\RemoveAndTrueRector;
@@ -109,6 +110,7 @@ final class DeadCodeLevel
         TernaryToBooleanOrFalseToBooleanAndRector::class,
         RemoveUselessTernaryRector::class,
         RemoveDoubleAssignRector::class,
+        RemoveDoubleSelfAssignRector::class,
         RemoveUselessAssignFromPropertyPromotionRector::class,
         RemoveConcatAutocastRector::class,
         SimplifyIfElseWithSameContentRector::class,


### PR DESCRIPTION
Adds a dead-code rule that removes a duplicated self-assign of the same variable in a chained assignment.

```diff
-$validator = $validator = Validation::createValidator();
+$validator = Validation::createValidator();
```

Only triggers when both sides of the outer assign are the **same** `Variable`; a real chained assign to different variables (`$first = $second = ...`) is skipped.