### PR TITLE
[DeadCode] Use PHPStan flow analysis for property initialization in RemoveDefaultValueFromAssignedPropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/assign_after_throwing_branch.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/assign_after_throwing_branch.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+use RuntimeException;
+
+final class AssignAfterThrowingBranch
+{
+    private ?string $name = null;
+
+    public function __construct(string $name, bool $shouldFail)
+    {
+        if ($shouldFail) {
+            throw new RuntimeException('nope');
+        }
+
+        $this->name = $name;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+use RuntimeException;
+
+final class AssignAfterThrowingBranch
+{
+    private ?string $name;
+
+    public function __construct(string $name, bool $shouldFail)
+    {
+        if ($shouldFail) {
+            throw new RuntimeException('nope');
+        }
+
+        $this->name = $name;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/assign_in_if_elseif_else.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/assign_in_if_elseif_else.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class AssignInIfElseIfElse
+{
+    private ?string $name = null;
+
+    public function __construct(int $type)
+    {
+        if ($type === 1) {
+            $this->name = 'one';
+        } elseif ($type === 2) {
+            $this->name = 'two';
+        } else {
+            $this->name = 'many';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class AssignInIfElseIfElse
+{
+    private ?string $name;
+
+    public function __construct(int $type)
+    {
+        if ($type === 1) {
+            $this->name = 'one';
+        } elseif ($type === 2) {
+            $this->name = 'two';
+        } else {
+            $this->name = 'many';
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/assign_in_switch_with_default.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/assign_in_switch_with_default.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class AssignInSwitchWithDefault
+{
+    private ?string $name = null;
+
+    public function __construct(int $type)
+    {
+        switch ($type) {
+            case 1:
+                $this->name = 'one';
+                break;
+            default:
+                $this->name = 'many';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class AssignInSwitchWithDefault
+{
+    private ?string $name;
+
+    public function __construct(int $type)
+    {
+        switch ($type) {
+            case 1:
+                $this->name = 'one';
+                break;
+            default:
+                $this->name = 'many';
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/return_after_assign.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/return_after_assign.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class ReturnAfterAssign
+{
+    private ?string $name = null;
+
+    public function __construct(string $name, bool $shouldReturn = false)
+    {
+        $this->name = $name;
+
+        if ($shouldReturn) {
+            return;
+        }
+
+        $this->name = strtoupper($name);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class ReturnAfterAssign
+{
+    private ?string $name;
+
+    public function __construct(string $name, bool $shouldReturn = false)
+    {
+        $this->name = $name;
+
+        if ($shouldReturn) {
+            return;
+        }
+
+        $this->name = strtoupper($name);
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_assign_in_foreach.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_assign_in_foreach.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class SkipAssignInForeach
+{
+    private ?string $name = null;
+
+    /**
+     * @param string[] $names
+     */
+    public function __construct(array $names)
+    {
+        foreach ($names as $name) {
+            $this->name = $name;
+        }
+    }
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_assign_inside_closure.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_assign_inside_closure.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+use Closure;
+
+final class SkipAssignInsideClosure
+{
+    private ?string $name = null;
+
+    public Closure $setName;
+
+    public function __construct(string $name)
+    {
+        $this->setName = function () use ($name): void {
+            $this->name = $name;
+        };
+    }
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_assign_only_in_try.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_assign_only_in_try.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+use Throwable;
+
+final class SkipAssignOnlyInTry
+{
+    private ?string $name = null;
+
+    public function __construct(string $name)
+    {
+        try {
+            $this->name = json_encode($name, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+        }
+    }
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_assign_reads_default.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_assign_reads_default.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class SkipAssignReadsDefault
+{
+    private int $count = 0;
+
+    public function __construct(int $extra)
+    {
+        $this->count = $this->count + $extra;
+    }
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_assign_via_offset_access.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_assign_via_offset_access.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class SkipAssignViaOffsetAccess
+{
+    /**
+     * @var array<string, bool>
+     */
+    private array $cachedByName = [];
+
+    public function __construct(string $name)
+    {
+        $this->cachedByName[$name] = true;
+    }
+}

--- a/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
@@ -6,9 +6,14 @@ namespace Rector\DeadCode\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Return_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\Expr\PropertyInitializationExpr;
+use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
@@ -23,7 +28,8 @@ final class RemoveDefaultValueFromAssignedPropertyRector extends AbstractRector
 {
     public function __construct(
         private readonly ConstructorAssignDetector $constructorAssignDetector,
-        private readonly BetterNodeFinder $betterNodeFinder
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer
     ) {
     }
 
@@ -79,8 +85,9 @@ CODE_SAMPLE
             return null;
         }
 
-        // early return can skip the assign, so the default value is still needed
-        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($constructClassMethod, Return_::class)) {
+        // the scope of every constructor exit point, as resolved by PHPStan flow analysis
+        $executionEndScope = $constructClassMethod->getAttribute(AttributeKey::EXECUTION_END_SCOPE);
+        if (! $executionEndScope instanceof Scope) {
             return null;
         }
 
@@ -102,7 +109,20 @@ CODE_SAMPLE
                 }
 
                 $propertyName = $this->getName($propertyProperty);
-                if (! $this->constructorAssignDetector->isPropertyAssigned($node, $propertyName)) {
+
+                // guards against an assign that reads the default value first, e.g. $this->value = $this->value + 1
+                if (! $this->constructorAssignDetector->isPropertyAssignedConditionally($node, $propertyName)) {
+                    continue;
+                }
+
+                // the property must be initialized on every path out of the constructor,
+                // otherwise removing the default value leaves it uninitialized
+                if (! $executionEndScope->hasExpressionType(new PropertyInitializationExpr($propertyName))->yes()) {
+                    continue;
+                }
+
+                // $this->value['key'] = ... writes to the default value, it does not replace it
+                if ($this->isAssignedViaOffsetAccess($constructClassMethod, $propertyName)) {
                     continue;
                 }
 
@@ -116,5 +136,30 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    private function isAssignedViaOffsetAccess(ClassMethod $constructClassMethod, string $propertyName): bool
+    {
+        $assign = $this->betterNodeFinder->findFirstInFunctionLikeScoped(
+            $constructClassMethod,
+            function (Node $node) use ($propertyName): bool {
+                if (! $node instanceof Assign) {
+                    return false;
+                }
+
+                $assignVar = $node->var;
+                if (! $assignVar instanceof ArrayDimFetch) {
+                    return false;
+                }
+
+                while ($assignVar instanceof ArrayDimFetch) {
+                    $assignVar = $assignVar->var;
+                }
+
+                return $this->propertyFetchAnalyzer->isLocalPropertyFetchName($assignVar, $propertyName);
+            }
+        );
+
+        return $assign instanceof Assign;
     }
 }

--- a/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
@@ -10,10 +10,8 @@ use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PHPStan\Analyser\Scope;
-use PHPStan\Node\Expr\PropertyInitializationExpr;
+use Rector\NodeAnalyzer\AlwaysInitializedPropertyAnalyzer;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
@@ -29,7 +27,8 @@ final class RemoveDefaultValueFromAssignedPropertyRector extends AbstractRector
     public function __construct(
         private readonly ConstructorAssignDetector $constructorAssignDetector,
         private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer
+        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer,
+        private readonly AlwaysInitializedPropertyAnalyzer $alwaysInitializedPropertyAnalyzer
     ) {
     }
 
@@ -85,12 +84,6 @@ CODE_SAMPLE
             return null;
         }
 
-        // the scope of every constructor exit point, as resolved by PHPStan flow analysis
-        $executionEndScope = $constructClassMethod->getAttribute(AttributeKey::EXECUTION_END_SCOPE);
-        if (! $executionEndScope instanceof Scope) {
-            return null;
-        }
-
         $hasChanged = false;
 
         foreach ($node->getProperties() as $property) {
@@ -117,7 +110,10 @@ CODE_SAMPLE
 
                 // the property must be initialized on every path out of the constructor,
                 // otherwise removing the default value leaves it uninitialized
-                if (! $executionEndScope->hasExpressionType(new PropertyInitializationExpr($propertyName))->yes()) {
+                if (! $this->alwaysInitializedPropertyAnalyzer->isAlwaysInitialized(
+                    $constructClassMethod,
+                    $propertyName
+                )) {
                     continue;
                 }
 

--- a/src/NodeAnalyzer/AlwaysInitializedPropertyAnalyzer.php
+++ b/src/NodeAnalyzer/AlwaysInitializedPropertyAnalyzer.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeAnalyzer;
+
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\MutatingScope;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\Expr\PropertyInitializationExpr;
+use PHPStan\Node\MethodReturnStatementsNode;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+/**
+ * Answers "is this property initialized on every path out of this class method?",
+ * backed by the same PHPStan flow analysis that powers its uninitialized property rules
+ *
+ * @see \Rector\Tests\NodeAnalyzer\AlwaysInitializedPropertyAnalyzerTest
+ */
+final class AlwaysInitializedPropertyAnalyzer
+{
+    public function isAlwaysInitialized(ClassMethod $classMethod, string $propertyName): bool
+    {
+        $executionEndScope = $this->resolveExecutionEndScope($classMethod);
+        if (! $executionEndScope instanceof Scope) {
+            return false;
+        }
+
+        return $executionEndScope->hasExpressionType(new PropertyInitializationExpr($propertyName))
+            ->yes();
+    }
+
+    /**
+     * Scope merged from every execution end and return statement, so it describes
+     * what is certain once the class method has finished, no matter which path was taken
+     */
+    private function resolveExecutionEndScope(ClassMethod $classMethod): ?MutatingScope
+    {
+        $methodReturnStatementsNode = $classMethod->getAttribute(AttributeKey::METHOD_RETURN_STATEMENTS_NODE);
+        if (! $methodReturnStatementsNode instanceof MethodReturnStatementsNode) {
+            return null;
+        }
+
+        $executionEndScope = null;
+
+        foreach ($methodReturnStatementsNode->getExecutionEnds() as $executionEndNode) {
+            $executionEndScope = $this->mergeScopes(
+                $executionEndScope,
+                $executionEndNode->getStatementResult()
+                    ->getScope()
+            );
+        }
+
+        foreach ($methodReturnStatementsNode->getReturnStatements() as $returnStatement) {
+            $executionEndScope = $this->mergeScopes($executionEndScope, $returnStatement->getScope());
+        }
+
+        return $executionEndScope;
+    }
+
+    private function mergeScopes(?MutatingScope $mutatingScope, Scope $scope): ?MutatingScope
+    {
+        if (! $scope instanceof MutatingScope) {
+            return $mutatingScope;
+        }
+
+        if (! $mutatingScope instanceof MutatingScope) {
+            return $scope;
+        }
+
+        return $mutatingScope->mergeWith($scope);
+    }
+}

--- a/src/NodeTypeResolver/Node/AttributeKey.php
+++ b/src/NodeTypeResolver/Node/AttributeKey.php
@@ -178,8 +178,8 @@ final class AttributeKey
     public const string NEWLINE_ON_FLUENT_CALL = 'newline_on_fluent_call';
 
     /**
-     * Scope merged from every execution end and return statement of a class method,
-     * so it describes what is certain once the method has finished
+     * PHPStan virtual node that holds every exit point of a class method,
+     * @see \Rector\NodeAnalyzer\AlwaysInitializedPropertyAnalyzer to read it
      */
-    public const string EXECUTION_END_SCOPE = 'execution_end_scope';
+    public const string METHOD_RETURN_STATEMENTS_NODE = 'method_return_statements_node';
 }

--- a/src/NodeTypeResolver/Node/AttributeKey.php
+++ b/src/NodeTypeResolver/Node/AttributeKey.php
@@ -176,4 +176,10 @@ final class AttributeKey
     public const string IS_IN_TRY_BLOCK = 'is_in_try_block';
 
     public const string NEWLINE_ON_FLUENT_CALL = 'newline_on_fluent_call';
+
+    /**
+     * Scope merged from every execution end and return statement of a class method,
+     * so it describes what is certain once the method has finished
+     */
+    public const string EXECUTION_END_SCOPE = 'execution_end_scope';
 }

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -83,6 +83,7 @@ use PhpParser\Node\Stmt\TryCatch;
 use PhpParser\Node\Stmt\Unset_;
 use PhpParser\Node\Stmt\While_;
 use PhpParser\Node\UnionType;
+use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PHPStan\Analyser\Fiber\FiberScope;
 use PHPStan\Analyser\MutatingScope;
@@ -641,8 +642,33 @@ final readonly class PHPStanNodeScopeResolver
             return;
         }
 
+        // the node keeps every exit point scope alive, so only pay for it where a property can be initialized
+        if (! $this->hasPropertyAssign($classMethod)) {
+            return;
+        }
+
         // kept raw on purpose, merging the exit point scopes is only worth it once a rule asks for it
         $classMethod->setAttribute(AttributeKey::METHOD_RETURN_STATEMENTS_NODE, $methodReturnStatementsNode);
+    }
+
+    private function hasPropertyAssign(ClassMethod $classMethod): bool
+    {
+        $nodeFinder = new NodeFinder();
+
+        $assign = $nodeFinder->findFirst((array) $classMethod->stmts, static function (Node $node): bool {
+            if (! $node instanceof Assign) {
+                return false;
+            }
+
+            $assignVar = $node->var;
+            while ($assignVar instanceof ArrayDimFetch) {
+                $assignVar = $assignVar->var;
+            }
+
+            return $assignVar instanceof PropertyFetch;
+        });
+
+        return $assign instanceof Assign;
     }
 
     /**

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -87,11 +87,13 @@ use PhpParser\NodeTraverser;
 use PHPStan\Analyser\Fiber\FiberScope;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Analyser\UndefinedVariableException;
 use PHPStan\Node\FunctionCallableNode;
 use PHPStan\Node\InstantiationCallableNode;
 use PHPStan\Node\MethodCallableNode;
+use PHPStan\Node\MethodReturnStatementsNode;
 use PHPStan\Node\Printer\Printer;
 use PHPStan\Node\StaticMethodCallableNode;
 use PHPStan\Node\UnreachableStatementNode;
@@ -153,8 +155,17 @@ final readonly class PHPStanNodeScopeResolver
 
         $scope = $formerMutatingScope ?? $this->scopeFactory->createFromFile($filePath);
 
+        /**
+         * PHPStan emits the MethodReturnStatementsNode without the ClassMethod it belongs to,
+         * but with its attributes copied over, so the start file position pairs them back together
+         *
+         * @var array<int, ClassMethod>
+         */
+        $classMethodsByStartFilePos = [];
+
         $nodeCallback = function (Node $node, MutatingScope $mutatingScope) use (
             &$nodeCallback,
+            &$classMethodsByStartFilePos,
             $filePath,
         ): void {
             if ($mutatingScope instanceof FiberScope) {
@@ -194,11 +205,21 @@ final readonly class PHPStanNodeScopeResolver
                 return;
             }
 
+            // emitted once the whole class method body is resolved, so the class method is already known
+            if ($node instanceof MethodReturnStatementsNode) {
+                $this->processMethodReturnStatementsNode($node, $classMethodsByStartFilePos);
+                return;
+            }
+
             // init current Node set Attribute
             // not a VirtualNode, then set scope attribute
             // do not return early, as its properties will be checked next
             if (! $node instanceof VirtualNode) {
                 $node->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+
+                if ($node instanceof ClassMethod && $node->getStartFilePos() >= 0) {
+                    $classMethodsByStartFilePos[$node->getStartFilePos()] = $node;
+                }
             }
 
             // handle unwrapped stmts
@@ -607,6 +628,52 @@ final readonly class PHPStanNodeScopeResolver
             $mutatingScope,
             $nodeCallback
         );
+    }
+
+    /**
+     * @param array<int, ClassMethod> $classMethodsByStartFilePos
+     */
+    private function processMethodReturnStatementsNode(
+        MethodReturnStatementsNode $methodReturnStatementsNode,
+        array $classMethodsByStartFilePos
+    ): void {
+        $classMethod = $classMethodsByStartFilePos[$methodReturnStatementsNode->getStartFilePos()] ?? null;
+        if (! $classMethod instanceof ClassMethod) {
+            return;
+        }
+
+        $executionEndScope = null;
+
+        foreach ($methodReturnStatementsNode->getExecutionEnds() as $executionEndNode) {
+            $executionEndScope = $this->mergeScopes(
+                $executionEndScope,
+                $executionEndNode->getStatementResult()
+                    ->getScope()
+            );
+        }
+
+        foreach ($methodReturnStatementsNode->getReturnStatements() as $returnStatement) {
+            $executionEndScope = $this->mergeScopes($executionEndScope, $returnStatement->getScope());
+        }
+
+        if (! $executionEndScope instanceof MutatingScope) {
+            return;
+        }
+
+        $classMethod->setAttribute(AttributeKey::EXECUTION_END_SCOPE, $executionEndScope);
+    }
+
+    private function mergeScopes(?MutatingScope $mutatingScope, Scope $scope): ?MutatingScope
+    {
+        if (! $scope instanceof MutatingScope) {
+            return $mutatingScope;
+        }
+
+        if (! $mutatingScope instanceof MutatingScope) {
+            return $scope;
+        }
+
+        return $mutatingScope->mergeWith($scope);
     }
 
     /**

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -87,7 +87,6 @@ use PhpParser\NodeTraverser;
 use PHPStan\Analyser\Fiber\FiberScope;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
-use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Analyser\UndefinedVariableException;
 use PHPStan\Node\FunctionCallableNode;
@@ -642,38 +641,8 @@ final readonly class PHPStanNodeScopeResolver
             return;
         }
 
-        $executionEndScope = null;
-
-        foreach ($methodReturnStatementsNode->getExecutionEnds() as $executionEndNode) {
-            $executionEndScope = $this->mergeScopes(
-                $executionEndScope,
-                $executionEndNode->getStatementResult()
-                    ->getScope()
-            );
-        }
-
-        foreach ($methodReturnStatementsNode->getReturnStatements() as $returnStatement) {
-            $executionEndScope = $this->mergeScopes($executionEndScope, $returnStatement->getScope());
-        }
-
-        if (! $executionEndScope instanceof MutatingScope) {
-            return;
-        }
-
-        $classMethod->setAttribute(AttributeKey::EXECUTION_END_SCOPE, $executionEndScope);
-    }
-
-    private function mergeScopes(?MutatingScope $mutatingScope, Scope $scope): ?MutatingScope
-    {
-        if (! $scope instanceof MutatingScope) {
-            return $mutatingScope;
-        }
-
-        if (! $mutatingScope instanceof MutatingScope) {
-            return $scope;
-        }
-
-        return $mutatingScope->mergeWith($scope);
+        // kept raw on purpose, merging the exit point scopes is only worth it once a rule asks for it
+        $classMethod->setAttribute(AttributeKey::METHOD_RETURN_STATEMENTS_NODE, $methodReturnStatementsNode);
     }
 
     /**

--- a/tests/NodeAnalyzer/AlwaysInitializedPropertyAnalyzerTest.php
+++ b/tests/NodeAnalyzer/AlwaysInitializedPropertyAnalyzerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\NodeAnalyzer;
+
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\NodeAnalyzer\AlwaysInitializedPropertyAnalyzer;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\Testing\TestingParser\TestingParser;
+
+final class AlwaysInitializedPropertyAnalyzerTest extends AbstractLazyTestCase
+{
+    private AlwaysInitializedPropertyAnalyzer $alwaysInitializedPropertyAnalyzer;
+
+    private TestingParser $testingParser;
+
+    private BetterNodeFinder $betterNodeFinder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->alwaysInitializedPropertyAnalyzer = $this->make(AlwaysInitializedPropertyAnalyzer::class);
+        $this->testingParser = $this->make(TestingParser::class);
+        $this->betterNodeFinder = $this->make(BetterNodeFinder::class);
+    }
+
+    #[DataProvider('provideData')]
+    public function test(string $filePath, string $propertyName, bool $expectedIsAlwaysInitialized): void
+    {
+        $stmts = $this->testingParser->parseFileToDecoratedNodes($filePath);
+
+        $classMethod = $this->betterNodeFinder->findFirstInstanceOf($stmts, ClassMethod::class);
+        $this->assertInstanceOf(ClassMethod::class, $classMethod);
+
+        $this->assertSame(
+            $expectedIsAlwaysInitialized,
+            $this->alwaysInitializedPropertyAnalyzer->isAlwaysInitialized($classMethod, $propertyName)
+        );
+    }
+
+    /**
+     * @return iterable<array{string, string, bool}>
+     */
+    public static function provideData(): iterable
+    {
+        $sourceDirectory = __DIR__ . '/Source/AlwaysInitializedProperty';
+
+        yield [$sourceDirectory . '/DirectAssign.php', 'name', true];
+
+        // never touched in the constructor
+        yield [$sourceDirectory . '/DirectAssign.php', 'surname', false];
+
+        // the early return skips the assign
+        yield [$sourceDirectory . '/EarlyReturn.php', 'name', false];
+
+        yield [$sourceDirectory . '/EveryBranchAssign.php', 'name', true];
+
+        // the loop body might never run
+        yield [$sourceDirectory . '/AssignInForeach.php', 'name', false];
+    }
+
+    public function testUnresolvedClassMethodIsNotInitialized(): void
+    {
+        $classMethod = new ClassMethod('__construct');
+
+        $this->assertFalse($this->alwaysInitializedPropertyAnalyzer->isAlwaysInitialized($classMethod, 'name'));
+    }
+}

--- a/tests/NodeAnalyzer/Source/AlwaysInitializedProperty/AssignInForeach.php
+++ b/tests/NodeAnalyzer/Source/AlwaysInitializedProperty/AssignInForeach.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\NodeAnalyzer\Source\AlwaysInitializedProperty;
+
+final class AssignInForeach
+{
+    private ?string $name = null;
+
+    /**
+     * @param string[] $names
+     */
+    public function __construct(array $names)
+    {
+        foreach ($names as $name) {
+            $this->name = $name;
+        }
+    }
+}

--- a/tests/NodeAnalyzer/Source/AlwaysInitializedProperty/DirectAssign.php
+++ b/tests/NodeAnalyzer/Source/AlwaysInitializedProperty/DirectAssign.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\NodeAnalyzer\Source\AlwaysInitializedProperty;
+
+final class DirectAssign
+{
+    private ?string $name = null;
+
+    private ?string $surname = null;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/NodeAnalyzer/Source/AlwaysInitializedProperty/EarlyReturn.php
+++ b/tests/NodeAnalyzer/Source/AlwaysInitializedProperty/EarlyReturn.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\NodeAnalyzer\Source\AlwaysInitializedProperty;
+
+final class EarlyReturn
+{
+    private ?string $name = null;
+
+    public function __construct(string $name, bool $shouldReturn)
+    {
+        if ($shouldReturn) {
+            return;
+        }
+
+        $this->name = $name;
+    }
+}

--- a/tests/NodeAnalyzer/Source/AlwaysInitializedProperty/EveryBranchAssign.php
+++ b/tests/NodeAnalyzer/Source/AlwaysInitializedProperty/EveryBranchAssign.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\NodeAnalyzer\Source\AlwaysInitializedProperty;
+
+final class EveryBranchAssign
+{
+    private ?string $name = null;
+
+    public function __construct(int $type)
+    {
+        if ($type === 1) {
+            $this->name = 'one';
+        } elseif ($type === 2) {
+            $this->name = 'two';
+        } else {
+            $this->name = 'many';
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to https://github.com/rectorphp/rector-src/pull/8209#issuecomment-5089180560 — @staabm suggested basing the rule on PHPStan's own uninitialized-property mechanics instead of hand-rolled AST scanning.

## New service

`Rector\NodeAnalyzer\AlwaysInitializedPropertyAnalyzer` answers one question, for any class method:

```php
$this->alwaysInitializedPropertyAnalyzer->isAlwaysInitialized($classMethod, $propertyName);
```

Under the hood it merges the scope of every exit point of that method and asks PHPStan whether the property is initialized there — the same query PHPStan's own `ClassPropertiesNode::collectUninitializedProperties()` uses:

```php
$executionEndScope->hasExpressionType(new PropertyInitializationExpr($propertyName))->yes()
```

It is not tied to constructors, so any rule that today guesses at "is this property assigned" can use it. `ConstructorAssignDetector` has 8 other consumers that inherit the same blind spots this replaces — migrating them is a separate change.

Wiring: `PHPStanNodeScopeResolver` already receives every virtual node PHPStan emits, it just dropped them. It now picks up `MethodReturnStatementsNode` and stores it on the matching `ClassMethod` under `AttributeKey::METHOD_RETURN_STATEMENTS_NODE`. PHPStan does not expose the `ClassMethod` on that virtual node, but it copies the method's attributes onto it, so the start file position pairs them back up.

## Rule change

The `Return_`-scanning heuristic added in #8209 is gone — PHPStan handles it structurally, plus everything the heuristic could not.

Early `return` no longer blocks the whole constructor, only paths that actually skip the assign:

```diff
 final class ReturnAfterAssign
 {
-    private ?string $name = null;
+    private ?string $name;

     public function __construct(string $name, bool $shouldReturn = false)
     {
         $this->name = $name;

         if ($shouldReturn) {
             return;
         }

         $this->name = strtoupper($name);
     }
 }
```

`if`/`elseif`/`else`, `switch` with `default`, and a throwing branch are all understood:

```diff
 final class AssignInIfElseIfElse
 {
-    private ?string $name = null;
+    private ?string $name;

     public function __construct(int $type)
     {
         if ($type === 1) {
             $this->name = 'one';
         } elseif ($type === 2) {
             $this->name = 'two';
         } else {
             $this->name = 'many';
         }
     }
 }
```

Still skipped: assign inside `foreach` (loop may not run), inside `try` only, inside a closure that is never invoked, and an assign that reads the default first (`$this->count = $this->count + $extra`).

## Bug fixed on the way

Offset writes were treated as full assigns, so this used to produce a fatal `must not be accessed before initialization`:

```php
final class SkipAssignViaOffsetAccess
{
    private array $cachedByName = [];

    public function __construct(string $name)
    {
        $this->cachedByName[$name] = true;
    }
}
```

It was hit by `Rector\Privatization\Guard\ParentClassMagicCallGuard` when running Rector on this repo itself. Now skipped.

## Performance

Kept for the record. All runs: `bin/rector process --dry-run --no-progress-bar --no-diffs --clear-cache`, `withoutParallel()`, only this rule registered, PHP 8.4.23. Branches alternated every repetition so machine drift hits both sides equally; 6 repetitions per side, median reported.

Corpora:
- `scale1000` — 1000 files, one class each, one property with a default plus a constructor that assigns it (the case asked about: this rule firing 1000 times)
- `methods` — same 1000 classes, each with 10 extra methods that never touch a property
- `real code` — this repo's own `src/` + `rules/`, 1317 files

| corpus | time before | time after | delta | peak mem before | peak mem after | delta |
| --- | --- | --- | --- | --- | --- | --- |
| scale1000 | 1.65 s | 1.66 s | +0.6% | 146.8 MB | 160.7 MB | +9.4% |
| methods | 8.88 s | 9.02 s | +1.6% | 607.8 MB | 620.4 MB | +2.1% |
| real code | 27.94 s | 27.56 s | −1.4% | 889.3 MB | 936.3 MB | +5.3% |

Time is a wash. Memory grows because the exit point scopes stay reachable after analysis.

Two earlier variants were measured and rejected:

| variant | scale1000 time | scale1000 mem | methods time | methods mem |
| --- | --- | --- | --- | --- |
| merge scopes eagerly in the resolver | −1.8% | +7.3% | **+6.7%** | **+6.7%** |
| store the node, merge lazily, no filter | +1.2% | +9.5% | −0.2% | **+32.7%** |
| **shipped: lazy + only decorate methods that assign a property** | +0.6% | +9.4% | +1.6% | +2.1% |

Eager merging costs real time on method-heavy code. Storing the raw node for every method costs a lot of memory, because it pins every exit point scope. Doing both — decorate only methods that contain a `$this->...` assign, and merge on demand — keeps each within noise on real code.

## Tests

- `tests/NodeAnalyzer/AlwaysInitializedPropertyAnalyzerTest.php` — 6 cases against the service directly, via `TestingParser` so the nodes carry real PHPStan scopes
- 9 new rule fixtures (17 total). Sanity check: stubbing out the PHPStan query fails 5 of them, so they exercise the new path rather than the old one.
