### PR TITLE
[Config] Add ruleWithConfigurationComposerVersionBound()

### DIFF
--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\Config;
 
+use Composer\Semver\Semver;
 use Illuminate\Container\Container;
 use Override;
 use Rector\Caching\Contract\CacheMetaExtensionInterface;
 use Rector\Caching\Contract\ValueObject\Storage\CacheStorageInterface;
+use Rector\Composer\InstalledPackageResolver;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Configuration\RectorConfigBuilder;
@@ -41,6 +43,8 @@ final class RectorConfig extends Container
      * @var string[]
      */
     private array $autotagInterfaces = [Command::class, ResettableInterface::class];
+
+    private ?InstalledPackageResolver $installedPackageResolver = null;
 
     private static ?bool $recreated = null;
 
@@ -193,6 +197,32 @@ final class RectorConfig extends Container
 
         // for cache invalidation in case of sets change
         SimpleParameterProvider::addParameter(Option::REGISTERED_RECTOR_RULES, $rectorClass);
+    }
+
+    /**
+     * Register the rule configuration only if the package version installed in the analysed project satisfies
+     * the version constraint. Useful for configuration valid since a specific package version,
+     * e.g. an attribute added in PHPUnit 11.
+     *
+     * @param class-string<ConfigurableRectorInterface> $rectorClass
+     * @param mixed[] $configuration
+     */
+    public function ruleWithConfigurationComposerVersionBound(
+        string $rectorClass,
+        array $configuration,
+        string $packageName,
+        string $versionConstraint
+    ): void {
+        $packageVersion = $this->resolveInstalledPackageVersion($packageName);
+        if ($packageVersion === null) {
+            return;
+        }
+
+        if (! Semver::satisfies($packageVersion, $versionConstraint)) {
+            return;
+        }
+
+        $this->ruleWithConfiguration($rectorClass, $configuration);
     }
 
     /**
@@ -487,5 +517,12 @@ final class RectorConfig extends Container
     public function setOverflowLevels(array $levelOverflows): void
     {
         SimpleParameterProvider::addParameter(Option::LEVEL_OVERFLOWS, $levelOverflows);
+    }
+
+    private function resolveInstalledPackageVersion(string $packageName): ?string
+    {
+        $this->installedPackageResolver ??= new InstalledPackageResolver();
+
+        return $this->installedPackageResolver->resolvePackageVersion($packageName);
     }
 }

--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -7,6 +7,11 @@ namespace Rector\Tests\Config;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Renaming\ValueObject\RenameProperty;
 use Rector\Symfony\Set\TwigSetList;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
@@ -28,5 +33,52 @@ final class RectorConfigTest extends AbstractLazyTestCase
 
         // only collect root withRules()
         $this->assertCount(1, SimpleParameterProvider::provideArrayParameter(Option::ROOT_STANDALONE_REGISTERED_RULES));
+    }
+
+    public function testRuleWithConfigurationComposerVersionBoundOnSatisfiedConstraint(): void
+    {
+        $rectorConfig = $this->getContainer();
+
+        $rectorConfig->ruleWithConfigurationComposerVersionBound(
+            RenameClassRector::class,
+            [
+                'SomeOldClass' => 'SomeNewClass',
+            ],
+            'phpunit/phpunit',
+            '>=9.0'
+        );
+
+        $registeredRectorRules = SimpleParameterProvider::provideArrayParameter(Option::REGISTERED_RECTOR_RULES);
+        $this->assertContains(RenameClassRector::class, $registeredRectorRules);
+    }
+
+    public function testRuleWithConfigurationComposerVersionBoundOnUnsatisfiedConstraint(): void
+    {
+        $rectorConfig = $this->getContainer();
+
+        $rectorConfig->ruleWithConfigurationComposerVersionBound(
+            RenameMethodRector::class,
+            [new MethodCallRename('SomeClass', 'oldMethod', 'newMethod')],
+            'phpunit/phpunit',
+            '<9.0'
+        );
+
+        $registeredRectorRules = SimpleParameterProvider::provideArrayParameter(Option::REGISTERED_RECTOR_RULES);
+        $this->assertNotContains(RenameMethodRector::class, $registeredRectorRules);
+    }
+
+    public function testRuleWithConfigurationComposerVersionBoundOnMissingPackage(): void
+    {
+        $rectorConfig = $this->getContainer();
+
+        $rectorConfig->ruleWithConfigurationComposerVersionBound(
+            RenamePropertyRector::class,
+            [new RenameProperty('SomeClass', 'oldProperty', 'newProperty')],
+            'not-installed/package',
+            '>=1.0'
+        );
+
+        $registeredRectorRules = SimpleParameterProvider::provideArrayParameter(Option::REGISTERED_RECTOR_RULES);
+        $this->assertNotContains(RenamePropertyRector::class, $registeredRectorRules);
     }
 }


### PR DESCRIPTION
`ComposerPackageConstraintInterface` binds a whole rule to a package version. There is no way to bind a *single configuration item* - e.g. one `AnnotationToAttribute` pair - to the package version that introduced it.

This adds a version-bound variant of `ruleWithConfiguration()`:

```php
$rectorConfig->ruleWithConfigurationComposerVersionBound(
    AnnotationToAttributeRector::class,
    [new AnnotationToAttribute('test', 'PHPUnit\Framework\Attributes\Test')],
    'phpunit/phpunit',
    '>=10.0'
);
```

The configuration is registered only when the analysed project has a matching installed version. Since repeated `ruleWithConfiguration()` calls for the same rule class are merged, version-specific pairs stack on top of version-neutral ones across set files:

```php
// version-neutral pairs
$rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
    new AnnotationToAttribute('someTag', SomeAttribute::class),
]);

// only on PHPUnit 11+
$rectorConfig->ruleWithConfigurationComposerVersionBound(
    AnnotationToAttributeRector::class,
    [new AnnotationToAttribute('someElevenTag', SomeElevenAttribute::class)],
    'phpunit/phpunit',
    '>=11.0'
);
```

Version resolving reuses `InstalledPackageResolver`, so it follows the same rules as `ComposerPackageConstraintFilter`, including the `composer.json` constraint priority added in #8242. An unresolvable version - package not installed - means the configuration is not registered, same as the existing filter.
