### PR TITLE
[DeadCode] Skip early return in constructor in RemoveDefaultValueFromAssignedPropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/return_in_closure.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/return_in_closure.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class ReturnInClosure
+{
+    private ?string $name = null;
+
+    public function __construct(string $name)
+    {
+        $this->name = (function () use ($name): string {
+            return $name;
+        })();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class ReturnInClosure
+{
+    private ?string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = (function () use ($name): string {
+            return $name;
+        })();
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_early_return_in_constructor.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_early_return_in_constructor.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class SkipEarlyReturnInConstructor
+{
+    public int $x = 0;
+
+    public function __construct(bool $shouldReturn = false)
+    {
+        if ($shouldReturn) {
+            return;
+        }
+
+        $this->x = 100;
+    }
+}

--- a/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
@@ -8,6 +8,8 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
 use Rector\ValueObject\MethodName;
@@ -20,7 +22,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveDefaultValueFromAssignedPropertyRector extends AbstractRector
 {
     public function __construct(
-        private readonly ConstructorAssignDetector $constructorAssignDetector
+        private readonly ConstructorAssignDetector $constructorAssignDetector,
+        private readonly BetterNodeFinder $betterNodeFinder
     ) {
     }
 
@@ -71,7 +74,13 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $node->getMethod(MethodName::CONSTRUCT) instanceof ClassMethod) {
+        $constructClassMethod = $node->getMethod(MethodName::CONSTRUCT);
+        if (! $constructClassMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        // early return can skip the assign, so the default value is still needed
+        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($constructClassMethod, Return_::class)) {
             return null;
         }
 


### PR DESCRIPTION
The rule removed the default value whenever a first-level `$this->prop = ...` was found in the constructor. But an early `return` can skip that assign, leaving a typed property uninitialized:

```php
class Foo {
    public int $x = 0;
    public function __construct(bool $return = false) {
        if ($return) {
            return;
        }
        $this->x = 0;
    }
}

print (new Foo())->x . ';' . (new Foo(true))->x;
```

Before this fix, the rule produced:

```diff
 class Foo {
-    public int $x = 0;
+    public int $x;
     public function __construct(bool $return = false) {
```

which turns `(new Foo(true))->x` into `Error: Typed property Foo::$x must not be accessed before initialization`.

Now any `return` in the constructor body makes the rule bail out. Returns inside nested closures/arrow functions/anonymous classes are ignored, as they do not skip the constructor assign:

```php
final class ReturnInClosure
{
    private ?string $name = null; // still changed to `private ?string $name;`

    public function __construct(string $name)
    {
        $this->name = (function () use ($name): string {
            return $name;
        })();
    }
}
```
