### PR TITLE
[DeadCode] Skip static property in RemoveDefaultValueFromAssignedPropertyRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_static_property.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_static_property.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class SkipStaticProperty
+{
+    private static ?int $value = null;
+
+    public function __construct(int $value)
+    {
+        self::$value = $value;
+    }
+
+    public static function getValue(): ?int
+    {
+        return self::$value;
+    }
+}

--- a/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
@@ -102,6 +102,11 @@ CODE_SAMPLE
                 continue;
             }
 
+            // static property can be read before the constructor is called
+            if ($property->isStatic()) {
+                continue;
+            }
+
             if (! $property->isPrivate() && ! $isFinal) {
                 continue;
             }


### PR DESCRIPTION
A static property is shared per class, not per instance. Removing its default value makes it uninitialized until the first constructor call, so any read before that (or without ever instantiating the class) throws `Error: Typed static property must not be accessed before initialization`.

`ConstructorAssignDetector` matches `StaticPropertyFetch` as well as `PropertyFetch`, so `self::$value = $value;` in the constructor was treated as "always assigned" and the default was dropped.

```diff
 final class SkipStaticProperty
 {
-    private static ?int $value = null;
+    private static ?int $value;

     public function __construct(int $value)
     {
         self::$value = $value;
     }

     public static function getValue(): ?int
     {
         return self::$value;
     }
 }
```

`SkipStaticProperty::getValue()` throws after the change, without ever constructing the class.

Static properties are now skipped.