### PR TITLE
 [DeadCode] Skip protected property on non-final class on RemoveDefaultValueFromAssignedPropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_protected_property_on_non_final_class.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_protected_property_on_non_final_class.php.inc
@@ -11,5 +11,3 @@ class SkipProtectedPropertyOnNonFinalClass
         $this->value = $value;
     }
 }
-
-?>

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_protected_property_on_non_final_class.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_protected_property_on_non_final_class.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+class SkipProtectedPropertyOnNonFinalClass
+{
+    private int $value = 5;
+
+    public function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_protected_property_on_non_final_class.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_protected_property_on_non_final_class.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPr
 
 class SkipProtectedPropertyOnNonFinalClass
 {
-    private int $value = 5;
+    protected int $value = 5;
 
     public function __construct(int $value)
     {

--- a/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
+use Rector\Configuration\Parameter\FeatureFlags;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
@@ -89,6 +90,7 @@ CODE_SAMPLE
         }
 
         $hasChanged = false;
+        $isFinal = $node->isFinal() || FeatureFlags::treatClassesAsFinal($node);
 
         foreach ($node->getProperties() as $property) {
             // untyped properties are handled by RemoveNullPropertyInitializationRector
@@ -97,6 +99,10 @@ CODE_SAMPLE
             }
 
             if ($property->hooks !== []) {
+                continue;
+            }
+
+            if (! $property->isPrivate() && ! $isFinal) {
                 continue;
             }
 


### PR DESCRIPTION
protected property can be overridden by child via custom construct, see https://3v4l.org/PNpBG#v8.5.8