### PR TITLE
Deduplicate PHP version branching in RectorConfigBuilder

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -588,12 +588,30 @@ final class RectorConfigBuilder
 
         $this->isWithPhpSetsUsed = true;
 
-        $pickedArguments = array_filter(func_get_args());
-        if ($pickedArguments !== []) {
+        $pickedPhpVersions = array_keys(array_filter([
+            PhpVersion::PHP_53 => $php53,
+            PhpVersion::PHP_54 => $php54,
+            PhpVersion::PHP_55 => $php55,
+            PhpVersion::PHP_56 => $php56,
+            PhpVersion::PHP_70 => $php70,
+            PhpVersion::PHP_71 => $php71,
+            PhpVersion::PHP_72 => $php72,
+            PhpVersion::PHP_73 => $php73,
+            PhpVersion::PHP_74 => $php74,
+            PhpVersion::PHP_80 => $php80,
+            PhpVersion::PHP_81 => $php81,
+            PhpVersion::PHP_82 => $php82,
+            PhpVersion::PHP_83 => $php83,
+            PhpVersion::PHP_84 => $php84,
+            PhpVersion::PHP_85 => $php85,
+            PhpVersion::PHP_86 => $php86,
+        ]));
+
+        if ($pickedPhpVersions !== []) {
             Notifier::errorWithPhpSetsNotSuitableForPHP74AndLower();
         }
 
-        if (count($pickedArguments) > 1) {
+        if (count($pickedPhpVersions) > 1) {
             throw new InvalidConfigurationException(
                 sprintf(
                     'Pick only one version target in "withPhpSets()". All rules up to this version will be used.%sTo use your composer.json PHP version, keep arguments empty.',
@@ -602,82 +620,12 @@ final class RectorConfigBuilder
             );
         }
 
-        if ($pickedArguments === []) {
-            $projectPhpVersion = ComposerJsonPhpVersionResolver::resolveFromCwdOrFail();
-            $phpLevelSets = PhpLevelSetResolver::resolveFromPhpVersion($projectPhpVersion);
-
-            $this->sets = array_merge($this->sets, $phpLevelSets);
-
-            return $this;
+        // no version picked, resolve it from the project composer.json
+        if ($pickedPhpVersions === []) {
+            return $this->addPhpLevelSets(ComposerJsonPhpVersionResolver::resolveFromCwdOrFail());
         }
 
-        if ($php53) {
-            $this->withPhp53Sets();
-            return $this;
-        }
-
-        if ($php54) {
-            $this->withPhp54Sets();
-            return $this;
-        }
-
-        if ($php55) {
-            $this->withPhp55Sets();
-            return $this;
-        }
-
-        if ($php56) {
-            $this->withPhp56Sets();
-            return $this;
-        }
-
-        if ($php70) {
-            $this->withPhp70Sets();
-            return $this;
-        }
-
-        if ($php71) {
-            $this->withPhp71Sets();
-            return $this;
-        }
-
-        if ($php72) {
-            $this->withPhp72Sets();
-            return $this;
-        }
-
-        if ($php73) {
-            $this->withPhp73Sets();
-            return $this;
-        }
-
-        if ($php74) {
-            $this->withPhp74Sets();
-            return $this;
-        }
-
-        if ($php80) {
-            $targetPhpVersion = PhpVersion::PHP_80;
-        } elseif ($php81) {
-            $targetPhpVersion = PhpVersion::PHP_81;
-        } elseif ($php82) {
-            $targetPhpVersion = PhpVersion::PHP_82;
-        } elseif ($php83) {
-            $targetPhpVersion = PhpVersion::PHP_83;
-        } elseif ($php84) {
-            $targetPhpVersion = PhpVersion::PHP_84;
-        } elseif ($php85) {
-            $targetPhpVersion = PhpVersion::PHP_85;
-        } elseif ($php86) {
-            $targetPhpVersion = PhpVersion::PHP_86;
-        } else {
-            throw new InvalidConfigurationException('Invalid PHP version set');
-        }
-
-        $phpLevelSets = PhpLevelSetResolver::resolveFromPhpVersion($targetPhpVersion);
-        $this->sets = array_merge($this->sets, $phpLevelSets);
-
-        return $this;
+        return $this->addPhpLevelSets($pickedPhpVersions[0]);
     }
 
     /**
@@ -686,83 +634,47 @@ final class RectorConfigBuilder
      */
     public function withPhp53Sets(): self
     {
-        $this->isWithPhpSetsUsed = true;
-
-        $this->sets = array_merge($this->sets, PhpLevelSetResolver::resolveFromPhpVersion(PhpVersion::PHP_53));
-
-        return $this;
+        return $this->addPhpLevelSets(PhpVersion::PHP_53);
     }
 
     public function withPhp54Sets(): self
     {
-        $this->isWithPhpSetsUsed = true;
-
-        $this->sets = array_merge($this->sets, PhpLevelSetResolver::resolveFromPhpVersion(PhpVersion::PHP_54));
-
-        return $this;
+        return $this->addPhpLevelSets(PhpVersion::PHP_54);
     }
 
     public function withPhp55Sets(): self
     {
-        $this->isWithPhpSetsUsed = true;
-
-        $this->sets = array_merge($this->sets, PhpLevelSetResolver::resolveFromPhpVersion(PhpVersion::PHP_55));
-
-        return $this;
+        return $this->addPhpLevelSets(PhpVersion::PHP_55);
     }
 
     public function withPhp56Sets(): self
     {
-        $this->isWithPhpSetsUsed = true;
-
-        $this->sets = array_merge($this->sets, PhpLevelSetResolver::resolveFromPhpVersion(PhpVersion::PHP_56));
-
-        return $this;
+        return $this->addPhpLevelSets(PhpVersion::PHP_56);
     }
 
     public function withPhp70Sets(): self
     {
-        $this->isWithPhpSetsUsed = true;
-
-        $this->sets = array_merge($this->sets, PhpLevelSetResolver::resolveFromPhpVersion(PhpVersion::PHP_70));
-
-        return $this;
+        return $this->addPhpLevelSets(PhpVersion::PHP_70);
     }
 
     public function withPhp71Sets(): self
     {
-        $this->isWithPhpSetsUsed = true;
-
-        $this->sets = array_merge($this->sets, PhpLevelSetResolver::resolveFromPhpVersion(PhpVersion::PHP_71));
-
-        return $this;
+        return $this->addPhpLevelSets(PhpVersion::PHP_71);
     }
 
     public function withPhp72Sets(): self
     {
-        $this->isWithPhpSetsUsed = true;
-
-        $this->sets = array_merge($this->sets, PhpLevelSetResolver::resolveFromPhpVersion(PhpVersion::PHP_72));
-
-        return $this;
+        return $this->addPhpLevelSets(PhpVersion::PHP_72);
     }
 
     public function withPhp73Sets(): self
     {
-        $this->isWithPhpSetsUsed = true;
-
-        $this->sets = array_merge($this->sets, PhpLevelSetResolver::resolveFromPhpVersion(PhpVersion::PHP_73));
-
-        return $this;
+        return $this->addPhpLevelSets(PhpVersion::PHP_73);
     }
 
     public function withPhp74Sets(): self
     {
-        $this->isWithPhpSetsUsed = true;
-
-        $this->sets = array_merge($this->sets, PhpLevelSetResolver::resolveFromPhpVersion(PhpVersion::PHP_74));
-
-        return $this;
+        return $this->addPhpLevelSets(PhpVersion::PHP_74);
     }
 
     // there is no withPhp80Sets() and above,
@@ -1214,32 +1126,25 @@ final class RectorConfigBuilder
         bool $php72 = false,
         bool $php71 = false,
     ): self {
-        $pickedArguments = array_filter(func_get_args());
-        if (count($pickedArguments) !== 1) {
+        $pickedDowngradeSets = array_keys(array_filter([
+            DowngradeLevelSetList::DOWN_TO_PHP_84 => $php84,
+            DowngradeLevelSetList::DOWN_TO_PHP_83 => $php83,
+            DowngradeLevelSetList::DOWN_TO_PHP_82 => $php82,
+            DowngradeLevelSetList::DOWN_TO_PHP_81 => $php81,
+            DowngradeLevelSetList::DOWN_TO_PHP_80 => $php80,
+            DowngradeLevelSetList::DOWN_TO_PHP_74 => $php74,
+            DowngradeLevelSetList::DOWN_TO_PHP_73 => $php73,
+            DowngradeLevelSetList::DOWN_TO_PHP_72 => $php72,
+            DowngradeLevelSetList::DOWN_TO_PHP_71 => $php71,
+        ]));
+
+        if (count($pickedDowngradeSets) !== 1) {
             throw new InvalidConfigurationException(
                 'Pick only one PHP version target in "withDowngradeSets()". All rules down to this version will be used.',
             );
         }
 
-        if ($php84) {
-            $this->sets[] = DowngradeLevelSetList::DOWN_TO_PHP_84;
-        } elseif ($php83) {
-            $this->sets[] = DowngradeLevelSetList::DOWN_TO_PHP_83;
-        } elseif ($php82) {
-            $this->sets[] = DowngradeLevelSetList::DOWN_TO_PHP_82;
-        } elseif ($php81) {
-            $this->sets[] = DowngradeLevelSetList::DOWN_TO_PHP_81;
-        } elseif ($php80) {
-            $this->sets[] = DowngradeLevelSetList::DOWN_TO_PHP_80;
-        } elseif ($php74) {
-            $this->sets[] = DowngradeLevelSetList::DOWN_TO_PHP_74;
-        } elseif ($php73) {
-            $this->sets[] = DowngradeLevelSetList::DOWN_TO_PHP_73;
-        } elseif ($php72) {
-            $this->sets[] = DowngradeLevelSetList::DOWN_TO_PHP_72;
-        } elseif ($php71) {
-            $this->sets[] = DowngradeLevelSetList::DOWN_TO_PHP_71;
-        }
+        $this->sets[] = $pickedDowngradeSets[0];
 
         return $this;
     }
@@ -1289,6 +1194,18 @@ final class RectorConfigBuilder
 
             $this->setProviders[$setProvider] = true;
         }
+
+        return $this;
+    }
+
+    /**
+     * @param PhpVersion::* $phpVersion
+     */
+    private function addPhpLevelSets(int $phpVersion): self
+    {
+        $this->isWithPhpSetsUsed = true;
+
+        $this->sets = array_merge($this->sets, PhpLevelSetResolver::resolveFromPhpVersion($phpVersion));
 
         return $this;
     }


### PR DESCRIPTION
Follow-up to #8225, same class. Two methods mapped a pile of bool arguments to a PHP version through long branch chains, and nine more methods repeated the same three statements.

## `withPhpSets()`

Sixteen bool arguments were resolved by nine early-return blocks followed by a seven-branch `elseif` chain:

```php
if ($php53) {
    $this->withPhp53Sets();
    return $this;
}

if ($php54) {
    $this->withPhp54Sets();
    return $this;
}

// ... seven more of these ...

if ($php80) {
    $targetPhpVersion = PhpVersion::PHP_80;
} elseif ($php81) {
    $targetPhpVersion = PhpVersion::PHP_81;
} elseif ($php82) {
// ... five more ...
} else {
    throw new InvalidConfigurationException('Invalid PHP version set');
}
```

Now one map:

```php
$pickedPhpVersions = array_keys(array_filter([
    PhpVersion::PHP_53 => $php53,
    PhpVersion::PHP_54 => $php54,
    // ...
    PhpVersion::PHP_86 => $php86,
]));
```

This also replaces the `func_get_args()` call that the arity checks were built on, so the "pick only one version" and "resolve from composer.json" branches read off the same array. The unreachable `'Invalid PHP version set'` branch goes away — a non-empty picked list always has exactly one entry by that point.

The argument order in the signature is unchanged, including `$php84`/`$php85`/`$php86` staying last for positional-call BC.

## `withDowngradeSets()`

Same shape, nine branches:

```diff
-if ($php84) {
-    $this->sets[] = DowngradeLevelSetList::DOWN_TO_PHP_84;
-} elseif ($php83) {
-    $this->sets[] = DowngradeLevelSetList::DOWN_TO_PHP_83;
-} elseif ($php82) {
-// ... six more ...
-}
+$pickedDowngradeSets = array_keys(array_filter([
+    DowngradeLevelSetList::DOWN_TO_PHP_84 => $php84,
+    DowngradeLevelSetList::DOWN_TO_PHP_83 => $php83,
+    // ...
+]));
```

## The nine `withPhpNNSets()` methods

Each was the same three statements with one constant swapped:

```php
public function withPhp70Sets(): self
{
    $this->isWithPhpSetsUsed = true;

    $this->sets = array_merge($this->sets, PhpLevelSetResolver::resolveFromPhpVersion(PhpVersion::PHP_70));

    return $this;
}
```

becomes

```php
public function withPhp70Sets(): self
{
    return $this->addPhpLevelSets(PhpVersion::PHP_70);
}
```

`withPhpSets()` uses the same private helper for both its composer.json branch and its explicit-version branch.

## Verification

Public API and argument order are unchanged. Since these methods have no direct test coverage, I diffed old against new behavior over 14 cases through reflection on the resulting `$sets`: no arguments (composer.json resolution), `php53`/`php74` by flag vs. by dedicated method, `php80`, `php86`, an explicitly-passed `false`, both downgrade targets, and all four throw paths (two versions at once, `withPhpSets()` called twice, no downgrade target, two downgrade targets). Output is byte-identical on every one.

Net `-83` lines.