### PR TITLE
Fix InstalledPackageResolver cwd fallback lost by promoted property

### DIFF
--- a/src/Composer/InstalledPackageResolver.php
+++ b/src/Composer/InstalledPackageResolver.php
@@ -21,15 +21,14 @@ final class InstalledPackageResolver
      */
     private ?array $resolvedInstalledPackages = null;
 
-    public function __construct(
-        private readonly ?string $projectDirectory = null
-    ) {
-        // fallback to root project directory
-        if ($projectDirectory === null) {
-            $projectDirectory = getcwd();
-        }
+    private readonly string $projectDirectory;
 
-        Assert::directory($projectDirectory);
+    public function __construct(?string $projectDirectory = null)
+    {
+        // fallback to root project directory
+        $this->projectDirectory = $projectDirectory ?? (string) getcwd();
+
+        Assert::directory($this->projectDirectory);
     }
 
     /**

--- a/tests/Composer/InstalledPackageResolverTest.php
+++ b/tests/Composer/InstalledPackageResolverTest.php
@@ -18,4 +18,13 @@ final class InstalledPackageResolverTest extends TestCase
         $this->assertContainsOnlyInstancesOf(InstalledPackage::class, $installedPackages);
         $this->assertGreaterThan(77, count($installedPackages));
     }
+
+    public function testFallbackToCurrentWorkingDirectory(): void
+    {
+        $installedPackageResolver = new InstalledPackageResolver();
+        $installedPackages = $installedPackageResolver->resolve();
+
+        $this->assertContainsOnlyInstancesOf(InstalledPackage::class, $installedPackages);
+        $this->assertGreaterThan(77, count($installedPackages));
+    }
 }


### PR DESCRIPTION
`InstalledPackageResolver` reassigns the local `$projectDirectory` variable in the constructor, but the value is bound to a **promoted** readonly property. The reassignment never reaches `$this->projectDirectory`, which stays `null`:

```php
public function __construct(
    private readonly ?string $projectDirectory = null
) {
    // fallback to root project directory
    if ($projectDirectory === null) {
        $projectDirectory = getcwd(); // <-- only the local variable
    }

    Assert::directory($projectDirectory);
}
```

`resolveVendorDir()` then builds `null . '/vendor'` = `/vendor`, so `resolve()` always throws:

> The installed package json not found. Make sure you run `composer update` and the "vendor/composer/installed.json" file exists

This is invisible for `SetManager`, because `RectorConfigBuilder` passes `getcwd()` explicitly. It is hit by the autowired instance behind the freshly added `ComposerPackageConstraintFilter` — any rule implementing `ComposerPackageConstraintInterface` (#7877) currently crashes.

```diff
-    public function __construct(
-        private readonly ?string $projectDirectory = null
-    ) {
-        // fallback to root project directory
-        if ($projectDirectory === null) {
-            $projectDirectory = getcwd();
-        }
-
-        Assert::directory($projectDirectory);
-    }
+    private readonly string $projectDirectory;
+
+    public function __construct(?string $projectDirectory = null)
+    {
+        // fallback to root project directory
+        $this->projectDirectory = $projectDirectory ?? (string) getcwd();
+
+        Assert::directory($this->projectDirectory);
+    }
```

Covered by a new test case that constructs the resolver without arguments.
