### PR TITLE
[DeadCode] Skip array dim fetch assign in RemoveDefaultValueFromAssignedPropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_array_dim_fetch_assign.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_array_dim_fetch_assign.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class SkipArrayDimFetchAssign
+{
+    private array $default = [
+        'name' => 'some name',
+        'tplset' => null,
+    ];
+
+    public function __construct()
+    {
+        $this->default['tplset'] = 'dotty';
+    }
+}

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_nested_array_dim_fetch_assign.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_nested_array_dim_fetch_assign.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class SkipNestedArrayDimFetchAssign
+{
+    private array $config = [
+        'first' => ['second' => null],
+    ];
+
+    public function __construct()
+    {
+        $this->config['first']['second'] = 'value';
+    }
+}

--- a/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
@@ -6,9 +6,12 @@ namespace Rector\DeadCode\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
+use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
@@ -23,7 +26,8 @@ final class RemoveDefaultValueFromAssignedPropertyRector extends AbstractRector
 {
     public function __construct(
         private readonly ConstructorAssignDetector $constructorAssignDetector,
-        private readonly BetterNodeFinder $betterNodeFinder
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly PropertyFetchAnalyzer $propertyFetchAnalyzer
     ) {
     }
 
@@ -106,6 +110,11 @@ CODE_SAMPLE
                     continue;
                 }
 
+                // partial assign, e.g. $this->items['key'] = ...; keeps the default value required
+                if ($this->isAssignedViaArrayDimFetch($node, $propertyName)) {
+                    continue;
+                }
+
                 $propertyProperty->default = null;
                 $hasChanged = true;
             }
@@ -116,5 +125,26 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    private function isAssignedViaArrayDimFetch(Class_ $class, string $propertyName): bool
+    {
+        return $this->betterNodeFinder->findFirst($class, function (Node $subNode) use ($propertyName): bool {
+            if (! $subNode instanceof Assign) {
+                return false;
+            }
+
+            $assignedExpr = $subNode->var;
+            if (! $assignedExpr instanceof ArrayDimFetch) {
+                return false;
+            }
+
+            // unwrap nested dims, e.g. $this->items['first']['second'] = ...
+            while ($assignedExpr instanceof ArrayDimFetch) {
+                $assignedExpr = $assignedExpr->var;
+            }
+
+            return $this->propertyFetchAnalyzer->isLocalPropertyFetchName($assignedExpr, $propertyName);
+        }) instanceof Assign;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9826

`$this->default['tplset'] = 'dotty';` was treated as a full property assign, because `PropertyAssignMatcher` intentionally also matches `$this->prop[...] = ` (useful for type inference). A partial array assign does not overwrite the property, so the default value is still required.

Skip the property when it is assigned via array dim fetch, incl. nested dims.

```diff
 class ModuleDefine
 {
    private array $default = [
        'name' => 'some name',
        'tplset' => null,
    ];

     public function __construct()
     {
         $this->default['tplset'] = 'dotty';
     }
 }
```

Before this PR the default value was removed, leaving `private array $default;` and an uninitialized property → `Error: Typed property must not be accessed before initialization`.
