### PR TITLE
[Reflection] Add ClassReflectionProvider facade over PHPStan ReflectionProvider

### DIFF
--- a/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
+++ b/rules/CodeQuality/Rector/Catch_/ThrowWithPreviousExceptionRector.php
@@ -16,11 +16,11 @@ use PhpParser\Node\Stmt\Catch_;
 use PhpParser\NodeVisitor;
 use PHPStan\Reflection\ExtendedParameterReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\Resolver\ClassNameFromObjectTypeResolver;
 use Rector\ValueObject\MethodName;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -34,7 +34,7 @@ final class ThrowWithPreviousExceptionRector extends AbstractRector
     private const int DEFAULT_EXCEPTION_ARGUMENT_POSITION = 2;
 
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -219,11 +219,11 @@ CODE_SAMPLE
             return false;
         }
 
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return false;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
         $construct = $classReflection->hasMethod(MethodName::CONSTRUCT);
 
         if (! $construct) {
@@ -251,11 +251,11 @@ CODE_SAMPLE
     private function resolveExceptionArgumentPosition(Name $exceptionName): ?int
     {
         $className = $this->getName($exceptionName);
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return self::DEFAULT_EXCEPTION_ARGUMENT_POSITION;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
         $construct = $classReflection->hasMethod(MethodName::CONSTRUCT);
         if (! $construct) {
             return self::DEFAULT_EXCEPTION_ARGUMENT_POSITION;

--- a/rules/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector.php
+++ b/rules/CodeQuality/Rector/ClassConstFetch/VariableConstFetchToClassConstFetchRector.php
@@ -9,9 +9,9 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class VariableConstFetchToClassConstFetchRector extends AbstractRector
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -98,11 +98,11 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $this->reflectionProvider->hasClass($classObjectType->getClassName())) {
+        if (! $this->classReflectionProvider->hasClass($classObjectType->getClassName())) {
             return null;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($classObjectType->getClassName());
+        $classReflection = $this->classReflectionProvider->getClass($classObjectType->getClassName());
         if (! $classReflection->isFinalByKeyword()) {
             if (! $classReflection->hasConstant($constantName)) {
                 return null;

--- a/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php
+++ b/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php
@@ -8,13 +8,13 @@ use PhpParser\Node;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\CodeQuality\NodeAnalyzer\LocalPropertyAnalyzer;
 use Rector\CodeQuality\NodeAnalyzer\MissingPropertiesResolver;
 use Rector\CodeQuality\NodeFactory\MissingPropertiesFactory;
 use Rector\NodeAnalyzer\ClassAnalyzer;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -26,7 +26,7 @@ final class CompleteDynamicPropertiesRector extends AbstractRector
     public function __construct(
         private readonly MissingPropertiesFactory $missingPropertiesFactory,
         private readonly LocalPropertyAnalyzer $localPropertyAnalyzer,
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly ClassAnalyzer $classAnalyzer,
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
         private readonly MissingPropertiesResolver $missingPropertiesResolver,
@@ -120,7 +120,7 @@ CODE_SAMPLE
         }
 
         $className = (string) $this->getName($class);
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return true;
         }
 
@@ -129,7 +129,7 @@ CODE_SAMPLE
             return true;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
 
         // properties are accessed via magic, nothing we can do
         if ($classReflection->hasMethod('__set')) {
@@ -140,7 +140,7 @@ CODE_SAMPLE
             return true;
         }
 
-        return $class->extends instanceof FullyQualified && ! $this->reflectionProvider->hasClass(
+        return $class->extends instanceof FullyQualified && ! $this->classReflectionProvider->hasClass(
             $class->extends->toString()
         );
     }
@@ -152,10 +152,10 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return null;
         }
 
-        return $this->reflectionProvider->getClass($className);
+        return $this->classReflectionProvider->getClass($className);
     }
 }

--- a/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
+++ b/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
@@ -19,11 +19,11 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Php\PhpPropertyReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\TypeCombinator;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\Resolver\ClassNameFromObjectTypeResolver;
 use Rector\ValueObject\MethodName;
@@ -36,7 +36,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class IssetOnPropertyObjectToPropertyExistsRector extends AbstractRector
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly ReflectionResolver $reflectionResolver,
         private readonly ValueResolver $valueResolver
     ) {
@@ -217,10 +217,10 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return null;
         }
 
-        return $this->reflectionProvider->getClass($className);
+        return $this->classReflectionProvider->getClass($className);
     }
 }

--- a/rules/CodeQuality/Rector/Property/FixClassCaseSensitivityVarDocblockRector.php
+++ b/rules/CodeQuality/Rector/Property/FixClassCaseSensitivityVarDocblockRector.php
@@ -11,13 +11,13 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Naming\Naming\UseImportsResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -29,7 +29,7 @@ final class FixClassCaseSensitivityVarDocblockRector extends AbstractRector
     public function __construct(
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly DocBlockUpdater $docBlockUpdater,
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly UseImportsResolver $useImportsResolver,
     ) {
     }
@@ -99,7 +99,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $realClassName = $this->reflectionProvider->getClass($existingClassName)
+        $realClassName = $this->classReflectionProvider->getClass($existingClassName)
             ->getName();
 
         $hasLeadingSlash = str_starts_with($writtenName, '\\');
@@ -131,7 +131,7 @@ CODE_SAMPLE
 
         // already fully qualified
         if (str_starts_with($writtenName, '\\')) {
-            return $this->reflectionProvider->hasClass($bareName) ? $bareName : null;
+            return $this->classReflectionProvider->hasClass($bareName) ? $bareName : null;
         }
 
         $parts = explode('\\', $bareName);
@@ -155,7 +155,7 @@ CODE_SAMPLE
                     $candidate .= '\\' . implode('\\', array_slice($parts, 1));
                 }
 
-                if ($this->reflectionProvider->hasClass($candidate)) {
+                if ($this->classReflectionProvider->hasClass($candidate)) {
                     return $candidate;
                 }
             }
@@ -165,13 +165,13 @@ CODE_SAMPLE
         $scope = $node->getAttribute(AttributeKey::SCOPE);
         if ($scope instanceof Scope) {
             $namespace = $scope->getNamespace();
-            if ($namespace !== null && $this->reflectionProvider->hasClass($namespace . '\\' . $bareName)) {
+            if ($namespace !== null && $this->classReflectionProvider->hasClass($namespace . '\\' . $bareName)) {
                 return $namespace . '\\' . $bareName;
             }
         }
 
         // global namespace
-        if ($this->reflectionProvider->hasClass($bareName)) {
+        if ($this->classReflectionProvider->hasClass($bareName)) {
             return $bareName;
         }
 

--- a/rules/CodingStyle/Rector/String_/UseClassKeywordForClassNameResolutionRector.php
+++ b/rules/CodingStyle/Rector/String_/UseClassKeywordForClassNameResolutionRector.php
@@ -9,9 +9,9 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -26,7 +26,7 @@ final class UseClassKeywordForClassNameResolutionRector extends AbstractRector
     private const string CLASS_BEFORE_STATIC_ACCESS_REGEX = '#(?<class_name>[\\\\a-zA-Z0-9_\\x80-\\xff]*)::#';
 
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -111,7 +111,7 @@ CODE_SAMPLE
         $classNames = [];
 
         foreach ($matches['class_name'] as $matchedClassName) {
-            if (! $this->reflectionProvider->hasClass($matchedClassName)) {
+            if (! $this->classReflectionProvider->hasClass($matchedClassName)) {
                 continue;
             }
 
@@ -129,7 +129,7 @@ CODE_SAMPLE
     {
         $exprsToConcat = [];
         foreach ($parts as $part) {
-            if ($this->reflectionProvider->hasClass($part)) {
+            if ($this->classReflectionProvider->hasClass($part)) {
                 $exprsToConcat[] = new ClassConstFetch(new FullyQualified(ltrim($part, '\\')), 'class');
             } else {
                 $exprsToConcat[] = new String_($part);

--- a/rules/DeadCode/NodeManipulator/LivingCodeManipulator.php
+++ b/rules/DeadCode/NodeManipulator/LivingCodeManipulator.php
@@ -30,16 +30,16 @@ use PhpParser\Node\Expr\UnaryMinus;
 use PhpParser\Node\Expr\UnaryPlus;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\ValueObject\MethodName;
 
 final readonly class LivingCodeManipulator
 {
     public function __construct(
         private NodeTypeResolver $nodeTypeResolver,
-        private ReflectionProvider $reflectionProvider
+        private ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -122,11 +122,11 @@ final readonly class LivingCodeManipulator
         $cloneObjectType = $this->nodeTypeResolver->getType($clone->expr);
 
         foreach ($cloneObjectType->getObjectClassNames() as $className) {
-            if (! $this->reflectionProvider->hasClass($className)) {
+            if (! $this->classReflectionProvider->hasClass($className)) {
                 continue;
             }
 
-            if ($this->reflectionProvider->getClass($className)->hasNativeMethod(MethodName::CLONE)) {
+            if ($this->classReflectionProvider->getClass($className)->hasNativeMethod(MethodName::CLONE)) {
                 return true;
             }
         }

--- a/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
+++ b/rules/DeadCode/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
@@ -13,12 +13,12 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Expression;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\Enum\ObjectReference;
 use Rector\NodeAnalyzer\ClassAnalyzer;
 use Rector\NodeManipulator\ClassMethodManipulator;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ClassReflectionAnalyzer;
+use Rector\Reflection\ClassReflectionProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -30,7 +30,7 @@ final class RemoveParentCallWithoutParentRector extends AbstractRector
     public function __construct(
         private readonly ClassMethodManipulator $classMethodManipulator,
         private readonly ClassAnalyzer $classAnalyzer,
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly ClassReflectionAnalyzer $classReflectionAnalyzer
     ) {
     }
@@ -142,7 +142,7 @@ CODE_SAMPLE
     private function shouldSkipClass(Class_ $class): bool
     {
         // skip cases when parent class reflection is not found
-        if ($class->extends instanceof FullyQualified && ! $this->reflectionProvider->hasClass(
+        if ($class->extends instanceof FullyQualified && ! $this->classReflectionProvider->hasClass(
             $class->extends->toString()
         )) {
             return true;
@@ -180,11 +180,11 @@ CODE_SAMPLE
             return false;
         }
 
-        if (! $this->reflectionProvider->hasClass($parentClassName)) {
+        if (! $this->classReflectionProvider->hasClass($parentClassName)) {
             return true;
         }
 
-        $parentClassReflection = $this->reflectionProvider->getClass($parentClassName);
+        $parentClassReflection = $this->classReflectionProvider->getClass($parentClassName);
 
         return $this->hasUnresolvableParentClass($parentClassReflection);
     }

--- a/rules/Naming/Guard/HasMagicGetSetGuard.php
+++ b/rules/Naming/Guard/HasMagicGetSetGuard.php
@@ -4,23 +4,23 @@ declare(strict_types=1);
 
 namespace Rector\Naming\Guard;
 
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\Naming\ValueObject\PropertyRename;
+use Rector\Reflection\ClassReflectionProvider;
 
 final readonly class HasMagicGetSetGuard
 {
     public function __construct(
-        private ReflectionProvider $reflectionProvider
+        private ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
     public function isConflicting(PropertyRename $propertyRename): bool
     {
-        if (! $this->reflectionProvider->hasClass($propertyRename->getClassLikeName())) {
+        if (! $this->classReflectionProvider->hasClass($propertyRename->getClassLikeName())) {
             return false;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($propertyRename->getClassLikeName());
+        $classReflection = $this->classReflectionProvider->getClass($propertyRename->getClassLikeName());
         if ($classReflection->hasMethod('__set')) {
             return true;
         }

--- a/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
+++ b/rules/Php55/Rector/String_/StringClassNameToClassConstantRector.php
@@ -9,10 +9,10 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -33,7 +33,7 @@ final class StringClassNameToClassConstantRector extends AbstractRector implemen
     private array $classesToSkip = [];
 
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
     ) {
     }
 
@@ -134,7 +134,7 @@ CODE_SAMPLE
             return true;
         }
 
-        if (! $this->reflectionProvider->hasClass($classLikeName)) {
+        if (! $this->classReflectionProvider->hasClass($classLikeName)) {
             return true;
         }
 

--- a/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
+++ b/rules/Php80/Rector/Class_/AnnotationToAttributeRector.php
@@ -20,7 +20,6 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocChildNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -38,6 +37,7 @@ use Rector\Php80\ValueObject\DoctrineTagAndAnnotationToAttribute;
 use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\Util\StringUtils;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -71,7 +71,7 @@ final class AnnotationToAttributeRector extends AbstractRector implements Config
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly AttributeValueResolver $attributeValueResolver
     ) {
     }
@@ -235,7 +235,7 @@ CODE_SAMPLE
                 }
 
                 // make sure the attribute class really exists to avoid error on early upgrade
-                if (! $this->reflectionProvider->hasClass($annotationToAttribute->getAttributeClass())) {
+                if (! $this->classReflectionProvider->hasClass($annotationToAttribute->getAttributeClass())) {
                     continue;
                 }
 
@@ -414,12 +414,12 @@ CODE_SAMPLE
     private function isExistingAttributeClass(AnnotationToAttribute $annotationToAttribute): bool
     {
         // make sure the attribute class really exists to avoid error on early upgrade
-        if (! $this->reflectionProvider->hasClass($annotationToAttribute->getAttributeClass())) {
+        if (! $this->classReflectionProvider->hasClass($annotationToAttribute->getAttributeClass())) {
             return false;
         }
 
         // make sure the class is marked as attribute
-        $classReflection = $this->reflectionProvider->getClass($annotationToAttribute->getAttributeClass());
+        $classReflection = $this->classReflectionProvider->getClass($annotationToAttribute->getAttributeClass());
         return $classReflection->isAttributeClass();
     }
 }

--- a/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
+++ b/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
@@ -21,7 +21,6 @@ use PHPStan\Analyser\Fiber\FiberScope;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\Native\ExtendedNativeParameterReflection;
 use PHPStan\Reflection\ParametersAcceptor;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
@@ -32,6 +31,7 @@ use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Reflection\ClassReflectionProvider;
 
 final readonly class NullToStrictStringIntConverter
 {
@@ -39,7 +39,7 @@ final readonly class NullToStrictStringIntConverter
         private ValueResolver $valueResolver,
         private NodeTypeResolver $nodeTypeResolver,
         private PropertyFetchAnalyzer $propertyFetchAnalyzer,
-        private ReflectionProvider $reflectionProvider,
+        private ClassReflectionProvider $classReflectionProvider,
     ) {
     }
 
@@ -178,11 +178,11 @@ final readonly class NullToStrictStringIntConverter
             return false;
         }
 
-        if (! $this->reflectionProvider->hasClass($varType->getClassName())) {
+        if (! $this->classReflectionProvider->hasClass($varType->getClassName())) {
             return false;
         }
 
-        return $this->reflectionProvider->getClass($varType->getClassName())
+        return $this->classReflectionProvider->getClass($varType->getClassName())
             ->hasMethod('__get');
     }
 

--- a/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
+++ b/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
@@ -14,12 +14,12 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\VariadicPlaceholder;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\NodeCollector\NodeAnalyzer\ArrayCallableMethodMatcher;
 use Rector\NodeCollector\ValueObject\ArrayCallable;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\ValueObject\PhpVersion;
@@ -35,7 +35,7 @@ class ArrayToFirstClassCallableRector extends AbstractRector implements MinPhpVe
 {
     public function __construct(
         private readonly ArrayCallableMethodMatcher $arrayCallableMethodMatcher,
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly ReflectionResolver $reflectionResolver,
     ) {
     }
@@ -165,7 +165,7 @@ CODE_SAMPLE
             return false;
         }
 
-        $arrayClassReflection = $this->reflectionProvider->getClass($arrayCallable->getClass());
+        $arrayClassReflection = $this->classReflectionProvider->getClass($arrayCallable->getClass());
 
         // we're unable to find it
         if (! $arrayClassReflection->hasMethod($arrayCallable->getMethod())) {

--- a/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
+++ b/rules/Php81/Rector/MethodCall/MyCLabsMethodCallToEnumConstRector.php
@@ -13,9 +13,9 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -32,7 +32,7 @@ final class MyCLabsMethodCallToEnumConstRector extends AbstractRector implements
     private const array ENUM_METHODS = ['from', 'values', 'keys', 'isValid', 'search', 'toArray', 'assertValidValue'];
 
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
     ) {
     }
 
@@ -105,11 +105,11 @@ CODE_SAMPLE
 
     private function isEnumConstant(string $className, string $constant): bool
     {
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return false;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
 
         return $classReflection->hasConstant($constant);
     }
@@ -225,7 +225,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            $classReflection = $this->reflectionProvider->getClass($className);
+            $classReflection = $this->classReflectionProvider->getClass($className);
             // method self::getValidEnumExpr process enum static methods from constants
             if ($classReflection->hasConstant($methodName)) {
                 return null;

--- a/rules/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector.php
+++ b/rules/Php81/Rector/New_/MyCLabsConstructorCallToEnumFromRector.php
@@ -8,11 +8,11 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name\FullyQualified;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\Enum\ObjectReference;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\ValueObject\MethodName;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -29,7 +29,7 @@ final class MyCLabsConstructorCallToEnumFromRector extends AbstractRector implem
     private const string DEFAULT_ENUM_CONSTRUCTOR = 'from';
 
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
     ) {
     }
 
@@ -95,7 +95,7 @@ CODE_SAMPLE
 
     private function isMyCLabsConstructor(New_ $new, string $classname): bool
     {
-        $classReflection = $this->reflectionProvider->getClass($classname);
+        $classReflection = $this->classReflectionProvider->getClass($classname);
         if (! $classReflection->hasMethod(MethodName::CONSTRUCT)) {
             return true;
         }

--- a/rules/Php82/NodeManipulator/ReadonlyClassManipulator.php
+++ b/rules/Php82/NodeManipulator/ReadonlyClassManipulator.php
@@ -13,11 +13,11 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\Analyser\Scope;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionProperty;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\Php81\Enum\AttributeName;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\ValueObject\MethodName;
 use Rector\ValueObject\Visibility;
 
@@ -26,7 +26,7 @@ final readonly class ReadonlyClassManipulator
     public function __construct(
         private VisibilityManipulator $visibilityManipulator,
         private PhpAttributeAnalyzer $phpAttributeAnalyzer,
-        private ReflectionProvider $reflectionProvider
+        private ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -134,11 +134,11 @@ final readonly class ReadonlyClassManipulator
                 $traitName = $trait->toString();
 
                 // trait not autoloaded
-                if (! $this->reflectionProvider->hasClass($traitName)) {
+                if (! $this->classReflectionProvider->hasClass($traitName)) {
                     return true;
                 }
 
-                $traitClassReflection = $this->reflectionProvider->getClass($traitName);
+                $traitClassReflection = $this->classReflectionProvider->getClass($traitName);
                 $nativeReflection = $traitClassReflection->getNativeReflection();
 
                 if ($this->hasReadonlyProperty($nativeReflection->getProperties())) {
@@ -188,7 +188,7 @@ final readonly class ReadonlyClassManipulator
             return true;
         }
 
-        return $class->extends instanceof FullyQualified && ! $this->reflectionProvider->hasClass(
+        return $class->extends instanceof FullyQualified && ! $this->classReflectionProvider->hasClass(
             $class->extends->toString()
         );
     }

--- a/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
+++ b/rules/Php83/Rector/ClassConst/AddTypeToConstRector.php
@@ -20,13 +20,13 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Configuration\Parameter\FeatureFlags;
 use Rector\DeadCode\PhpDoc\TagRemover\VarTagRemover;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
@@ -39,7 +39,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class AddTypeToConstRector extends AbstractRector implements MinPhpVersionInterface
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly VarTagRemover $varTagRemover,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
@@ -216,11 +216,11 @@ CODE_SAMPLE
      */
     private function getParentReflections(string $className): array
     {
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return [];
         }
 
-        $currentClassReflection = $this->reflectionProvider->getClass($className);
+        $currentClassReflection = $this->classReflectionProvider->getClass($className);
 
         return array_filter($currentClassReflection->getAncestors(), static fn (ClassReflection $classReflection): bool =>
             // skip base class

--- a/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
+++ b/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
@@ -19,7 +19,6 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\DeadCode\NodeAnalyzer\ParentClassAnalyzer;
 use Rector\NodeAnalyzer\ClassAnalyzer;
@@ -27,6 +26,7 @@ use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\PhpParser\AstResolver;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\ValueObject\MethodName;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\ValueObject\PolyfillPackage;
@@ -61,7 +61,7 @@ final class AddOverrideAttributeToOverriddenMethodsRector extends AbstractRector
     private bool $hasChanged = false;
 
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly ClassAnalyzer $classAnalyzer,
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
         private readonly AstResolver $astResolver,
@@ -190,11 +190,11 @@ CODE_SAMPLE
         }
 
         $className = (string) $this->getName($node);
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return null;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
         $parentClassReflections = $classReflection->getParents();
 
         // interfaces are added for Stringable

--- a/rules/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector.php
+++ b/rules/Php85/Rector/Property/AddOverrideAttributeToOverriddenPropertiesRector.php
@@ -11,10 +11,10 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\NodeAnalyzer\ClassAnalyzer;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -32,7 +32,7 @@ final class AddOverrideAttributeToOverriddenPropertiesRector extends AbstractRec
     private bool $hasChanged = false;
 
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly ClassAnalyzer $classAnalyzer,
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
     ) {
@@ -96,11 +96,11 @@ CODE_SAMPLE
         }
 
         $className = (string) $this->getName($node);
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return null;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
         $parentClassReflections = $classReflection->getParents();
 
         if ($parentClassReflections === []) {

--- a/rules/Privatization/Guard/OverrideByParentClassGuard.php
+++ b/rules/Privatization/Guard/OverrideByParentClassGuard.php
@@ -7,7 +7,7 @@ namespace Rector\Privatization\Guard;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
-use PHPStan\Reflection\ReflectionProvider;
+use Rector\Reflection\ClassReflectionProvider;
 
 /**
  * Verify whether Class_'s method or property allowed to be overridden by verify class parent or implements exists
@@ -15,13 +15,13 @@ use PHPStan\Reflection\ReflectionProvider;
 final readonly class OverrideByParentClassGuard
 {
     public function __construct(
-        private ReflectionProvider $reflectionProvider
+        private ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
     public function isLegal(Class_ $class): bool
     {
-        if ($class->extends instanceof FullyQualified && ! $this->reflectionProvider->hasClass(
+        if ($class->extends instanceof FullyQualified && ! $this->classReflectionProvider->hasClass(
             $class->extends->toString()
         )) {
             return false;
@@ -29,7 +29,7 @@ final readonly class OverrideByParentClassGuard
 
         return array_all(
             $class->implements,
-            fn (Name $name): bool => $this->reflectionProvider->hasClass($name->toString())
+            fn (Name $name): bool => $this->classReflectionProvider->hasClass($name->toString())
         );
     }
 }

--- a/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
+++ b/rules/Privatization/Rector/Class_/FinalizeTestCaseClassRector.php
@@ -6,9 +6,9 @@ namespace Rector\Privatization\Rector\Class_;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -18,7 +18,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class FinalizeTestCaseClassRector extends AbstractRector
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly VisibilityManipulator $visibilityManipulator
     ) {
     }
@@ -79,11 +79,11 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return null;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
         if (! $classReflection->is('PHPUnit\Framework\TestCase')) {
             return null;
         }

--- a/rules/Renaming/NodeManipulator/ClassRenamer.php
+++ b/rules/Renaming/NodeManipulator/ClassRenamer.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -22,6 +21,7 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockClassRenamer;
 use Rector\NodeTypeResolver\ValueObject\OldToNewType;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\Renaming\Collector\RenamedNameCollector;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\Util\FileHasher;
@@ -37,7 +37,7 @@ final class ClassRenamer
         private readonly PhpDocClassRenamer $phpDocClassRenamer,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly DocBlockClassRenamer $docBlockClassRenamer,
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly FileHasher $fileHasher,
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly RenamedNameCollector $renamedNameCollector
@@ -122,8 +122,8 @@ final class ClassRenamer
     private function shouldSkip(string $newName, FullyQualified $fullyQualified): bool
     {
         if ($fullyQualified->getAttribute(AttributeKey::IS_STATICCALL_CLASS_NAME) === true
-            && $this->reflectionProvider->hasClass($newName)) {
-            $classReflection = $this->reflectionProvider->getClass($newName);
+            && $this->classReflectionProvider->hasClass($newName)) {
+            $classReflection = $this->classReflectionProvider->getClass($newName);
             return $classReflection->isInterface();
         }
 
@@ -210,11 +210,11 @@ final class ClassRenamer
         string $newClassName,
         ?Scope $scope
     ): bool {
-        if (! $this->reflectionProvider->hasClass($newClassName)) {
+        if (! $this->classReflectionProvider->hasClass($newClassName)) {
             return true;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($newClassName);
+        $classReflection = $this->classReflectionProvider->getClass($newClassName);
         // ensure new is not with interface
         if ($fullyQualified->getAttribute(AttributeKey::IS_NEW_INSTANCE_NAME) !== true) {
             if ($fullyQualified->getAttribute(AttributeKey::IS_CLASS_EXTENDS) === true && $scope instanceof Scope) {

--- a/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/Renaming/Rector/MethodCall/RenameMethodRector.php
@@ -17,11 +17,11 @@ use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\NodeManipulator\ClassManipulator;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\Reflection\ReflectionResolver;
 use Rector\Renaming\Contract\MethodCallRenameInterface;
 use Rector\Renaming\ValueObject\MethodCallRename;
@@ -43,7 +43,7 @@ final class RenameMethodRector extends AbstractRector implements ConfigurableRec
     public function __construct(
         private readonly ClassManipulator $classManipulator,
         private readonly ReflectionResolver $reflectionResolver,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -114,11 +114,11 @@ CODE_SAMPLE
         }
 
         $targetClass = $methodCallRename->getClass();
-        if (! $this->reflectionProvider->hasClass($targetClass)) {
+        if (! $this->classReflectionProvider->hasClass($targetClass)) {
             return false;
         }
 
-        $targetClassReflection = $this->reflectionProvider->getClass($targetClass);
+        $targetClassReflection = $this->classReflectionProvider->getClass($targetClass);
         if ($classReflection->getName() === $targetClassReflection->getName()) {
             return false;
         }

--- a/rules/Renaming/Rector/Name/RenameClassRector.php
+++ b/rules/Renaming/Rector/Name/RenameClassRector.php
@@ -12,11 +12,11 @@ use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\Configuration\RenamedClassesDataCollector;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\Renaming\NodeManipulator\ClassRenamer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -30,7 +30,7 @@ final class RenameClassRector extends AbstractRector implements ConfigurableRect
     public function __construct(
         private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
         private readonly ClassRenamer $classRenamer,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -129,7 +129,7 @@ CODE_SAMPLE
         FullyQualified $fullyQualified,
         array $oldToNewClasses
     ): bool {
-        if (! $this->reflectionProvider->hasClass($fullyQualified->toString())) {
+        if (! $this->classReflectionProvider->hasClass($fullyQualified->toString())) {
             return false;
         }
 
@@ -144,12 +144,12 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (! $this->reflectionProvider->hasClass($newClass)) {
+            if (! $this->classReflectionProvider->hasClass($newClass)) {
                 continue;
             }
 
-            $classReflection = $this->reflectionProvider->getClass($newClass);
-            $oldClassReflection = $this->reflectionProvider->getClass($oldClass);
+            $classReflection = $this->classReflectionProvider->getClass($newClass);
+            $oldClassReflection = $this->classReflectionProvider->getClass($oldClass);
 
             if ($oldClassReflection->hasConstant($constFetchName) && ! $classReflection->hasConstant($constFetchName)) {
                 // should be skipped as new class does not have access to the constant

--- a/rules/Strict/NodeAnalyzer/UninitializedPropertyAnalyzer.php
+++ b/rules/Strict/NodeAnalyzer/UninitializedPropertyAnalyzer.php
@@ -9,11 +9,11 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ThisType;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpParser\AstResolver;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\Resolver\ClassNameFromObjectTypeResolver;
 use Rector\TypeDeclaration\AlreadyAssignDetector\ConstructorAssignDetector;
 
@@ -24,7 +24,7 @@ final readonly class UninitializedPropertyAnalyzer
         private NodeTypeResolver $nodeTypeResolver,
         private ConstructorAssignDetector $constructorAssignDetector,
         private NodeNameResolver $nodeNameResolver,
-        private ReflectionProvider $reflectionProvider
+        private ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -80,11 +80,11 @@ final readonly class UninitializedPropertyAnalyzer
 
     private function hasTypedDefaultProperty(string $className, string $propertyName): bool
     {
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return false;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
         if (! $classReflection->hasNativeProperty($propertyName)) {
             return false;
         }

--- a/rules/Transform/NodeTypeAnalyzer/TypeProvidingExprFromClassResolver.php
+++ b/rules/Transform/NodeTypeAnalyzer/TypeProvidingExprFromClassResolver.php
@@ -13,20 +13,20 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use Rector\Naming\Naming\PropertyNaming;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\Resolver\ClassNameFromObjectTypeResolver;
 use Rector\ValueObject\MethodName;
 
 final readonly class TypeProvidingExprFromClassResolver
 {
     public function __construct(
-        private ReflectionProvider $reflectionProvider,
+        private ClassReflectionProvider $classReflectionProvider,
         private NodeNameResolver $nodeNameResolver,
         private PropertyNaming $propertyNaming,
     ) {
@@ -43,7 +43,7 @@ final readonly class TypeProvidingExprFromClassResolver
         $className = (string) $this->nodeNameResolver->getName($class);
 
         // A. match a method
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
         $methodCallProvidingType = $this->resolveMethodCallProvidingType($classReflection, $objectType);
         if ($methodCallProvidingType instanceof MethodCall) {
             return $methodCallProvidingType;

--- a/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/CallTypesResolver.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\VariadicPlaceholder;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\MixedType;
@@ -22,6 +21,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\Resolver\ClassNameFromObjectTypeResolver;
 
 final readonly class CallTypesResolver
@@ -29,7 +29,7 @@ final readonly class CallTypesResolver
     public function __construct(
         private NodeTypeResolver $nodeTypeResolver,
         private TypeFactory $typeFactory,
-        private ReflectionProvider $reflectionProvider
+        private ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -191,7 +191,7 @@ final readonly class CallTypesResolver
         }
 
         // fix false positive generic type on string
-        if (! $this->reflectionProvider->hasClass($argValueType->getClassName())) {
+        if (! $this->classReflectionProvider->hasClass($argValueType->getClassName())) {
             return new MixedType();
         }
 

--- a/rules/TypeDeclaration/NodeFactory/JMSTypePropertyTypeFactory.php
+++ b/rules/TypeDeclaration/NodeFactory/JMSTypePropertyTypeFactory.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
@@ -17,6 +16,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\DeadCode\PhpDoc\TagRemover\VarTagRemover;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\Mapper\ScalarStringToTypeMapper;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
@@ -27,7 +27,7 @@ final readonly class JMSTypePropertyTypeFactory
         private StaticTypeMapper $staticTypeMapper,
         private PhpDocInfoFactory $phpDocInfoFactory,
         private VarTagRemover $varTagRemover,
-        private ReflectionProvider $reflectionProvider,
+        private ClassReflectionProvider $classReflectionProvider,
     ) {
     }
 
@@ -46,7 +46,7 @@ final readonly class JMSTypePropertyTypeFactory
 
         $node = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($type, TypeKind::PROPERTY);
 
-        if ($node instanceof FullyQualified && ! $this->reflectionProvider->hasClass($node->toString())) {
+        if ($node instanceof FullyQualified && ! $this->classReflectionProvider->hasClass($node->toString())) {
             return null;
         }
 

--- a/rules/TypeDeclaration/PHPStan/ObjectTypeSpecifier.php
+++ b/rules/TypeDeclaration/PHPStan/ObjectTypeSpecifier.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\UseItem;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
@@ -22,6 +21,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
 use Rector\Naming\Naming\UseImportsResolver;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\Naming\NameScopeFactory;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
@@ -32,7 +32,7 @@ use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
 final readonly class ObjectTypeSpecifier
 {
     public function __construct(
-        private ReflectionProvider $reflectionProvider,
+        private ClassReflectionProvider $classReflectionProvider,
         private UseImportsResolver $useImportsResolver,
         private NameScopeFactory $nameScopeFactory
     ) {
@@ -63,7 +63,7 @@ final readonly class ObjectTypeSpecifier
             }
         }
 
-        if ($this->reflectionProvider->hasClass($className)) {
+        if ($this->classReflectionProvider->hasClass($className)) {
             return new FullyQualifiedObjectType($className);
         }
 
@@ -73,7 +73,7 @@ final readonly class ObjectTypeSpecifier
             $namespaceName = $scope->getNamespace();
             if ($namespaceName !== null) {
                 $newClassName = $namespaceName . '\\' . $className;
-                if ($this->reflectionProvider->hasClass($newClassName)) {
+                if ($this->classReflectionProvider->hasClass($newClassName)) {
                     return new FullyQualifiedObjectType($newClassName);
                 }
             }
@@ -274,7 +274,7 @@ final readonly class ObjectTypeSpecifier
             return null;
         }
 
-        if (! $this->reflectionProvider->hasClass($prefix . $useItem->name->toString())) {
+        if (! $this->classReflectionProvider->hasClass($prefix . $useItem->name->toString())) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/NarrowObjectReturnTypeRector.php
@@ -12,7 +12,6 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
@@ -22,6 +21,7 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -41,7 +41,7 @@ final class NarrowObjectReturnTypeRector extends AbstractRector
         private readonly TypeComparator $typeComparator,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly DocBlockUpdater $docBlockUpdater,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -137,11 +137,11 @@ CODE_SAMPLE
 
         // non-existing class
         if ($declaredType !== 'object') {
-            if (! $this->reflectionProvider->hasClass($declaredType)) {
+            if (! $this->classReflectionProvider->hasClass($declaredType)) {
                 return null;
             }
 
-            $declaredTypeClassReflection = $this->reflectionProvider->getClass($declaredType);
+            $declaredTypeClassReflection = $this->classReflectionProvider->getClass($declaredType);
 
             // already last final object
             if ($declaredTypeClassReflection->isFinalByKeyword()) {
@@ -305,8 +305,8 @@ CODE_SAMPLE
             $className = $classNames[0];
 
             // skip anonymous classes, they have no usable name
-            if ($this->reflectionProvider->hasClass($className)) {
-                $returnedClassReflection = $this->reflectionProvider->getClass($className);
+            if ($this->classReflectionProvider->hasClass($className)) {
+                $returnedClassReflection = $this->classReflectionProvider->getClass($className);
                 if ($returnedClassReflection->isAnonymous()) {
                     return null;
                 }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromGetRepositoryDocblockRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -20,6 +19,7 @@ use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -37,7 +37,7 @@ final class ReturnTypeFromGetRepositoryDocblockRector extends AbstractRector
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly DocBlockUpdater $docBlockUpdater,
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard
     ) {
     }
@@ -126,7 +126,7 @@ CODE_SAMPLE
         }
 
         // must be an existing repository class
-        if (! $this->reflectionProvider->hasClass($returnTypeNode->toString())) {
+        if (! $this->classReflectionProvider->hasClass($returnTypeNode->toString())) {
             return null;
         }
 

--- a/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromReturnNewRector.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StaticType;
@@ -27,6 +26,7 @@ use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\StaticTypeMapper\ValueObject\Type\SelfStaticType;
@@ -47,7 +47,7 @@ final class ReturnTypeFromReturnNewRector extends AbstractRector implements MinP
 {
     public function __construct(
         private readonly TypeFactory $typeFactory,
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly ReflectionResolver $reflectionResolver,
         private readonly StrictReturnNewAnalyzer $strictReturnNewAnalyzer,
         private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
@@ -168,11 +168,11 @@ CODE_SAMPLE
             return new StaticType($classReflection);
         }
 
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return null;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
         return new ObjectType($className, null, $classReflection);
     }
 

--- a/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromContainerGetSetUpRector.php
@@ -16,7 +16,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -25,6 +24,7 @@ use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\ValueObject\MethodName;
 use Rector\ValueObject\PhpVersionFeature;
@@ -43,7 +43,7 @@ final class TypedPropertyFromContainerGetSetUpRector extends AbstractRector impl
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -152,7 +152,7 @@ CODE_SAMPLE
             }
 
             // must be an existing object type
-            if (! $this->reflectionProvider->hasClass($propertyTypeNode->toString())) {
+            if (! $this->classReflectionProvider->hasClass($propertyTypeNode->toString())) {
                 continue;
             }
 

--- a/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector.php
+++ b/rules/TypeDeclaration/Rector/Class_/TypedPropertyFromGetRepositorySetUpRector.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -23,6 +22,7 @@ use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\ValueObject\MethodName;
 use Rector\ValueObject\PhpVersionFeature;
@@ -41,7 +41,7 @@ final class TypedPropertyFromGetRepositorySetUpRector extends AbstractRector imp
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -150,7 +150,7 @@ CODE_SAMPLE
             }
 
             // must be an existing object type
-            if (! $this->reflectionProvider->hasClass($propertyTypeNode->toString())) {
+            if (! $this->classReflectionProvider->hasClass($propertyTypeNode->toString())) {
                 continue;
             }
 

--- a/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/TrustedClassMethodPropertyTypeInferer.php
+++ b/rules/TypeDeclaration/TypeInferer/PropertyTypeInferer/TrustedClassMethodPropertyTypeInferer.php
@@ -15,7 +15,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\NodeVisitor;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
@@ -30,6 +29,7 @@ use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
@@ -42,7 +42,7 @@ final readonly class TrustedClassMethodPropertyTypeInferer
 {
     public function __construct(
         private ClassMethodPropertyFetchManipulator $classMethodPropertyFetchManipulator,
-        private ReflectionProvider $reflectionProvider,
+        private ClassReflectionProvider $classReflectionProvider,
         private NodeNameResolver $nodeNameResolver,
         private SimpleCallableNodeTraverser $simpleCallableNodeTraverser,
         private TypeFactory $typeFactory,
@@ -217,7 +217,7 @@ final readonly class TrustedClassMethodPropertyTypeInferer
         if (! \str_ends_with($fullyQualifiedName, '\\' . $originalName->toString())) {
             $className = $originalName->toString();
 
-            if ($this->reflectionProvider->hasClass($className)) {
+            if ($this->classReflectionProvider->hasClass($className)) {
                 return new FullyQualifiedObjectType($className);
             }
 

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddReturnDocblockForCommonObjectDenominatorRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\IntegerType;
@@ -19,6 +18,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\TypeDeclarationDocblocks\NodeDocblockTypeDecorator;
 use Rector\TypeDeclarationDocblocks\NodeFinder\ReturnNodeFinder;
@@ -34,7 +34,7 @@ final class AddReturnDocblockForCommonObjectDenominatorRector extends AbstractRe
     public function __construct(
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly ReturnNodeFinder $returnNodeFinder,
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly UsefulArrayTagNodeAnalyzer $usefulArrayTagNodeAnalyzer,
         private readonly NodeDocblockTypeDecorator $nodeDocblockTypeDecorator
     ) {
@@ -223,7 +223,7 @@ CODE_SAMPLE
      */
     private function resolveParentClassesAndInterfaces(string $className): array
     {
-        $referenceClassReflection = $this->reflectionProvider->getClass($className);
+        $referenceClassReflection = $this->classReflectionProvider->getClass($className);
 
         $currentParentClassesAndInterfaces = $referenceClassReflection->getParentClassesNames();
 

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/AddParamTypeToRefactorMethodRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -19,6 +18,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -30,7 +30,7 @@ final class AddParamTypeToRefactorMethodRector extends AbstractRector
     public function __construct(
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly PhpDocTypeChanger $phpDocTypeChanger,
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly ValueResolver $valueResolver,
     ) {
     }
@@ -155,11 +155,11 @@ CODE_SAMPLE
             }
 
             // skip interface node types, they expand to an unwieldy union of all implementers
-            if (! $this->reflectionProvider->hasClass($nodeType)) {
+            if (! $this->classReflectionProvider->hasClass($nodeType)) {
                 return null;
             }
 
-            if ($this->reflectionProvider->getClass($nodeType)->isInterface()) {
+            if ($this->classReflectionProvider->getClass($nodeType)->isInterface()) {
                 return null;
             }
 

--- a/src/BetterPhpDocParser/PhpDocParser/ClassAnnotationMatcher.php
+++ b/src/BetterPhpDocParser/PhpDocParser/ClassAnnotationMatcher.php
@@ -9,10 +9,10 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\GroupUse;
 use PhpParser\Node\Stmt\Use_;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\CodingStyle\NodeAnalyzer\UseImportNameMatcher;
 use Rector\Naming\Naming\UseImportsResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Reflection\ClassReflectionProvider;
 
 /**
  * Matches "@ORM\Entity" to FQN names based on use imports in the file
@@ -27,7 +27,7 @@ final class ClassAnnotationMatcher
     public function __construct(
         private readonly UseImportNameMatcher $useImportNameMatcher,
         private readonly UseImportsResolver $useImportsResolver,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -67,7 +67,7 @@ final class ClassAnnotationMatcher
             $namespace = $scope->getNamespace();
             if ($namespace !== null) {
                 $namespacedTag = $namespace . '\\' . $tag;
-                if ($this->reflectionProvider->hasClass($namespacedTag)) {
+                if ($this->classReflectionProvider->hasClass($namespacedTag)) {
                     return $namespacedTag;
                 }
 
@@ -114,6 +114,6 @@ final class ClassAnnotationMatcher
             return false;
         }
 
-        return $this->reflectionProvider->hasClass($tag);
+        return $this->classReflectionProvider->hasClass($tag);
     }
 }

--- a/src/Console/Command/CustomRuleCommand.php
+++ b/src/Console/Command/CustomRuleCommand.php
@@ -6,10 +6,10 @@ namespace Rector\Console\Command;
 
 use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\Enum\ClassName;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\FileSystem\JsonFileSystem;
+use Rector\Reflection\ClassReflectionProvider;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -21,7 +21,7 @@ final class CustomRuleCommand extends Command
 {
     public function __construct(
         private readonly SymfonyStyle $symfonyStyle,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ClassReflectionProvider $classReflectionProvider
     ) {
         parent::__construct();
     }
@@ -141,6 +141,6 @@ final class CustomRuleCommand extends Command
 
     private function isPHPUnitAttributeSupported(): bool
     {
-        return $this->reflectionProvider->hasClass(ClassName::DATA_PROVIDER);
+        return $this->classReflectionProvider->hasClass(ClassName::DATA_PROVIDER);
     }
 }

--- a/src/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
+++ b/src/FamilyTree/Reflection/FamilyRelationsAnalyzer.php
@@ -8,13 +8,13 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Interface_;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\Reflection\ClassReflectionProvider;
 
 final readonly class FamilyRelationsAnalyzer
 {
     public function __construct(
-        private ReflectionProvider $reflectionProvider,
+        private ClassReflectionProvider $classReflectionProvider,
         private NodeNameResolver $nodeNameResolver,
     ) {
     }
@@ -29,11 +29,11 @@ final readonly class FamilyRelationsAnalyzer
 
         if ($classOrName instanceof Name) {
             $fullName = $this->nodeNameResolver->getName($classOrName);
-            if (! $this->reflectionProvider->hasClass($fullName)) {
+            if (! $this->classReflectionProvider->hasClass($fullName)) {
                 return [];
             }
 
-            $classReflection = $this->reflectionProvider->getClass($fullName);
+            $classReflection = $this->classReflectionProvider->getClass($fullName);
             $ancestors = [...$classReflection->getParents(), ...$classReflection->getInterfaces()];
 
             return array_map(

--- a/src/NodeAnalyzer/CallAnalyzer.php
+++ b/src/NodeAnalyzer/CallAnalyzer.php
@@ -13,9 +13,9 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\If_;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Reflection\ClassReflectionProvider;
 
 final readonly class CallAnalyzer
 {
@@ -25,7 +25,7 @@ final readonly class CallAnalyzer
     private const array OBJECT_CALL_TYPES = [MethodCall::class, NullsafeMethodCall::class, StaticCall::class];
 
     public function __construct(
-        private ReflectionProvider $reflectionProvider
+        private ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -69,11 +69,11 @@ final readonly class CallAnalyzer
         }
 
         $className = $type->getClassName();
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return false;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
         return $classReflection->getNativeReflection()
             ->isInstantiable();
     }

--- a/src/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
+++ b/src/NodeCollector/NodeAnalyzer/ArrayCallableMethodMatcher.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
@@ -25,6 +24,7 @@ use Rector\NodeCollector\ValueObject\ArrayCallableDynamicMethod;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\MethodName;
 
@@ -33,7 +33,7 @@ final readonly class ArrayCallableMethodMatcher
     public function __construct(
         private NodeTypeResolver $nodeTypeResolver,
         private ValueResolver $valueResolver,
-        private ReflectionProvider $reflectionProvider,
+        private ClassReflectionProvider $classReflectionProvider,
         private ReflectionResolver $reflectionResolver
     ) {
     }
@@ -158,11 +158,11 @@ final readonly class ArrayCallableMethodMatcher
             $classConstantReference = $classReflection->getName();
         }
 
-        if (! $this->reflectionProvider->hasClass($classConstantReference)) {
+        if (! $this->classReflectionProvider->hasClass($classConstantReference)) {
             return new MixedType();
         }
 
-        $classReflection = $this->reflectionProvider->getClass($classConstantReference);
+        $classReflection = $this->classReflectionProvider->getClass($classConstantReference);
         $hasConstruct = $classReflection->hasMethod(MethodName::CONSTRUCT);
 
         if (! $hasConstruct) {

--- a/src/NodeManipulator/ClassManipulator.php
+++ b/src/NodeManipulator/ClassManipulator.php
@@ -5,25 +5,25 @@ declare(strict_types=1);
 namespace Rector\NodeManipulator;
 
 use PhpParser\Node\Stmt\Class_;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\Reflection\ClassReflectionProvider;
 
 final readonly class ClassManipulator
 {
     public function __construct(
         private NodeNameResolver $nodeNameResolver,
-        private ReflectionProvider $reflectionProvider,
+        private ClassReflectionProvider $classReflectionProvider,
     ) {
     }
 
     public function hasParentMethodOrInterface(ObjectType $objectType, string $oldMethod): bool
     {
-        if (! $this->reflectionProvider->hasClass($objectType->getClassName())) {
+        if (! $this->classReflectionProvider->hasClass($objectType->getClassName())) {
             return false;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($objectType->getClassName());
+        $classReflection = $this->classReflectionProvider->getClass($objectType->getClassName());
         $ancestorClassReflections = [...$classReflection->getParents(), ...$classReflection->getInterfaces()];
         foreach ($ancestorClassReflections as $ancestorClassReflection) {
             if (! $ancestorClassReflection->hasMethod($oldMethod)) {

--- a/src/NodeTypeResolver/NodeTypeCorrector/GenericClassStringTypeCorrector.php
+++ b/src/NodeTypeResolver/NodeTypeCorrector/GenericClassStringTypeCorrector.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\NodeTypeCorrector;
 
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
+use Rector\Reflection\ClassReflectionProvider;
 
 final readonly class GenericClassStringTypeCorrector
 {
     public function __construct(
-        private ReflectionProvider $reflectionProvider
+        private ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -27,11 +27,11 @@ final readonly class GenericClassStringTypeCorrector
             }
 
             $value = $traversedType->getValue();
-            if (! $this->reflectionProvider->hasClass($value)) {
+            if (! $this->classReflectionProvider->hasClass($value)) {
                 return $traverseCallback($traversedType);
             }
 
-            $classReflection = $this->reflectionProvider->getClass($value);
+            $classReflection = $this->classReflectionProvider->getClass($value);
             if ($classReflection->getName() !== $value) {
                 return $traverseCallback($traversedType);
             }

--- a/src/NodeTypeResolver/NodeTypeResolver/PropertyFetchTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver/PropertyFetchTypeResolver.php
@@ -7,7 +7,6 @@ namespace Rector\NodeTypeResolver\NodeTypeResolver;
 use PhpParser\Node;
 use PhpParser\Node\Expr\PropertyFetch;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -16,6 +15,7 @@ use Rector\NodeTypeResolver\Contract\NodeTypeResolverAwareInterface;
 use Rector\NodeTypeResolver\Contract\NodeTypeResolverInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\Reflection\ClassReflectionProvider;
 
 /**
  * @see \Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\PropertyFetchTypeResolver\PropertyFetchTypeResolverTest
@@ -28,7 +28,7 @@ final class PropertyFetchTypeResolver implements NodeTypeResolverInterface, Node
 
     public function __construct(
         private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -77,11 +77,11 @@ final class PropertyFetchTypeResolver implements NodeTypeResolverInterface, Node
             return new MixedType();
         }
 
-        if (! $this->reflectionProvider->hasClass($varType->getClassName())) {
+        if (! $this->classReflectionProvider->hasClass($varType->getClassName())) {
             return new MixedType();
         }
 
-        $classReflection = $this->reflectionProvider->getClass($varType->getClassName());
+        $classReflection = $this->classReflectionProvider->getClass($varType->getClassName());
         if (! $classReflection->hasInstanceProperty($propertyName)) {
             return new MixedType();
         }

--- a/src/NodeTypeResolver/NodeTypeResolver/TraitTypeResolver.php
+++ b/src/NodeTypeResolver/NodeTypeResolver/TraitTypeResolver.php
@@ -6,12 +6,12 @@ namespace Rector\NodeTypeResolver\NodeTypeResolver;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Trait_;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\NodeTypeResolver\Contract\NodeTypeResolverInterface;
+use Rector\Reflection\ClassReflectionProvider;
 
 /**
  * @see \Rector\Tests\NodeTypeResolver\PerNodeTypeResolver\TraitTypeResolver\TraitTypeResolverTest
@@ -21,7 +21,7 @@ use Rector\NodeTypeResolver\Contract\NodeTypeResolverInterface;
 final readonly class TraitTypeResolver implements NodeTypeResolverInterface
 {
     public function __construct(
-        private ReflectionProvider $reflectionProvider
+        private ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -39,11 +39,11 @@ final readonly class TraitTypeResolver implements NodeTypeResolverInterface
     public function resolve(Node $node): Type
     {
         $traitName = (string) $node->namespacedName;
-        if (! $this->reflectionProvider->hasClass($traitName)) {
+        if (! $this->classReflectionProvider->hasClass($traitName)) {
             return new MixedType();
         }
 
-        $classReflection = $this->reflectionProvider->getClass($traitName);
+        $classReflection = $this->classReflectionProvider->getClass($traitName);
 
         $types = [];
         $types[] = new ObjectType($traitName);

--- a/src/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/src/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -9,7 +9,6 @@ use PhpParser\Node as PhpParserNode;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Type;
 use Rector\Application\Provider\CurrentFileProvider;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
@@ -19,6 +18,7 @@ use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipper;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\PhpDocParser\PhpDocParser\PhpDocNodeVisitor\AbstractPhpDocNodeVisitor;
 use Rector\PhpParser\Node\FileNode;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\StaticTypeMapper\PhpDocParser\IdentifierPhpDocTypeMapper;
 use Rector\StaticTypeMapper\ValueObject\Type\AliasedObjectType;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
@@ -34,7 +34,7 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
     public function __construct(
         private readonly ClassNameImportSkipper $classNameImportSkipper,
         private readonly CurrentFileProvider $currentFileProvider,
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly IdentifierPhpDocTypeMapper $identifierPhpDocTypeMapper
     ) {
     }
@@ -181,7 +181,7 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
 
         $className = $fullyQualifiedObjectType->getClassName();
 
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return false;
         }
 

--- a/src/PhpAttribute/GenericAnnotationToAttributeConverter.php
+++ b/src/PhpAttribute/GenericAnnotationToAttributeConverter.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Stmt\Use_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -17,6 +16,7 @@ use Rector\Naming\Naming\UseImportsResolver;
 use Rector\Php80\NodeFactory\AttrGroupsFactory;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Rector\Php80\ValueObject\DoctrineTagAndAnnotationToAttribute;
+use Rector\Reflection\ClassReflectionProvider;
 
 /**
  * @api used in Rector packages
@@ -25,7 +25,7 @@ final readonly class GenericAnnotationToAttributeConverter
 {
     public function __construct(
         private AttrGroupsFactory $attrGroupsFactory,
-        private ReflectionProvider $reflectionProvider,
+        private ClassReflectionProvider $classReflectionProvider,
         private UseImportsResolver $useImportsResolver,
         private PhpDocInfoFactory $phpDocInfoFactory,
         private PhpDocTagRemover $phpDocTagRemover,
@@ -97,12 +97,12 @@ final readonly class GenericAnnotationToAttributeConverter
     private function isExistingAttributeClass(AnnotationToAttribute $annotationToAttribute): bool
     {
         // make sure the attribute class really exists to avoid error on early upgrade
-        if (! $this->reflectionProvider->hasClass($annotationToAttribute->getAttributeClass())) {
+        if (! $this->classReflectionProvider->hasClass($annotationToAttribute->getAttributeClass())) {
             return false;
         }
 
         // make sure the class is marked as attribute
-        $classReflection = $this->reflectionProvider->getClass($annotationToAttribute->getAttributeClass());
+        $classReflection = $this->classReflectionProvider->getClass($annotationToAttribute->getAttributeClass());
         return $classReflection->isAttributeClass();
     }
 }

--- a/src/PhpAttribute/NodeFactory/AnnotationToAttributeIntegerValueCaster.php
+++ b/src/PhpAttribute/NodeFactory/AnnotationToAttributeIntegerValueCaster.php
@@ -12,16 +12,16 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
+use Rector\Reflection\ClassReflectionProvider;
 use Webmozart\Assert\Assert;
 
 final readonly class AnnotationToAttributeIntegerValueCaster
 {
     public function __construct(
-        private ReflectionProvider $reflectionProvider,
+        private ClassReflectionProvider $classReflectionProvider,
     ) {
     }
 
@@ -32,11 +32,11 @@ final readonly class AnnotationToAttributeIntegerValueCaster
     {
         Assert::allIsInstanceOf($args, Arg::class);
 
-        if (! $this->reflectionProvider->hasClass($annotationToAttribute->getAttributeClass())) {
+        if (! $this->classReflectionProvider->hasClass($annotationToAttribute->getAttributeClass())) {
             return;
         }
 
-        $attributeClassReflection = $this->reflectionProvider->getClass($annotationToAttribute->getAttributeClass());
+        $attributeClassReflection = $this->classReflectionProvider->getClass($annotationToAttribute->getAttributeClass());
         if (! $attributeClassReflection->hasConstructor()) {
             return;
         }

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -19,7 +19,6 @@ use PhpParser\Node\Scalar\MagicConst\Dir;
 use PhpParser\Node\Scalar\MagicConst\File;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantScalarType;
@@ -32,6 +31,7 @@ use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\Reflection\ClassReflectionAnalyzer;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\Resolver\ClassNameFromObjectTypeResolver;
 use TypeError;
@@ -48,7 +48,7 @@ final class ValueResolver
         private readonly NodeNameResolver $nodeNameResolver,
         private readonly NodeTypeResolver $nodeTypeResolver,
         private readonly ConstFetchAnalyzer $constFetchAnalyzer,
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly ReflectionResolver $reflectionResolver,
         private readonly ClassReflectionAnalyzer $classReflectionAnalyzer,
         private readonly CurrentFileProvider $currentFileProvider,
@@ -297,12 +297,12 @@ final class ValueResolver
             return constant($classConstantReference);
         }
 
-        if (! $this->reflectionProvider->hasClass($class)) {
+        if (! $this->classReflectionProvider->hasClass($class)) {
             // fallback to constant reference itself, to avoid fatal error
             return $classConstantReference;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($class);
+        $classReflection = $this->classReflectionProvider->getClass($class);
 
         if (! $classReflection->hasConstant($constant)) {
             // fallback to constant reference itself, to avoid fatal error

--- a/src/Reflection/ClassReflectionProvider.php
+++ b/src/Reflection/ClassReflectionProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Reflection;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+
+/**
+ * Narrow facade over PHPStan ReflectionProvider class lookups,
+ * so rules do not have to depend on PHPStan reflection directly
+ */
+final readonly class ClassReflectionProvider
+{
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function hasClass(string $className): bool
+    {
+        return $this->reflectionProvider->hasClass($className);
+    }
+
+    public function getClass(string $className): ClassReflection
+    {
+        return $this->reflectionProvider->getClass($className);
+    }
+}

--- a/src/Reflection/MethodReflectionResolver.php
+++ b/src/Reflection/MethodReflectionResolver.php
@@ -6,12 +6,11 @@ namespace Rector\Reflection;
 
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\ReflectionProvider;
 
 final readonly class MethodReflectionResolver
 {
     public function __construct(
-        private ReflectionProvider $reflectionProvider
+        private ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -20,11 +19,11 @@ final readonly class MethodReflectionResolver
      */
     public function resolveMethodReflection(string $className, string $methodName, ?Scope $scope): ?MethodReflection
     {
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return null;
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
 
         // better, with support for "@method" annotation methods
         if ($scope instanceof Scope) {

--- a/src/Skipper/SkipVoter/ClassSkipVoter.php
+++ b/src/Skipper/SkipVoter/ClassSkipVoter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Skipper\SkipVoter;
 
-use PHPStan\Reflection\ReflectionProvider;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\Skipper\SkipCriteriaResolver\SkippedClassResolver;
 use Rector\Skipper\Skipper\SkipSkipper;
 use Rector\Skipper\ValueObject\SkipMatch;
@@ -14,7 +14,7 @@ final readonly class ClassSkipVoter
     public function __construct(
         private SkipSkipper $skipSkipper,
         private SkippedClassResolver $skippedClassResolver,
-        private ReflectionProvider $reflectionProvider
+        private ClassReflectionProvider $classReflectionProvider
     ) {
     }
 
@@ -24,7 +24,7 @@ final readonly class ClassSkipVoter
             return true;
         }
 
-        return $this->reflectionProvider->hasClass($element);
+        return $this->classReflectionProvider->hasClass($element);
     }
 
     public function matchSkip(string|object $element, string $filePath): ?SkipMatch

--- a/src/StaticTypeMapper/PhpDocParser/IdentifierPhpDocTypeMapper.php
+++ b/src/StaticTypeMapper/PhpDocParser/IdentifierPhpDocTypeMapper.php
@@ -10,7 +10,6 @@ use PHPStan\Analyser\NameScope;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
@@ -23,6 +22,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\Enum\ObjectReference;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Reflection\ClassReflectionProvider;
 use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
 use Rector\StaticTypeMapper\Mapper\ScalarStringToTypeMapper;
@@ -39,7 +39,7 @@ final readonly class IdentifierPhpDocTypeMapper implements PhpDocTypeMapperInter
     public function __construct(
         private ObjectTypeSpecifier $objectTypeSpecifier,
         private ScalarStringToTypeMapper $scalarStringToTypeMapper,
-        private ReflectionProvider $reflectionProvider,
+        private ClassReflectionProvider $classReflectionProvider,
         private ReflectionResolver $reflectionResolver
     ) {
     }
@@ -129,11 +129,11 @@ final readonly class IdentifierPhpDocTypeMapper implements PhpDocTypeMapperInter
             return new MixedType();
         }
 
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return new MixedType();
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
         $parentClassReflection = $classReflection->getParentClass();
 
         if (! $parentClassReflection instanceof ClassReflection) {
@@ -151,11 +151,11 @@ final readonly class IdentifierPhpDocTypeMapper implements PhpDocTypeMapperInter
             return new MixedType();
         }
 
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return new MixedType();
         }
 
-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
         return new StaticType($classReflection);
     }
 


### PR DESCRIPTION
First step of lowering direct `phpstan/phpstan` coupling, while keeping all rules running on PHPStan's reflection underneath.

## What

Class lookups now go through a narrow Rector-owned facade instead of `PHPStan\Reflection\ReflectionProvider`:

```php
namespace Rector\Reflection;

final readonly class ClassReflectionProvider
{
    public function __construct(
        private ReflectionProvider $reflectionProvider,
    ) {
    }

    public function hasClass(string $className): bool;

    public function getClass(string $className): ClassReflection;
}
```

Call sites change mechanically:

```diff
-use PHPStan\Reflection\ReflectionProvider;
+use Rector\Reflection\ClassReflectionProvider;

 final class FinalizeTestCaseClassRector extends AbstractRector
 {
     public function __construct(
-        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ClassReflectionProvider $classReflectionProvider,
         private readonly VisibilityManipulator $visibilityManipulator
     ) {
     }
 ...
-        if (! $this->reflectionProvider->hasClass($className)) {
+        if (! $this->classReflectionProvider->hasClass($className)) {
             return null;
         }

-        $classReflection = $this->reflectionProvider->getClass($className);
+        $classReflection = $this->classReflectionProvider->getClass($className);
```

Some files lose their last PHPStan import outright:

```diff
 namespace Rector\Skipper\SkipVoter;

-use PHPStan\Reflection\ReflectionProvider;
+use Rector\Reflection\ClassReflectionProvider;
```

## Why

`ReflectionProvider` was imported in 68 files, but only 6 of its methods were ever called — and 55 files used nothing but `hasClass()` / `getClass()`. That is a wide import surface over a very narrow API.

Routing it through one class means a future change to how Rector resolves class reflection has a single edit point instead of 68.

## Numbers

| | before | after |
|---|---|---|
| files importing `ReflectionProvider` | 68 | 16 |
| `rules/` files importing any `PHPStan\` | 342 | 336 |
| changed files with zero `phpstan/phpstan` imports | 0 | 10 |

The 16 remaining are engine internals (`PHPStanNodeScopeResolver`, `NodeTypeResolver`, `AstResolver`, `ReflectionResolver`, the DI factories) plus rules doing function/constant lookups — those need `hasFunction()` / `getFunction()` / `hasConstant()` / `getAnonymousClassReflection()`, deliberately left out of this facade. A function-lookup equivalent can follow separately.

No behaviour change: the facade delegates straight to the same `ReflectionProvider` instance, resolved by autowiring from the existing `PUBLIC_PHPSTAN_SERVICE_TYPES` registration.