### PR TITLE
[DeadCode] Remove unreachable class-like checks in Class_ only rules

### DIFF
--- a/rules/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveArgumentFromDefaultParentCallRector.php
@@ -104,7 +104,7 @@ CODE_SAMPLE
 
         $ancestors = array_filter(
             $classReflection->getAncestors(),
-            fn (ClassReflection $ancestorClassReflection): bool => $classReflection->isClass() && $ancestorClassReflection->getName() !== $classReflection->getName()
+            fn (ClassReflection $ancestorClassReflection): bool => $ancestorClassReflection->getName() !== $classReflection->getName()
         );
 
         $hasChanged = false;

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -143,15 +143,7 @@ CODE_SAMPLE
 
     private function shouldSkip(ClassMethod $classMethod, ClassReflection $classReflection): bool
     {
-        // unreliable to detect trait, interface, anonymous class: doesn't make sense
-        if ($classReflection->isTrait()) {
-            return true;
-        }
-
-        if ($classReflection->isInterface()) {
-            return true;
-        }
-
+        // unreliable to detect anonymous class: doesn't make sense
         if ($classReflection->isAnonymous()) {
             return true;
         }

--- a/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByParentCallTypeRector.php
+++ b/rules/TypeDeclaration/Rector/ClassMethod/ParamTypeByParentCallTypeRector.php
@@ -181,11 +181,7 @@ CODE_SAMPLE
         }
 
         $classReflection = $this->reflectionResolver->resolveClassReflection($classMethod);
-        if (! $classReflection instanceof ClassReflection) {
-            return true;
-        }
-
-        return ! $classReflection->isClass();
+        return ! $classReflection instanceof ClassReflection;
     }
 
     private function isParamUsedInSpreadArg(ClassMethod $classMethod, Param $param): bool


### PR DESCRIPTION
Draft. Small first step of the "remove PHPStan, don't wrap it" thread — the subset where reflection is answering a question that cannot have another answer.

## Why these are constant

`Trait_`, `Interface_` and `Enum_` are sibling php-parser node classes, not subclasses of `Class_`:

```php
is_subclass_of(PhpParser\Node\Stmt\Enum_::class,      PhpParser\Node\Stmt\Class_::class); // false
is_subclass_of(PhpParser\Node\Stmt\Trait_::class,     PhpParser\Node\Stmt\Class_::class); // false
is_subclass_of(PhpParser\Node\Stmt\Interface_::class, PhpParser\Node\Stmt\Class_::class); // false
```

All three rules below declare:

```php
public function getNodeTypes(): array
{
    return [Class_::class];
}
```

so the reflection they resolve from their own node is always a class. `isTrait()` and `isInterface()` are always `false`, `isClass()` always `true`.

## Changes

`RemoveUnusedPrivateMethodRector` — never reached, node is always `Class_`:

```diff
-        // unreliable to detect trait, interface, anonymous class: doesn't make sense
-        if ($classReflection->isTrait()) {
-            return true;
-        }
-
-        if ($classReflection->isInterface()) {
-            return true;
-        }
-
-        if ($classReflection->isAnonymous()) {
+        // unreliable to detect anonymous class: doesn't make sense
+        if ($classReflection->isAnonymous()) {
             return true;
         }
```

`ParamTypeByParentCallTypeRector` — `! $classReflection->isClass()` is always `false`, so the guard reduces to the reflection-resolved check that precedes it:

```diff
         $classReflection = $this->reflectionResolver->resolveClassReflection($classMethod);
-        if (! $classReflection instanceof ClassReflection) {
-            return true;
-        }
-
-        return ! $classReflection->isClass();
+        return ! $classReflection instanceof ClassReflection;
```

`RemoveArgumentFromDefaultParentCallRector` — `$classReflection` is the outer node's own reflection, so `isClass()` is loop-invariant and always `true`:

```diff
         $ancestors = array_filter(
             $classReflection->getAncestors(),
-            fn (ClassReflection $ancestorClassReflection): bool => $classReflection->isClass() && $ancestorClassReflection->getName() !== $classReflection->getName()
+            fn (ClassReflection $ancestorClassReflection): bool => $ancestorClassReflection->getName() !== $classReflection->getName()
         );
```

## Scope

No behaviour change — these are provably constant conditions, not heuristics. 15 lines removed, 3 added.

Both `isClass()` sites were checked to be the node's *own* reflection (`resolveClassReflection($node)` / `($classMethod)`), not an ancestor's. Ancestor-reflection checks like `$parentClassReflection->isTrait()` in `AddOverrideAttributeToOverriddenMethodsRector` are genuinely needed and left alone.

Touches the same `shouldSkip()` as #TBD (native node API); whichever lands second needs a trivial rebase.