### PR TITLE
[scripts] Skip configurable rules in the unused-rules audit

### DIFF
--- a/scripts/list-unused-rules.php
+++ b/scripts/list-unused-rules.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Bridge\SetRectorsResolver;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Scripts\Finder\RectorClassFinder;
 use Rector\Scripts\Finder\RectorSetFilesFinder;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -45,11 +46,22 @@ $symfonyStyle->writeln(sprintf('<fg=yellow>Found %d used Rector rules in sets</>
 
 $unusedRectorRules = array_diff($rectorClasses, $usedRectorRules);
 
+// configurable rules require own configuration, without it they do nothing - they can never be part of a set
+$configurableRectorRules = array_filter(
+    $unusedRectorRules,
+    static fn (string $rectorClass): bool => is_a($rectorClass, ConfigurableRectorInterface::class, true)
+);
+
+$unusedRectorRules = array_diff($unusedRectorRules, $configurableRectorRules);
+
 $symfonyStyle->newLine();
 $symfonyStyle->listing($unusedRectorRules);
 
 $symfonyStyle->writeln(
     sprintf('<fg=yellow;options=bold>Found %d Rector rules not in any set</>', count($unusedRectorRules))
+);
+$symfonyStyle->writeln(
+    sprintf('<fg=green>Skipped %d configurable Rector rules</>', count($configurableRectorRules))
 );
 $symfonyStyle->newLine();
 


### PR DESCRIPTION
`scripts/list-unused-rules.php` reported 60 rules as "not in any set". 23 of them are `ConfigurableRectorInterface` rules — they do nothing without their own configuration, so they can never be listed in a set on their own. They are false positives that bury the rules genuinely missing from a set.

Now they are filtered out and counted separately.

Before:

```
Found 57 Rector rules not in any set
```

After:

```
Found 34 Rector rules not in any set
Skipped 23 configurable Rector rules
```

The remaining 34 are the actionable ones — e.g. `Rector\Symfony\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector`, `Rector\PHPUnit\PHPUnit100\Rector\Class_\RemoveNamedArgsInDataProviderRector` and `Rector\PHPUnit\PHPUnit120\Rector\MethodCall\ExplicitMockExpectsCallRector`, whose namespaces name the very set they are missing from.