### PR TITLE
Bump to PHPStan ^2.2.6 and Fix its Container compatibility in RichParser

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.2.2"
+        "phpstan/phpstan": "^2.2.6"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nikic/php-parser": "^5.8",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3.3",
-        "phpstan/phpstan": "^2.2.2",
+        "phpstan/phpstan": "^2.2.6",
         "react/event-loop": "^1.6",
         "react/promise": "^3.3",
         "react/socket": "^1.17",

--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/FixtureUnionTypes/multiple_types.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/FixtureUnionTypes/multiple_types.php.inc
@@ -23,7 +23,7 @@ namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector
 class MultipleTypes
 {
     /**
-     * @var bool|int|string
+     * @var int|string|bool
      */
     public $value;
     public function set()

--- a/rules-tests/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector/Fixture/final_class.php.inc
+++ b/rules-tests/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector/Fixture/final_class.php.inc
@@ -48,7 +48,7 @@ namespace Rector\Tests\DeadCode\Rector\FunctionLike\NarrowWideUnionReturnTypeRec
 
 final class FinalClass
 {
-    public function getData(): int|string
+    public function getData(): string|int
     {
         if (rand(0, 1)) {
             return 'text';

--- a/rules-tests/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector/Fixture/phpdocs.php.inc
+++ b/rules-tests/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector/Fixture/phpdocs.php.inc
@@ -6,7 +6,7 @@ use Rector\Tests\DeadCode\Rector\FunctionLike\NarrowWideUnionReturnTypeRector\So
 
 final class PhpDocs
 {
-    /** @return string|int|float */
+    /** @return string|int */
     public function foo(): string|int|float
     {
         if (rand(0, 1)) {

--- a/rules-tests/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector/Fixture/phpdocs.php.inc
+++ b/rules-tests/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector/Fixture/phpdocs.php.inc
@@ -71,7 +71,7 @@ use Rector\Tests\DeadCode\Rector\FunctionLike\NarrowWideUnionReturnTypeRector\So
 
 final class PhpDocs
 {
-    /** @return int|string */
+    /** @return string|int */
     public function foo(): string|int
     {
         if (rand(0, 1)) {

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/FixturePhp80/pathinfo_return.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector/FixturePhp80/pathinfo_return.php.inc
@@ -36,7 +36,7 @@ final class PathInfoReturn
      *
      * @psalm-assert-if-true =non-empty-string $filename
      */
-    public static function extension($filename): array|string
+    public static function extension($filename): string|array
     {
         return pathinfo($filename, PATHINFO_EXTENSION);
     }

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayMapRector/Fixture/fixture.php.inc
@@ -89,7 +89,7 @@ class Fixture
      */
     public function runThree(array $array, array $arrayTwo)
     {
-        return array_map(function (string $value, \Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Bar|\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Foo $second) {
+        return array_map(function (string $value, \Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Foo|\Rector\Tests\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector\Source\Bar $second) {
             return get_class($second) . $value;
         }, $array, $arrayTwo);
     }

--- a/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector/Fixture/fixture.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector/Fixture/fixture.php.inc
@@ -48,7 +48,7 @@ class Fixture
      */
     public function runTwo(array $array)
     {
-        return array_reduce($array, function (int|string $carry, int|string $value) {
+        return array_reduce($array, function (int|string $carry, string|int $value) {
             return $carry . $value;
         }, 100);
     }

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/Nesting/complex_array.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/Nesting/complex_array.php.inc
@@ -36,7 +36,7 @@ namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockRetur
 class ComplexArray
 {
    /**
-    * @return array<string, array<string, array<string, string>|int>|array<string, int|string>|bool>
+    * @return array<string, array<string, int|array<string, string>>|array<string, string|int>|bool>
     */
    public function run(): array
     {

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/covert-implicit-key.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/covert-implicit-key.php.inc
@@ -28,7 +28,7 @@ namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockRetur
 final class CoverImplicitKey
 {
     /**
-     * @return array<int, array<string, int|string>>
+     * @return array<int, array<string, string|int>>
      */
     private static function getExpectedAllOwners(): array
     {

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/repeated_item_type.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/repeated_item_type.php.inc
@@ -44,7 +44,7 @@ final class RepeatedItemType
     ) {}
 
     /**
-     * @return array<string, string|array<string, int|string>>
+     * @return array<string, string|array<string, string|int>>
      */
     public function toRequestPayload(): array
     {

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/with_duplicated_nested_array.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/with_duplicated_nested_array.php.inc
@@ -34,7 +34,7 @@ namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockRetur
 final class WithDuplicatedNestedArray
 {
     /**
-     * @return array<string, string[][]|bool[]|int[]>
+     * @return array<string, bool[]|int[]|string[][]>
      */
     public static function run(): iterable
     {

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/union_objects.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/union_objects.php.inc
@@ -42,7 +42,7 @@ final class UnionObjects
     }
 
     /**
-     * @param \Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Source\AnotherReturnedObject[]|\Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Source\SomeReturnedObject[] $items
+     * @param \Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Source\SomeReturnedObject[]|\Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Source\AnotherReturnedObject[] $items
      */
     private function run(array $items)
     {

--- a/src/DependencyInjection/PHPStan/PHPStanContainerMemento.php
+++ b/src/DependencyInjection/PHPStan/PHPStanContainerMemento.php
@@ -4,46 +4,39 @@ declare(strict_types=1);
 
 namespace Rector\DependencyInjection\PHPStan;
 
-use PHPStan\DependencyInjection\MemoizingContainer;
-use PHPStan\DependencyInjection\Nette\NetteContainer;
+use PhpParser\NodeVisitor;
+use PHPStan\DependencyInjection\DirectExtensionsCollection;
+use PHPStan\DependencyInjection\ExtensionsCollection;
 use PHPStan\Parser\AnonymousClassVisitor;
 use PHPStan\Parser\ArrayMapArgVisitor;
 use PHPStan\Parser\RichParser;
 use Rector\Util\Reflection\PrivatesAccessor;
 
 /**
- * Helper service to modify PHPStan container
+ * Helper service to modify PHPStan RichParser node visitors
  * To avoid issues caused by node replacement, like @see https://github.com/rectorphp/rector/issues/9492
  */
 final class PHPStanContainerMemento
 {
     public static function removeRichVisitors(RichParser $richParser): void
     {
-        // the only way now seems to access container early and remove unwanted services
-        // here https://github.com/phpstan/phpstan-src/blob/522421b007cbfc674bebb93e823c774167ac78cd/src/Parser/RichParser.php#L90-L92
         $privatesAccessor = new PrivatesAccessor();
 
-        /** @var MemoizingContainer $container */
-        $container = $privatesAccessor->getPrivateProperty($richParser, 'container');
-
-        /** @var NetteContainer $originalContainer */
-        $originalContainer = $privatesAccessor->getPrivateProperty($container, 'originalContainer');
-
-        /** @var NetteContainer $originalContainer */
-        $deeperContainer = $privatesAccessor->getPrivateProperty($originalContainer, 'container');
-
-        // get tags property
-        $tags = $privatesAccessor->getPrivateProperty($deeperContainer, 'tags');
+        /** @var ExtensionsCollection<NodeVisitor> $nodeVisitorsCollection */
+        $nodeVisitorsCollection = $privatesAccessor->getPrivateProperty($richParser, 'nodeVisitors');
 
         // keep visitors that are useful
-        // remove all the rest, https://github.com/phpstan/phpstan-src/tree/1d86de8bb9371534983a8dbcd879e057d2ff028f/src/Parser
-        $nodeVisitorsToKeep = [
-            $container->findServiceNamesByType(AnonymousClassVisitor::class)[0] => true,
-            $container->findServiceNamesByType(ArrayMapArgVisitor::class)[0] => true,
-        ];
+        // remove all the rest, https://github.com/phpstan/phpstan-src/tree/2.2.x/src/Parser
+        $nodeVisitorsToKeep = array_filter(
+            $nodeVisitorsCollection->getAll(),
+            static fn (NodeVisitor $nodeVisitor): bool => $nodeVisitor instanceof AnonymousClassVisitor
+                || $nodeVisitor instanceof ArrayMapArgVisitor
+        );
 
-        $tags[RichParser::VISITOR_SERVICE_TAG] = $nodeVisitorsToKeep;
-
-        $privatesAccessor->setPrivateProperty($deeperContainer, 'tags', $tags);
+        $privatesAccessor->setPrivateProperty(
+            $richParser,
+            'nodeVisitors',
+            new DirectExtensionsCollection($nodeVisitorsToKeep)
+        );
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9824

Currently update to use phpstan 2.2.6 cause crash:

```bash
PHP Fatal error:  Uncaught Rector\Exception\Reflection\MissingPrivatePropertyException:
Property "$container" was not found in "PHPStan\Parser\RichParser" class
  in vendor/rector/rector/src/Util/Reflection/PrivatesAccessor.php:82
```

This PR try bump to PHPStan ^2.2.6 and Fix its Container compatibility in RichParser.

See crash

https://github.com/rectorphp/rector-src/actions/runs/30224923562/job/89853439240#step:6:9