### PR TITLE
[Php80] Skip promoting a property the parent declares without a native type

### DIFF
--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_untyped_parent_property.php.inc
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Fixture/skip_untyped_parent_property.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+use Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Source\SomeCacheProvider;
+use Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Source\UntypedPropertyParent;
+
+final class SkipUntypedParentProperty extends UntypedPropertyParent
+{
+    /**
+     * @var SomeCacheProvider|null
+     */
+    protected $model;
+
+    public function __construct(SomeCacheProvider $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Source/UntypedPropertyParent.php
+++ b/rules-tests/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/Source/UntypedPropertyParent.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Source;
+
+abstract class UntypedPropertyParent
+{
+    /**
+     * @var SomeCacheProvider|null
+     */
+    protected $model;
+}

--- a/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/Php80/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -227,6 +227,10 @@ CODE_SAMPLE
                 continue;
             }
 
+            if ($this->shouldSkipUntypedParentProperty($classReflection, $propertyName)) {
+                continue;
+            }
+
             $hasChanged = true;
 
             // remove property from class
@@ -345,6 +349,25 @@ CODE_SAMPLE
         $paramType = TypeCombinator::union($paramType, $defaultType);
 
         $param->type = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($paramType, TypeKind::PARAM);
+    }
+
+    /**
+     * A parent property declared without a native type cannot be typed by a child. Promotion moves the param
+     * type onto the property, so promoting such a property makes the class fatal:
+     * "Type of Child::$property must not be defined (as in class Parent)".
+     */
+    private function shouldSkipUntypedParentProperty(ClassReflection $classReflection, string $propertyName): bool
+    {
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if (! $parentClassReflection->hasNativeProperty($propertyName)) {
+                continue;
+            }
+
+            return ! $parentClassReflection->getNativeProperty($propertyName)
+                ->hasNativeType();
+        }
+
+        return false;
     }
 
     private function shouldSkipParam(Param $param): bool


### PR DESCRIPTION
Promoting a property that a parent declares **without** a native type produces code PHP refuses to load.

A child may redeclare an inherited untyped property, but it may not add a type to it. Promotion moves the parameter type onto the property, so it does exactly that:

```php
abstract class ParentClass
{
    /**
     * @var SomeModel|null
     */
    protected $model;
}

final class ChildClass extends ParentClass
{
    /**
     * @var SomeModel|null
     */
    protected $model;

    public function __construct(SomeModel $model)
    {
        $this->model = $model;
    }
}
```

becomes

```php
final class ChildClass extends ParentClass
{
    public function __construct(protected SomeModel $model)
    {
    }
}
```

which fatals on load:

```
PHP Fatal error: Type of ChildClass::$model must not be defined (as in class ParentClass)
```

This is not caught by the existing skips: the property is typed neither in the child nor via a conflicting docblock, so nothing signals the clash — the constraint lives entirely in the ancestor.

## The fix

Skip promotion when the nearest ancestor declaring the property has no native type on it:

```php
private function shouldSkipUntypedParentProperty(ClassReflection $classReflection, string $propertyName): bool
{
    foreach ($classReflection->getParents() as $parentClassReflection) {
        if (! $parentClassReflection->hasNativeProperty($propertyName)) {
            continue;
        }

        return ! $parentClassReflection->getNativeProperty($propertyName)
            ->hasNativeType();
    }

    return false;
}
```

It returns on the first ancestor that declares the property, since that is the declaration the child must stay compatible with. A parent property that *is* natively typed keeps promoting as before — the child simply has to repeat the same type, which promotion already does.

## Test

`skip_untyped_parent_property.php.inc` with an `UntypedPropertyParent` source class. Verified it reproduces the bug: with the rule reverted the fixture fails —

```
Failed on fixture file "skip_untyped_parent_property.php.inc"
Tests: 56, Assertions: 58, Failures: 1
```

— and passes with the fix: `OK (56 tests, 57 assertions)`.

Found while running Rector over a codebase where API controllers inherit an untyped `protected $model` from a shared base controller; every promoted child became unloadable.
