### PR TITLE
[DeadCode] Keep empty __construct() in anonymous class that extends parent on RemoveEmptyClassMethodRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/removed_anonymous_class_construct_without_parent.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/removed_anonymous_class_construct_without_parent.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Fixture;
+
+function createPlain()
+{
+    return new class {
+        public function __construct()
+        {
+        }
+    };
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Fixture;
+
+function createPlain()
+{
+    return new class
+    {
+    };
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_anonymous_class_construct_with_parent.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_anonymous_class_construct_with_parent.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Source\ParentWithoutConstructor;
+
+function createStub()
+{
+    return new class extends ParentWithoutConstructor {
+        public function __construct()
+        {
+        }
+    };
+}
+
+?>

--- a/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
@@ -6,6 +6,7 @@ namespace Rector\DeadCode\Rector\ClassMethod;
 
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\DeprecatedTagValueNode;
@@ -139,6 +140,15 @@ CODE_SAMPLE
         }
 
         if ($this->classMethodManipulator->isNamedConstructor($classMethod)) {
+            return true;
+        }
+
+        // anonymous class extending a parent uses empty constructor on purpose,
+        // to avoid parent constructor being invoked
+        if ($class->isAnonymous() && $class->extends instanceof Name && $this->isName(
+            $classMethod,
+            MethodName::CONSTRUCT
+        )) {
             return true;
         }
 

--- a/src/FileSystem/FilePathHelper.php
+++ b/src/FileSystem/FilePathHelper.php
@@ -56,7 +56,7 @@ final readonly class FilePathHelper
             $path = $originalPath;
         }
 
-        $normalizedPath = PathNormalizer::normalize((string) $path);
+        $normalizedPath = PathNormalizer::normalize($path);
         $path = Strings::replace($normalizedPath, self::TWO_AND_MORE_SLASHES_REGEX, '/');
 
         $pathRoot = str_starts_with($path, '/') ? $directorySeparator : '';


### PR DESCRIPTION
An anonymous class that extends a parent often uses an empty `__construct()` on purpose - to neutralize the parent constructor. Removing it changes behavior of the stub/decorator.

Now kept:

```php
 function createStub()
 {
     return new class extends ParentWithoutConstructor {
        public function __construct()
        {
        }
     };
 }
```

Anonymous class without `extends` is still cleaned up:

```diff
 function createPlain()
 {
-    return new class {
-        public function __construct()
-        {
-        }
-    };
+    return new class {
+    };
 }
```