### PR TITLE
Require 99 % type coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ vendor/bin/phpunit
 
 PHPStan extras enabled in `phpstan.neon`:
 - `type-coverage` (ships the former `type-perfect` rules): `no_mixed`, `null_over_false`, `narrow_param`, `narrow_return` — return/param types must be narrow; prefer `null` over `false` for "no result".
+- `type_coverage`: at least 99 % of return types, param types, property types, constant types and `declare(strict_types=1)` must be in place.
 - `unused-public`: public methods/properties/constants must be used somewhere. If you add a new public API, expect to use it or mark it accordingly.
 - `symplify/phpstan-rules` + `rector-rules`: forbids `var_dump`, `dd`, `property_exists`, `class_exists`, `@` error suppression, dynamic names, etc., outside the narrowly listed exceptions in `phpstan.neon`. Do not add new exceptions casually — fix the code.
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -60,6 +60,14 @@ parameters:
         narrow_param: true
         narrow_return: true
 
+    # see https://github.com/TomasVotruba/type-coverage
+    type_coverage:
+        declare: 99
+        return_type: 99
+        param_type: 99
+        property_type: 99
+        constant_type: 99
+
     # see https://github.com/TomasVotruba/unused-public
     unused_public:
         methods: true


### PR DESCRIPTION
Follow-up to #8221, which brought in `tomasvotruba/type-coverage`.

Turns on the `type_coverage` thresholds that ship with it:

```diff
+    # see https://github.com/TomasVotruba/type-coverage
+    type_coverage:
+        declare: 99
+        return_type: 99
+        param_type: 99
+        property_type: 99
+        constant_type: 99
```

PHPStan then fails if any of these drop below 99 %:

```
Class constant type coverage is 98.0 % out of 738 possible
    Add more class constant types to reach 99 % coverage
```

Current numbers, measured with `type_coverage: measure: true`:

| metric | coverage | of |
| --- | --- | --- |
| Class constant type | 99.7 % | 738 |
| Param type | 99.9 % | 7772 |
| Property type | 100.0 % | 360 |
| Return type | 99.9 % | 7449 |
| Strict declares | 99.9 % | 2766 |

So this is a floor, not a task list - nothing to fix right now, it only stops the numbers from sliding.
