### PR TITLE
Remove NullToStrictStringFuncCallArgRector from the PHP 8.1 set

### DIFF
--- a/config/set/php81.php
+++ b/config/set/php81.php
@@ -11,7 +11,6 @@ use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php81\Rector\Class_\MyCLabsClassToEnumRector;
 use Rector\Php81\Rector\Class_\SpatieEnumClassToEnumRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictIntPregSlitFuncCallLimitArgRector;
-use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector;
 use Rector\Php81\Rector\MethodCall\RemoveReflectionSetAccessibleCallsRector;
 use Rector\Php81\Rector\MethodCall\SpatieEnumMethodCallToEnumConstRector;
@@ -28,7 +27,6 @@ return static function (RectorConfig $rectorConfig): void {
         ReadOnlyPropertyRector::class,
         SpatieEnumClassToEnumRector::class,
         SpatieEnumMethodCallToEnumConstRector::class,
-        NullToStrictStringFuncCallArgRector::class,
         NullToStrictIntPregSlitFuncCallLimitArgRector::class,
 
         ArrayToFirstClassCallableRector::class,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -117,6 +117,12 @@ parameters:
                 - src/Console/Notifier.php
                 - src/Util/FileHasher.php
 
+        # deliberately kept out of the php81 set, as it fires too often to be applied by default;
+        # it stays available to register directly with withRules()
+        -
+            identifier: rector.upgradeDowngradeRegisteredInSet
+            path: rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+
         # is nested expr
         -
             message: '#Access to an undefined property PhpParser\\Node\\Expr\:\:\$expr#'


### PR DESCRIPTION
`NullToStrictStringFuncCallArgRector` fires on a lot of call sites, and in practice it is commonly skipped rather than applied — so in the set it mostly generates `withSkip()` entries.

```diff
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
         ...
         SpatieEnumMethodCallToEnumConstRector::class,
-        NullToStrictStringFuncCallArgRector::class,
         NullToStrictIntPregSlitFuncCallLimitArgRector::class,
```

The rule and its 39 fixtures stay in place, so anyone who wants it can still opt in:

```php
->withRules([NullToStrictStringFuncCallArgRector::class])
```

## Two things worth deciding on before merge

**1. `withPhpLevel()` positions shift.** `withPhpLevel(N)` takes the first `N + 1` rules in set-file order, so removing an entry from `php81.php` shifts every later rule down by one. A config pinned at a given level will silently pick up whichever rule previously sat just past its cutoff. That is inherent to level-as-array-prefix and not specific to this rule, but it does mean this is not a no-op for level users.

**2. It still covers a real 8.1 deprecation.** Passing `null` to a non-nullable internal function parameter is deprecated in 8.1, so dropping it from the set means an upgrade run no longer flags those call sites at all. If the goal is "stop applying it by default" rather than "stop offering it", an alternative is to leave it in the set but let it be skipped more easily — happy to switch to that if you prefer.

I went with the straight removal since that is what was asked for.

## Checks

ECS and PHPStan clean. The rule's own test suite still passes (39 tests) — nothing about the rule changed, only its set membership. Full suite matches the pre-existing baseline on `main`.