### PR TITLE
[DeadCode] Add RemoveDefaultValueFromAssignedPropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/non_null_default.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/non_null_default.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class NonNullDefault
+{
+    private int $value = 5;
+
+    public function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class NonNullDefault
+{
+    private int $value;
+
+    public function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/nullable_typed_property.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/nullable_typed_property.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+use stdClass;
+
+final class NullableTypedProperty
+{
+    private ?stdClass $value = null;
+
+    public function __construct(stdClass $value)
+    {
+        $this->value = $value;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+use stdClass;
+
+final class NullableTypedProperty
+{
+    private ?stdClass $value;
+
+    public function __construct(stdClass $value)
+    {
+        $this->value = $value;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_conditionally_assigned.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_conditionally_assigned.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+use stdClass;
+
+final class SkipConditionallyAssigned
+{
+    private ?stdClass $value = null;
+
+    public function __construct(?stdClass $value)
+    {
+        if ($value instanceof stdClass) {
+            $this->value = $value;
+        }
+    }
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_no_constructor.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_no_constructor.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+use stdClass;
+
+final class SkipNoConstructor
+{
+    private ?stdClass $value = null;
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_not_assigned.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_not_assigned.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+use stdClass;
+
+final class SkipNotAssigned
+{
+    private ?stdClass $value = null;
+
+    public function __construct()
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_untyped_property.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_untyped_property.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+// untyped property is handled by RemoveNullPropertyInitializationRector
+final class SkipUntypedProperty
+{
+    private $value = null;
+
+    public function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/RemoveDefaultValueFromAssignedPropertyRectorTest.php
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/RemoveDefaultValueFromAssignedPropertyRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveDefaultValueFromAssignedPropertyRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector;
+
+return RectorConfig::configure()
+    ->withRules([RemoveDefaultValueFromAssignedPropertyRector::class]);

--- a/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php
+++ b/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php
@@ -28,7 +28,7 @@ final class RemovePhpVersionIdCheckRector extends AbstractRector
     /**
      * @var PhpVersion::*|null
      */
-    private int|null $phpVersion = null;
+    private int|null $phpVersion;
 
     public function __construct(
         private readonly PhpVersionProvider $phpVersionProvider,

--- a/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Rector\Property;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Rector\AbstractRector;
+use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
+use Rector\ValueObject\MethodName;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\RemoveDefaultValueFromAssignedPropertyRectorTest
+ */
+final class RemoveDefaultValueFromAssignedPropertyRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ConstructorAssignDetector $constructorAssignDetector
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove redundant default value from property that is always assigned in the constructor',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    private ?SomeType $someType = null;
+
+    public function __construct(SomeType $someType)
+    {
+        $this->someType = $someType;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    private ?SomeType $someType;
+
+    public function __construct(SomeType $someType)
+    {
+        $this->someType = $someType;
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node->getMethod(MethodName::CONSTRUCT) instanceof ClassMethod) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($node->getProperties() as $property) {
+            // untyped properties are handled by RemoveNullPropertyInitializationRector
+            if (! $property->type instanceof Node) {
+                continue;
+            }
+
+            if ($property->hooks !== []) {
+                continue;
+            }
+
+            foreach ($property->props as $propertyProperty) {
+                if (! $propertyProperty->default instanceof Expr) {
+                    continue;
+                }
+
+                $propertyName = $this->getName($propertyProperty);
+                if (! $this->constructorAssignDetector->isPropertyAssigned($node, $propertyName)) {
+                    continue;
+                }
+
+                $propertyProperty->default = null;
+                $hasChanged = true;
+            }
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+}

--- a/rules/Php80/Rector/Identical/StrStartsWithRector.php
+++ b/rules/Php80/Rector/Identical/StrStartsWithRector.php
@@ -30,7 +30,7 @@ final class StrStartsWithRector extends AbstractRector implements MinPhpVersionI
     /**
      * @var StrStartWithMatchAndRefactorInterface[]
      */
-    private array $strStartWithMatchAndRefactors = [];
+    private readonly array $strStartWithMatchAndRefactors;
 
     public function __construct(
         StrncmpMatchAndRefactor $strncmpMatchAndRefactor,

--- a/rules/Php80/ValueObject/NestedAnnotationToAttribute.php
+++ b/rules/Php80/ValueObject/NestedAnnotationToAttribute.php
@@ -12,7 +12,7 @@ final class NestedAnnotationToAttribute implements AnnotationToAttributeInterfac
     /**
      * @var AnnotationPropertyToAttributeClass[]
      */
-    private array $annotationPropertiesToAttributeClasses = [];
+    private array $annotationPropertiesToAttributeClasses;
 
     /**
      * @param array<string, string>|string[]|AnnotationPropertyToAttributeClass[] $annotationPropertiesToAttributeClasses

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -57,6 +57,7 @@ use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveNullNamedArgOnNullDefaultParamRector;
 use Rector\DeadCode\Rector\Node\RemoveNonExistingVarAnnotationRector;
 use Rector\DeadCode\Rector\Plus\RemoveDeadZeroAndOneOperationRector;
+use Rector\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector;
 use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessReadOnlyTagRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
@@ -102,6 +103,7 @@ final class DeadCodeLevel
         RemoveDeadContinueRector::class,
         RemoveUnusedNonEmptyArrayBeforeForeachRector::class,
         RemoveNullPropertyInitializationRector::class,
+        RemoveDefaultValueFromAssignedPropertyRector::class,
         RemoveUselessReturnExprInConstructRector::class,
         ReplaceBlockToItsStmtsRector::class,
         RemoveFilterVarOnExactTypeRector::class,

--- a/src/PhpParser/Node/AssignAndBinaryMap.php
+++ b/src/PhpParser/Node/AssignAndBinaryMap.php
@@ -81,7 +81,7 @@ final class AssignAndBinaryMap
     /**
      * @var array<class-string<BinaryOp>, class-string<AssignOp>>
      */
-    private array $binaryOpToAssignClasses = [];
+    private array $binaryOpToAssignClasses;
 
     public function __construct(
         private readonly NodeTypeResolver $nodeTypeResolver


### PR DESCRIPTION
Fixes rectorphp/rector#9822

A property with a redundant default value is never given `readonly` by `ReadOnlyPropertyRector`, because the default value blocks it. The default is dead: the property is always overwritten in the constructor.

This rule removes that redundant default from **typed** properties that are unconditionally assigned in the constructor, so downstream rules (like `ReadOnlyPropertyRector`) start working as expected.

```diff
 final class SomeClass
 {
-    private ?SomeType $someType = null;
+    private ?SomeType $someType;

     public function __construct(SomeType $someType)
     {
         $this->someType = $someType;
     }
 }
```

Any default is dead, not only `= null`:

```diff
 final class SomeClass
 {
-    private int $value = 5;
+    private int $value;

     public function __construct(int $value)
     {
         $this->value = $value;
     }
 }
```

Scope / guards:

- Only **typed** properties. Untyped `= null` is already handled by `RemoveNullPropertyInitializationRector`.
- Only when the property is **unconditionally** assigned in the constructor (conditional assignment is skipped, so an uninitialized-access error can't be introduced).
- Properties with hooks are skipped.