### PR TITLE
[DeadCode] Add RemoveParentDelegatingClassMethodRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_added_native_types.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_added_native_types.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentWithDocblockTypes;
+
+final class SkipAddedNativeTypes extends SomeParentWithDocblockTypes
+{
+    public function compute(int $value): int
+    {
+        return parent::compute($value);
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_attributed_method.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_attributed_method.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+final class SkipAttributedMethod extends SomeParentCommand
+{
+    #[\Deprecated]
+    protected function configure(): void
+    {
+        parent::configure();
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_construct.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_construct.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentWithConstructor;
+
+final class SkipConstruct extends SomeParentWithConstructor
+{
+    public function __construct(int $value)
+    {
+        parent::__construct($value);
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_deprecated_docblock.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_deprecated_docblock.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+final class SkipDeprecatedDocblock extends SomeParentCommand
+{
+    /**
+     * @deprecated
+     */
+    protected function configure(): void
+    {
+        parent::configure();
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_different_parent_method.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_different_parent_method.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+final class SkipDifferentParentMethod extends SomeParentCommand
+{
+    protected function configure(): void
+    {
+        parent::anotherMethod();
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_extra_stmt.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_extra_stmt.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+final class SkipExtraStmt extends SomeParentCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        echo 'more';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_final_method.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_final_method.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+class SkipFinalMethod extends SomeParentCommand
+{
+    final protected function configure(): void
+    {
+        parent::configure();
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_narrowed_param_type.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_narrowed_param_type.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+final class SkipNarrowedParamType extends SomeParentCommand
+{
+    public function process(int|float $value): int
+    {
+        return parent::process($value);
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_no_parent_class.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_no_parent_class.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+final class SkipNoParentClass
+{
+    protected function configure(): void
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_param_docblock.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_param_docblock.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+final class SkipParamDocblock extends SomeParentCommand
+{
+    /**
+     * @param positive-int $value
+     */
+    public function process(int $value): int
+    {
+        return parent::process($value);
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_private_parent_method.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_private_parent_method.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentWithPrivateMethod;
+
+final class SkipPrivateParentMethod extends SomeParentWithPrivateMethod
+{
+    protected function resolve(): void
+    {
+        parent::resolve();
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_swapped_args.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_swapped_args.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentWithTwoParams;
+
+final class SkipSwappedArgs extends SomeParentWithTwoParams
+{
+    public function run(int $first, int $second): int
+    {
+        return parent::run($second, $first);
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_wider_visibility.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_wider_visibility.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+final class SkipWiderVisibility extends SomeParentCommand
+{
+    public function configure(): void
+    {
+        parent::configure();
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/some_command.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/some_command.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+final class SomeCommand extends SomeParentCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+final class SomeCommand extends SomeParentCommand
+{
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/with_params_and_return.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/with_params_and_return.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+final class WithParamsAndReturn extends SomeParentCommand
+{
+    public function process(int $value): int
+    {
+        return parent::process($value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+final class WithParamsAndReturn extends SomeParentCommand
+{
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/RemoveParentDelegatingClassMethodRectorTest.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/RemoveParentDelegatingClassMethodRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveParentDelegatingClassMethodRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Source/SomeParentCommand.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Source/SomeParentCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source;
+
+abstract class SomeParentCommand
+{
+    protected function configure(): void
+    {
+    }
+
+    public function process(int $value): int
+    {
+        return $value;
+    }
+
+    public static function make(): void
+    {
+    }
+
+    public function anotherMethod(): void
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Source/SomeParentWithConstructor.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Source/SomeParentWithConstructor.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source;
+
+abstract class SomeParentWithConstructor
+{
+    public function __construct(int $value)
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Source/SomeParentWithDocblockTypes.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Source/SomeParentWithDocblockTypes.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source;
+
+abstract class SomeParentWithDocblockTypes
+{
+    /**
+     * @param int $value
+     * @return int
+     */
+    public function compute($value)
+    {
+        return $value;
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Source/SomeParentWithPrivateMethod.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Source/SomeParentWithPrivateMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source;
+
+abstract class SomeParentWithPrivateMethod
+{
+    private function resolve(): void
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Source/SomeParentWithTwoParams.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Source/SomeParentWithTwoParams.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source;
+
+abstract class SomeParentWithTwoParams
+{
+    public function run(int $first, int $second): int
+    {
+        return $first - $second;
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveParentDelegatingClassMethodRector::class]);

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeVisitor;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Reflection\ExtendedParameterReflection;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Enum\ObjectReference;
 use Rector\PHPStan\ScopeFetcher;
@@ -116,7 +117,15 @@ CODE_SAMPLE
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
 
         return $phpDocInfo->hasByNames(
-            ['@param', '@phpstan-param', '@psalm-param', '@return', '@phpstan-return', '@psalm-return']
+            [
+                '@param',
+                '@phpstan-param',
+                '@psalm-param',
+                '@return',
+                '@phpstan-return',
+                '@psalm-return',
+                '@deprecated',
+            ]
         );
     }
 
@@ -143,7 +152,14 @@ CODE_SAMPLE
             return null;
         }
 
-        return $parentClassReflection->getNativeMethod($methodName);
+        $extendedMethodReflection = $parentClassReflection->getNativeMethod($methodName);
+
+        // a private parent method is not visible in the child scope
+        if ($extendedMethodReflection->isPrivate()) {
+            return null;
+        }
+
+        return $extendedMethodReflection;
     }
 
     /**
@@ -233,7 +249,7 @@ CODE_SAMPLE
 
         foreach ($classMethod->getParams() as $position => $param) {
             $parameterReflection = $parameterReflections[$position] ?? null;
-            if ($parameterReflection === null) {
+            if (! $parameterReflection instanceof ExtendedParameterReflection) {
                 return false;
             }
 
@@ -242,8 +258,10 @@ CODE_SAMPLE
                 continue;
             }
 
+            // compare native types only, as the child method may add a native type
+            // the parent only has in a docblock - removing it would drop a runtime check
             $parentParameterType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
-                $parameterReflection->getType(),
+                $parameterReflection->getNativeType(),
                 TypeKind::PARAM
             );
 
@@ -258,7 +276,7 @@ CODE_SAMPLE
         }
 
         $parentReturnType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
-            $extendedParametersAcceptor->getReturnType(),
+            $extendedParametersAcceptor->getNativeReturnType(),
             TypeKind::RETURN
         );
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\NodeVisitor;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Enum\ObjectReference;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\Rector\AbstractRector;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use Rector\ValueObject\MethodName;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\RemoveParentDelegatingClassMethodRectorTest
+ */
+final class RemoveParentDelegatingClassMethodRector extends AbstractRector
+{
+    public function __construct(
+        private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove class method that only delegates call to parent class method with the same values',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeCommand extends Command
+{
+    protected function configure(): void
+    {
+        parent::configure();
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeCommand extends Command
+{
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?int
+    {
+        // constructors are handled by RemoveParentDelegatingConstructorRector
+        if ($this->isName($node, MethodName::CONSTRUCT)) {
+            return null;
+        }
+
+        if ($node->isFinal() || $node->isAbstract() || $node->isPrivate() || $node->byRef) {
+            return null;
+        }
+
+        if ($node->stmts === null || count($node->stmts) !== 1) {
+            return null;
+        }
+
+        if ($node->attrGroups !== []) {
+            return null;
+        }
+
+        if ($this->hasRefiningDocblock($node)) {
+            return null;
+        }
+
+        $parentMethodReflection = $this->matchParentMethodReflection($node);
+        if (! $parentMethodReflection instanceof ExtendedMethodReflection) {
+            return null;
+        }
+
+        if (! $this->isParentCallDelegatingParams($node, $node->stmts[0])) {
+            return null;
+        }
+
+        if (! $this->isSignatureMatching($node, $parentMethodReflection)) {
+            return null;
+        }
+
+        return NodeVisitor::REMOVE_NODE;
+    }
+
+    private function hasRefiningDocblock(ClassMethod $classMethod): bool
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
+
+        return $phpDocInfo->hasByNames(
+            ['@param', '@phpstan-param', '@psalm-param', '@return', '@phpstan-return', '@psalm-return']
+        );
+    }
+
+    private function matchParentMethodReflection(ClassMethod $classMethod): ?ExtendedMethodReflection
+    {
+        $scope = ScopeFetcher::fetch($classMethod);
+
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        if (! $classReflection->isClass()) {
+            return null;
+        }
+
+        $parentClassReflection = $classReflection->getParentClass();
+        if (! $parentClassReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        $methodName = $classMethod->name->toString();
+        if (! $parentClassReflection->hasNativeMethod($methodName)) {
+            return null;
+        }
+
+        return $parentClassReflection->getNativeMethod($methodName);
+    }
+
+    /**
+     * Body must be a sole parent::sameMethod($sameParams, ...) call, passing every param in the same order
+     */
+    private function isParentCallDelegatingParams(ClassMethod $classMethod, Stmt $soleStmt): bool
+    {
+        $staticCall = $this->matchParentStaticCall($soleStmt, $classMethod->name->toString());
+        if (! $staticCall instanceof StaticCall) {
+            return false;
+        }
+
+        $args = $staticCall->getArgs();
+        $params = $classMethod->getParams();
+        if (count($args) !== count($params)) {
+            return false;
+        }
+
+        $paramNames = [];
+        foreach ($params as $param) {
+            if ($param->variadic || $param->byRef || $param->default instanceof Node || $param->attrGroups !== []) {
+                return false;
+            }
+
+            $paramNames[] = $this->getName($param->var);
+        }
+
+        $argNames = [];
+        foreach ($args as $arg) {
+            if ($arg->name instanceof Node || $arg->unpack) {
+                return false;
+            }
+
+            if (! $arg->value instanceof Variable) {
+                return false;
+            }
+
+            $argNames[] = $this->getName($arg->value);
+        }
+
+        return $paramNames === $argNames;
+    }
+
+    private function matchParentStaticCall(Stmt $stmt, string $methodName): ?StaticCall
+    {
+        if ($stmt instanceof Return_) {
+            $expr = $stmt->expr;
+        } elseif ($stmt instanceof Expression) {
+            $expr = $stmt->expr;
+        } else {
+            return null;
+        }
+
+        if (! $expr instanceof StaticCall) {
+            return null;
+        }
+
+        if ($expr->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (! $this->isName($expr->class, ObjectReference::PARENT)) {
+            return null;
+        }
+
+        if (! $this->isName($expr->name, $methodName)) {
+            return null;
+        }
+
+        return $expr;
+    }
+
+    private function isSignatureMatching(
+        ClassMethod $classMethod,
+        ExtendedMethodReflection $extendedMethodReflection
+    ): bool {
+        if ($classMethod->isStatic() !== $extendedMethodReflection->isStatic()) {
+            return false;
+        }
+
+        if ($classMethod->isPublic() !== $extendedMethodReflection->isPublic()) {
+            return false;
+        }
+
+        $extendedParametersAcceptor = $extendedMethodReflection->getOnlyVariant();
+        $parameterReflections = $extendedParametersAcceptor->getParameters();
+
+        foreach ($classMethod->getParams() as $position => $param) {
+            $parameterReflection = $parameterReflections[$position] ?? null;
+            if ($parameterReflection === null) {
+                return false;
+            }
+
+            // no type override
+            if ($param->type === null) {
+                continue;
+            }
+
+            $parentParameterType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
+                $parameterReflection->getType(),
+                TypeKind::PARAM
+            );
+
+            if (! $this->nodeComparator->areNodesEqual($param->type, $parentParameterType)) {
+                return false;
+            }
+        }
+
+        // no return type override
+        if (! $classMethod->returnType instanceof Node) {
+            return true;
+        }
+
+        $parentReturnType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(
+            $extendedParametersAcceptor->getReturnType(),
+            TypeKind::RETURN
+        );
+
+        return $this->nodeComparator->areNodesEqual($classMethod->returnType, $parentReturnType);
+    }
+}

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -19,6 +19,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveMixedDocblockOverruledByNativeTypeRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveNullTagValueNodeRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
@@ -153,6 +154,7 @@ final class DeadCodeLevel
 
         RemoveParentCallWithoutParentRector::class,
         RemoveParentDelegatingConstructorRector::class,
+        RemoveParentDelegatingClassMethodRector::class,
 
         RemoveDeadConditionAboveReturnRector::class,
         RemoveDeadLoopRector::class,


### PR DESCRIPTION
Complements `RemoveParentDelegatingConstructorRector`, which only handles `__construct()`. Any other method whose body is a single `parent::sameMethod($sameParams)` call does nothing either.

```diff
 final class SomeCommand extends Command
 {
-    protected function configure(): void
-    {
-        parent::configure();
-    }
 }
```

Return-value delegation is covered too:

```diff
 final class SomeReader extends AbstractReader
 {
-    public function read(string $path): string
-    {
-        return parent::read($path);
-    }
 }
```

Skipped when removal would change behavior or signature:

* `__construct()` (other rule owns it)
* `final`, `abstract`, `private`, by-ref returning methods
* body with more than the single parent call, or delegating to a *different* parent method
* visibility or static-ness differing from parent (`public function configure()` over a `protected` parent)
* param type / return type narrower than parent
* params with defaults, variadic, by-ref, or attributes
* method attributes, or `@param`/`@return` docblocks refining types
