### PR TITLE
[CodingStyle] Use native php-parser node API over class reflection

### DIFF
--- a/rules/CodingStyle/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
+++ b/rules/CodingStyle/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
@@ -78,12 +78,12 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
-        if (! $classReflection instanceof ClassReflection) {
+        if ($node->isAnonymous()) {
             return null;
         }
 
-        if ($classReflection->isAnonymous()) {
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        if (! $classReflection instanceof ClassReflection) {
             return null;
         }
 

--- a/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -85,6 +85,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // unreliable to detect on anonymous class: doesn't make sense
+        if ($node->isAnonymous()) {
+            return null;
+        }
+
         $hasChanged = false;
 
         $classReflection = $this->reflectionResolver->resolveClassReflection($node);
@@ -143,16 +148,12 @@ CODE_SAMPLE
 
     private function shouldSkip(ClassMethod $classMethod, ClassReflection $classReflection): bool
     {
-        // unreliable to detect trait, interface, anonymous class: doesn't make sense
+        // unreliable to detect trait, interface: doesn't make sense
         if ($classReflection->isTrait()) {
             return true;
         }
 
         if ($classReflection->isInterface()) {
-            return true;
-        }
-
-        if ($classReflection->isAnonymous()) {
             return true;
         }
 

--- a/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
+++ b/rules/Php70/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
@@ -158,7 +158,7 @@ CODE_SAMPLE
 
             $this->hasChanged = true;
 
-            $objectReference = $this->resolveClassSelf($classReflection, $subNode);
+            $objectReference = $this->resolveClassSelf($class, $subNode);
             return $this->nodeFactory->createStaticCall($objectReference, $methodName, $subNode->args);
         });
     }
@@ -166,9 +166,9 @@ CODE_SAMPLE
     /**
      * @return ObjectReference::STATIC|ObjectReference::SELF
      */
-    private function resolveClassSelf(ClassReflection $classReflection, MethodCall $methodCall): string
+    private function resolveClassSelf(Class_ $class, MethodCall $methodCall): string
     {
-        if ($classReflection->isFinalByKeyword()) {
+        if ($class->isFinal()) {
             return ObjectReference::SELF;
         }
 


### PR DESCRIPTION
Draft. Companion to #8217. Same thread: replace PHPStan with native php-parser logic where the answer is already in the node being refactored — no reflection lookup, no file re-parse.

## Why only these

The constraint that makes this safe *and* faster: the node is already in hand. That rules out `AstResolver`-style replacements, which trade a reflection lookup for parsing a whole source file — the thing #8100, #8099, #8196 and friends have been removing.

`PhpParser\Node\Stmt\Class_` natively exposes:

```
isAbstract, isAnonymous, isFinal, isReadonly,
getMethods, getMethod, getProperties, getProperty, getConstants, getTraitUses
```

All three rules here declare `getNodeTypes(): [Class_::class]`, so `$node` is the class whose reflection they were querying.

## Changes

`ThisCallOnStaticMethodToStaticCallRector` — `$class` was already captured in the enclosing closure, so no plumbing needed. `isFinalByKeyword()` maps exactly to `isFinal()`: both mean the `final` keyword, neither counts `@final`:

```diff
-            $objectReference = $this->resolveClassSelf($classReflection, $subNode);
+            $objectReference = $this->resolveClassSelf($class, $subNode);
...
-    private function resolveClassSelf(ClassReflection $classReflection, MethodCall $methodCall): string
+    private function resolveClassSelf(Class_ $class, MethodCall $methodCall): string
     {
-        if ($classReflection->isFinalByKeyword()) {
+        if ($class->isFinal()) {
             return ObjectReference::SELF;
         }
```

`RemoveUnusedPrivateMethodRector` — anonymous-ness is a property of the class, but was being re-checked per method inside the loop. Hoisted to an early return:

```diff
         if ($node->getMethods() === []) {
             return null;
         }
 
+        // unreliable to detect on anonymous class: doesn't make sense
+        if ($node->isAnonymous()) {
+            return null;
+        }
+
         $hasChanged = false;
...
-        if ($classReflection->isAnonymous()) {
-            return true;
-        }
-
         // skip magic methods
```

`MakeInheritedMethodVisibilitySameAsParentRector` — moved above the reflection resolution, so anonymous classes now bail before the lookup happens at all:

```diff
+        if ($node->isAnonymous()) {
+            return null;
+        }
+
         $classReflection = $this->reflectionResolver->resolveClassReflection($node);
         if (! $classReflection instanceof ClassReflection) {
             return null;
         }
 
-        if ($classReflection->isAnonymous()) {
-            return null;
-        }
-
         $parentClassReflections = $classReflection->getParents();
```

## Scope

No behaviour change. Two of the three also skip work earlier than before.

This is deliberately the *whole* verified set for `Class_`-node rules, not a sample — a scan of every rule whose `getNodeTypes()` is `[Class_::class]` found only these three asking AST-answerable questions of their own reflection. Sites on ancestor reflections (`$parentClassReflection->isAnonymous()`, `->isTrait()`) need real reflection and are untouched.

Touches the same `shouldSkip()` as #8217; whichever lands second needs a trivial rebase.