### PR TITLE
[Composer] Prefer composer.json constraint over outdated installed.json version

### DIFF
--- a/src/Composer/InstalledPackageResolver.php
+++ b/src/Composer/InstalledPackageResolver.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\Composer;
 
+use Composer\Semver\Semver;
+use Composer\Semver\VersionParser;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Json;
 use Rector\Composer\ValueObject\InstalledPackage;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\Skipper\FileSystem\PathNormalizer;
+use UnexpectedValueException;
 use Webmozart\Assert\Assert;
 
 /**
@@ -16,10 +19,17 @@ use Webmozart\Assert\Assert;
  */
 final class InstalledPackageResolver
 {
+    private const string ANY_VERSION_LOWER_BOUND = '0.0.0.0-dev';
+
     /**
      * @var null|array<string, InstalledPackage>
      */
     private ?array $resolvedInstalledPackages = null;
+
+    /**
+     * @var null|array<string, mixed>
+     */
+    private ?array $projectComposerJson = null;
 
     private readonly string $projectDirectory;
 
@@ -75,36 +85,116 @@ final class InstalledPackageResolver
      */
     private function createInstalledPackages(array $packages): array
     {
+        $packageConstraints = $this->resolvePackageConstraints();
         $installedPackages = [];
 
         foreach ($packages as $package) {
             $name = $package['name'];
-            $installedPackages[$name] = new InstalledPackage($name, $package['version_normalized']);
+            $version = $package['version_normalized'];
+
+            $constraint = $packageConstraints[$name] ?? null;
+            if (is_string($constraint)) {
+                // the "installed.json" can be outdated, e.g. after a branch switch;
+                // in such case the "composer.json" constraint has a priority
+                $version = $this->matchConstraintVersion($version, $constraint) ?? $version;
+            }
+
+            $installedPackages[$name] = new InstalledPackage($name, $version);
         }
 
         return $installedPackages;
     }
 
-    private function resolveVendorDir(): string
+    /**
+     * @return null|string the lowest version allowed by the constraint, if the installed version is out of it
+     */
+    private function matchConstraintVersion(string $installedVersion, string $constraint): ?string
     {
-        $projectComposerJsonFilePath = $this->projectDirectory . '/composer.json';
-
-        if (\file_exists($projectComposerJsonFilePath)) {
-            $projectComposerContents = FileSystem::read($projectComposerJsonFilePath);
-            $projectComposerJson = Json::decode($projectComposerContents, true);
-
-            if (isset($projectComposerJson['config']['vendor-dir']) &&
-                is_string($projectComposerJson['config']['vendor-dir'])
-            ) {
-                $realPathVendorDir = realpath($projectComposerJson['config']['vendor-dir']) ?: '';
-                $normalizedRealPathVendorDir = PathNormalizer::normalize($realPathVendorDir);
-                $normalizedVendorDir = PathNormalizer::normalize($projectComposerJson['config']['vendor-dir']);
-
-                return $normalizedRealPathVendorDir === $normalizedVendorDir
-                    ? $projectComposerJson['config']['vendor-dir']
-                    : $this->projectDirectory . '/' . $projectComposerJson['config']['vendor-dir'];
+        try {
+            if (Semver::satisfies($installedVersion, $constraint)) {
+                return null;
             }
 
+            $lowestVersion = new VersionParser()->parseConstraints($constraint)
+                ->getLowerBound()
+                ->getVersion();
+        } catch (UnexpectedValueException) {
+            // non-comparable version or constraint, e.g. a dev one
+            return null;
+        }
+
+        // the constraint allows any version, nothing to fall back to
+        if ($lowestVersion === self::ANY_VERSION_LOWER_BOUND) {
+            return null;
+        }
+
+        // the lower bound is a dev one, e.g. "10.5.0.0-dev" for the "^10.5" constraint
+        if (str_ends_with($lowestVersion, '-dev')) {
+            return substr($lowestVersion, 0, -strlen('-dev'));
+        }
+
+        return $lowestVersion;
+    }
+
+    /**
+     * @return array<string, string> package name to the "composer.json" version constraint
+     */
+    private function resolvePackageConstraints(): array
+    {
+        $projectComposerJson = $this->loadProjectComposerJson();
+
+        $packageConstraints = [];
+
+        foreach (['require', 'require-dev'] as $section) {
+            $requiredPackages = $projectComposerJson[$section] ?? null;
+            if (! is_array($requiredPackages)) {
+                continue;
+            }
+
+            foreach ($requiredPackages as $packageName => $constraint) {
+                if (is_string($packageName) && is_string($constraint)) {
+                    $packageConstraints[$packageName] = $constraint;
+                }
+            }
+        }
+
+        return $packageConstraints;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadProjectComposerJson(): array
+    {
+        if ($this->projectComposerJson !== null) {
+            return $this->projectComposerJson;
+        }
+
+        $projectComposerJsonFilePath = $this->projectDirectory . '/composer.json';
+        if (! file_exists($projectComposerJsonFilePath)) {
+            return $this->projectComposerJson = [];
+        }
+
+        $projectComposerContents = FileSystem::read($projectComposerJsonFilePath);
+        $projectComposerJson = Json::decode($projectComposerContents, true);
+
+        return $this->projectComposerJson = is_array($projectComposerJson) ? $projectComposerJson : [];
+    }
+
+    private function resolveVendorDir(): string
+    {
+        $projectComposerJson = $this->loadProjectComposerJson();
+
+        if (isset($projectComposerJson['config']['vendor-dir']) &&
+            is_string($projectComposerJson['config']['vendor-dir'])
+        ) {
+            $realPathVendorDir = realpath($projectComposerJson['config']['vendor-dir']) ?: '';
+            $normalizedRealPathVendorDir = PathNormalizer::normalize($realPathVendorDir);
+            $normalizedVendorDir = PathNormalizer::normalize($projectComposerJson['config']['vendor-dir']);
+
+            return $normalizedRealPathVendorDir === $normalizedVendorDir
+                ? $projectComposerJson['config']['vendor-dir']
+                : $this->projectDirectory . '/' . $projectComposerJson['config']['vendor-dir'];
         }
 
         return $this->projectDirectory . '/vendor';

--- a/tests/Composer/Fixture/InstalledPackageResolver/outdated_installed_json/composer.json
+++ b/tests/Composer/Fixture/InstalledPackageResolver/outdated_installed_json/composer.json
@@ -1,0 +1,9 @@
+{
+    "require": {
+        "phpunit/phpunit": "^10.5",
+        "symfony/console": "^7.0"
+    },
+    "require-dev": {
+        "nette/utils": "^3.2"
+    }
+}

--- a/tests/Composer/Fixture/InstalledPackageResolver/outdated_installed_json/vendor/composer/installed.json
+++ b/tests/Composer/Fixture/InstalledPackageResolver/outdated_installed_json/vendor/composer/installed.json
@@ -1,0 +1,24 @@
+{
+    "packages": [
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.2",
+            "version_normalized": "11.5.2.0"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.2.0",
+            "version_normalized": "7.2.0.0"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v4.0.5",
+            "version_normalized": "4.0.5.0"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.11.0",
+            "version_normalized": "1.11.0.0"
+        }
+    ]
+}

--- a/tests/Composer/InstalledPackageResolverTest.php
+++ b/tests/Composer/InstalledPackageResolverTest.php
@@ -27,4 +27,23 @@ final class InstalledPackageResolverTest extends TestCase
         $this->assertContainsOnlyInstancesOf(InstalledPackage::class, $installedPackages);
         $this->assertGreaterThan(77, count($installedPackages));
     }
+
+    public function testComposerJsonHasPriorityOverOutdatedInstalledJson(): void
+    {
+        $installedPackageResolver = new InstalledPackageResolver(
+            __DIR__ . '/Fixture/InstalledPackageResolver/outdated_installed_json'
+        );
+
+        // the "installed.json" is outdated and contains 11.5.2.0
+        $this->assertSame('10.5.0.0', $installedPackageResolver->resolvePackageVersion('phpunit/phpunit'));
+
+        // the installed version matches the "composer.json" constraint
+        $this->assertSame('7.2.0.0', $installedPackageResolver->resolvePackageVersion('symfony/console'));
+
+        // require-dev is respected as well
+        $this->assertSame('3.2.0.0', $installedPackageResolver->resolvePackageVersion('nette/utils'));
+
+        // not required in the "composer.json" at all
+        $this->assertSame('1.11.0.0', $installedPackageResolver->resolvePackageVersion('webmozart/assert'));
+    }
 }


### PR DESCRIPTION
`InstalledPackageResolver` read package versions only from `vendor/composer/installed.json`. After a branch switch, that file can be stale - it may still hold the version installed for the *other* branch, and composer-based sets are then picked for the wrong major version.

Now the `composer.json` constraint wins: when the installed version does not satisfy the required constraint, the lowest version allowed by the constraint is used instead.

Example - branch requires PHPUnit 10, but `vendor/` still holds PHPUnit 11:

```json
// composer.json
{
    "require-dev": {
        "phpunit/phpunit": "^10.5"
    }
}

// vendor/composer/installed.json
{
    "packages": [
        { "name": "phpunit/phpunit", "version_normalized": "11.5.2.0" }
    ]
}
```

```diff
-phpunit/phpunit: 11.5.2.0   # PHPUnit 11 sets loaded
+phpunit/phpunit: 10.5.0.0   # PHPUnit 10 sets loaded, as composer.json requires
```

Untouched cases:

* installed version satisfies the constraint - installed version kept, as before
* package not required in `composer.json` - installed version kept
* `*` or dev constraints - no usable lower bound, installed version kept
