### PR TITLE
[Php73] Add ArrayKeysToArrayKeyFirstLastRector

### DIFF
--- a/config/set/php-polyfills.php
+++ b/config/set/php-polyfills.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Php73\Rector\BooleanOr\IsCountableRector;
 use Rector\Php73\Rector\FuncCall\ArrayKeyFirstLastRector;
+use Rector\Php73\Rector\FuncCall\ArrayKeysToArrayKeyFirstLastRector;
 use Rector\Php80\Rector\Identical\StrEndsWithRector;
 use Rector\Php80\Rector\Identical\StrStartsWithRector;
 use Rector\Php80\Rector\NotIdentical\MbStrContainsRector;
@@ -23,6 +24,7 @@ use Rector\Php84\Rector\Foreach_\ForeachToArrayFindRector;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
         ArrayKeyFirstLastRector::class,
+        ArrayKeysToArrayKeyFirstLastRector::class,
         IsCountableRector::class,
         GetDebugTypeRector::class,
         StrStartsWithRector::class,

--- a/config/set/php73.php
+++ b/config/set/php73.php
@@ -6,6 +6,7 @@ use Rector\Config\RectorConfig;
 use Rector\Php73\Rector\BooleanOr\IsCountableRector;
 use Rector\Php73\Rector\ConstFetch\SensitiveConstantNameRector;
 use Rector\Php73\Rector\FuncCall\ArrayKeyFirstLastRector;
+use Rector\Php73\Rector\FuncCall\ArrayKeysToArrayKeyFirstLastRector;
 use Rector\Php73\Rector\FuncCall\RegexDashEscapeRector;
 use Rector\Php73\Rector\FuncCall\SensitiveDefineRector;
 use Rector\Php73\Rector\FuncCall\SetCookieRector;
@@ -40,6 +41,7 @@ return static function (RectorConfig $rectorConfig): void {
         IsCountableRector::class,
 
         ArrayKeyFirstLastRector::class,
+        ArrayKeysToArrayKeyFirstLastRector::class,
 
         SensitiveDefineRector::class,
 

--- a/rules-tests/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector/ArrayKeysToArrayKeyFirstLastRectorTest.php
+++ b/rules-tests/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector/ArrayKeysToArrayKeyFirstLastRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php73\Rector\FuncCall\ArrayKeysToArrayKeyFirstLastRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ArrayKeysToArrayKeyFirstLastRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector/Fixture/fixture.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector/Fixture/fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\ArrayKeysToArrayKeyFirstLastRector\Fixture;
+
+final class SomeClass
+{
+    public function run(array $items)
+    {
+        $firstKey = current(array_keys($items));
+        $alsoFirstKey = reset(array_keys($items));
+        $lastKey = end(array_keys($items));
+
+        return [$firstKey, $alsoFirstKey, $lastKey];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\ArrayKeysToArrayKeyFirstLastRector\Fixture;
+
+final class SomeClass
+{
+    public function run(array $items)
+    {
+        $firstKey = array_key_first($items);
+        $alsoFirstKey = array_key_first($items);
+        $lastKey = array_key_last($items);
+
+        return [$firstKey, $alsoFirstKey, $lastKey];
+    }
+}
+
+?>

--- a/rules-tests/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector/Fixture/nested_expression.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector/Fixture/nested_expression.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\ArrayKeysToArrayKeyFirstLastRector\Fixture;
+
+final class NestedExpression
+{
+    public function run(array $items)
+    {
+        return trim((string) current(array_keys($this->resolveItems($items))));
+    }
+
+    private function resolveItems(array $items): array
+    {
+        return $items;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\ArrayKeysToArrayKeyFirstLastRector\Fixture;
+
+final class NestedExpression
+{
+    public function run(array $items)
+    {
+        return trim((string) array_key_first($this->resolveItems($items)));
+    }
+
+    private function resolveItems(array $items): array
+    {
+        return $items;
+    }
+}
+
+?>

--- a/rules-tests/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector/Fixture/skip_array_keys_with_search_value.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector/Fixture/skip_array_keys_with_search_value.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\ArrayKeysToArrayKeyFirstLastRector\Fixture;
+
+final class SkipArrayKeysWithSearchValue
+{
+    public function run(array $items)
+    {
+        // array_keys() with a search value returns only the matching keys
+        $firstMatchingKey = current(array_keys($items, 'value'));
+        $lastMatchingKey = end(array_keys($items, 'value', true));
+
+        return [$firstMatchingKey, $lastMatchingKey];
+    }
+}

--- a/rules-tests/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector/Fixture/skip_other_calls.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector/Fixture/skip_other_calls.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\ArrayKeysToArrayKeyFirstLastRector\Fixture;
+
+final class SkipOtherCalls
+{
+    public function run(array $items, array $keys)
+    {
+        // not array_keys()
+        $first = current(array_values($items));
+
+        // no inner call at all
+        $stillFirst = current($keys);
+
+        // key() of the keys array is always 0, not the first key
+        $zero = key(array_keys($items));
+
+        // first class callable
+        $callable = current(...);
+
+        // spread
+        $spread = current(...array_keys($items));
+
+        return [$first, $stillFirst, $zero, $callable, $spread];
+    }
+}

--- a/rules-tests/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector/config/configured_rule.php
+++ b/rules-tests/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php73\Rector\FuncCall\ArrayKeysToArrayKeyFirstLastRector;
+
+return RectorConfig::configure()
+    ->withRules([ArrayKeysToArrayKeyFirstLastRector::class]);

--- a/rules/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector.php
+++ b/rules/Php73/Rector/FuncCall/ArrayKeysToArrayKeyFirstLastRector.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php73\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\ValueObject\PolyfillPackage;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Rector\VersionBonding\Contract\RelatedPolyfillInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\Php73\Rector\FuncCall\ArrayKeysToArrayKeyFirstLastRector\ArrayKeysToArrayKeyFirstLastRectorTest
+ */
+final class ArrayKeysToArrayKeyFirstLastRector extends AbstractRector implements MinPhpVersionInterface, RelatedPolyfillInterface
+{
+    /**
+     * @var array<string, string>
+     */
+    private const array PREVIOUS_TO_NEW_FUNCTIONS = [
+        'current' => 'array_key_first',
+        'reset' => 'array_key_first',
+        'end' => 'array_key_last',
+    ];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Make use of array_key_first() and array_key_last() instead of reading a single key off array_keys()',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$firstKey = current(array_keys($items));
+$lastKey = end(array_keys($items));
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$firstKey = array_key_first($items);
+$lastKey = array_key_last($items);
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        $funcName = $this->getName($node);
+        if ($funcName === null) {
+            return null;
+        }
+
+        if (! isset(self::PREVIOUS_TO_NEW_FUNCTIONS[$funcName])) {
+            return null;
+        }
+
+        $args = $node->getArgs();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        if ($args[0]->name instanceof Identifier || $args[0]->unpack) {
+            return null;
+        }
+
+        $arrayKeysFuncCall = $args[0]->value;
+        if (! $arrayKeysFuncCall instanceof FuncCall) {
+            return null;
+        }
+
+        if (! $this->isName($arrayKeysFuncCall, 'array_keys')) {
+            return null;
+        }
+
+        if ($arrayKeysFuncCall->isFirstClassCallable()) {
+            return null;
+        }
+
+        $arrayKeysArgs = $arrayKeysFuncCall->getArgs();
+
+        // array_keys() with a search value returns only the matching keys, so the first one is not the array's first key
+        if (count($arrayKeysArgs) !== 1) {
+            return null;
+        }
+
+        if ($arrayKeysArgs[0]->name instanceof Identifier || $arrayKeysArgs[0]->unpack) {
+            return null;
+        }
+
+        $node->name = new Name(self::PREVIOUS_TO_NEW_FUNCTIONS[$funcName]);
+        $node->args = $arrayKeysArgs;
+
+        return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ARRAY_KEY_FIRST_LAST;
+    }
+
+    public function providePolyfillPackage(): string
+    {
+        return PolyfillPackage::PHP_73;
+    }
+}

--- a/tests/Bridge/SetRectorsResolverTest.php
+++ b/tests/Bridge/SetRectorsResolverTest.php
@@ -45,7 +45,7 @@ final class SetRectorsResolverTest extends TestCase
         $rectorRulesWithConfiguration = $this->setRectorsResolver->resolveFromFilePathsIncludingConfiguration(
             $configFilePaths
         );
-        $this->assertCount(62, $rectorRulesWithConfiguration);
+        $this->assertCount(63, $rectorRulesWithConfiguration);
     }
 
     public function testResolveWithConfiguration(): void
@@ -53,7 +53,7 @@ final class SetRectorsResolverTest extends TestCase
         $rectorRulesWithConfiguration = $this->setRectorsResolver->resolveFromFilePathIncludingConfiguration(
             SetList::PHP_73
         );
-        $this->assertCount(9, $rectorRulesWithConfiguration);
+        $this->assertCount(10, $rectorRulesWithConfiguration);
 
         $this->assertArrayHasKey(0, $rectorRulesWithConfiguration);
         $this->assertArrayHasKey(8, $rectorRulesWithConfiguration);


### PR DESCRIPTION
Adds `ArrayKeysToArrayKeyFirstLastRector`, which replaces reading a single key off `array_keys()` with the dedicated PHP 7.3 function:

```php
$firstKey = current(array_keys($items));
$alsoFirst = reset(array_keys($items));
$lastKey = end(array_keys($items));
```

```php
$firstKey = array_key_first($items);
$alsoFirst = array_key_first($items);
$lastKey = array_key_last($items);
```

`array_keys()` materializes every key just to have all but one thrown away. Beyond the wasted allocation, the intent is easier to read once the dedicated function is used.

This complements the existing `ArrayKeyFirstLastRector`, which is `STMTS_AWARE` and only matches the two-statement `reset($items); key($items);` form, the nested expression is not covered by it, so the two rules do not overlap.

### Skipped cases

- **`array_keys()` with a search value**, `array_keys($items, 'value')` returns only the matching keys, so its first entry is not the array's first key. Transforming this would be a behavior change.
- Named arguments, spread, and first-class callables on either call.
- `key(array_keys($items))`, which always evaluates to `0` rather than the first key.

### Note on empty arrays

`current(array_keys([]))` returns `false`, while `array_key_first([])` returns `null`. The rule transforms regardless, matching how `ArrayFirstLastRector` handles the equivalent `array_values($array)[0]` → `array_first($array)` case. Gating on a proven `non-empty-array` type would leave nearly nothing to fix. Happy to add such a guard if you would rather have it.