### PR TITLE
[Set] Allow a version constraint in ComposerTriggeredSet

### DIFF
--- a/src/Set/ValueObject/ComposerTriggeredSet.php
+++ b/src/Set/ValueObject/ComposerTriggeredSet.php
@@ -12,6 +12,7 @@ use Webmozart\Assert\Assert;
 
 /**
  * @api used by extensions
+ * @see \Rector\Tests\Set\ValueObject\ComposerTriggeredSetTest
  */
 final readonly class ComposerTriggeredSet implements SetInterface
 {

--- a/src/Set/ValueObject/ComposerTriggeredSet.php
+++ b/src/Set/ValueObject/ComposerTriggeredSet.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Set\ValueObject;
 
 use Composer\Semver\Semver;
+use Nette\Utils\Strings;
 use Rector\Composer\ValueObject\InstalledPackage;
 use Rector\Set\Contract\SetInterface;
 use Webmozart\Assert\Assert;
@@ -18,6 +19,13 @@ final readonly class ComposerTriggeredSet implements SetInterface
      * @see https://regex101.com/r/ioYomu/1
      */
     private const string PACKAGE_REGEX = '#^[a-z0-9-]+\/([a-z0-9-_]+|\*)$#';
+
+    /**
+     * A bare "10.0" version, that is turned into a "^10.0" constraint
+     *
+     * @see https://regex101.com/r/vTJXPU/1
+     */
+    private const string BARE_VERSION_REGEX = '#^\d+(\.\d+)*$#';
 
     public function __construct(
         private string $groupName,
@@ -50,11 +58,24 @@ final readonly class ComposerTriggeredSet implements SetInterface
             return false;
         }
 
-        return Semver::satisfies($package->getVersion(), '^' . $this->version);
+        return Semver::satisfies($package->getVersion(), $this->resolveVersionConstraint());
     }
 
     public function getName(): string
     {
         return $this->packageName . ' ' . $this->version;
+    }
+
+    /**
+     * A bare version means "this major version", e.g. "10.0" is "^10.0". Anything else is used as is,
+     * to allow a set that spans multiple major versions, e.g. ">=10.0" or ">=10.0 <13.0".
+     */
+    private function resolveVersionConstraint(): string
+    {
+        if (Strings::match($this->version, self::BARE_VERSION_REGEX) !== null) {
+            return '^' . $this->version;
+        }
+
+        return $this->version;
     }
 }

--- a/tests/Set/ValueObject/ComposerTriggeredSetTest.php
+++ b/tests/Set/ValueObject/ComposerTriggeredSetTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Set\ValueObject;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Rector\Composer\ValueObject\InstalledPackage;
+use Rector\Set\Enum\SetGroup;
+use Rector\Set\ValueObject\ComposerTriggeredSet;
+
+final class ComposerTriggeredSetTest extends TestCase
+{
+    #[DataProvider('provideData')]
+    public function testMatchInstalledPackages(
+        string $version,
+        string $installedVersion,
+        bool $expectedMatch
+    ): void {
+        $composerTriggeredSet = new ComposerTriggeredSet(
+            SetGroup::PHPUNIT,
+            'phpunit/phpunit',
+            $version,
+            __FILE__
+        );
+
+        $installedPackages = [
+            'phpunit/phpunit' => new InstalledPackage('phpunit/phpunit', $installedVersion),
+        ];
+
+        $this->assertSame($expectedMatch, $composerTriggeredSet->matchInstalledPackages($installedPackages));
+    }
+
+    public static function provideData(): Iterator
+    {
+        // a bare version keeps the "this major version" behaviour
+        yield ['10.0', '10.5.0.0', true];
+        yield ['10.0', '11.0.0.0', false];
+        yield ['10.0', '9.6.0.0', false];
+
+        // a constraint is used as is
+        yield ['>=10.0', '13.2.0.0', true];
+        yield ['>=10.0', '9.6.0.0', false];
+        yield ['>=10.0 <13.0', '12.5.0.0', true];
+        yield ['>=10.0 <13.0', '13.0.0.0', false];
+    }
+
+    public function testSkipNotInstalledPackage(): void
+    {
+        $composerTriggeredSet = new ComposerTriggeredSet(
+            SetGroup::PHPUNIT,
+            'phpunit/phpunit',
+            '>=10.0',
+            __FILE__
+        );
+
+        $this->assertFalse($composerTriggeredSet->matchInstalledPackages([]));
+    }
+}


### PR DESCRIPTION
`ComposerTriggeredSet` hardcodes `'^' . $version`, so a set can only be bound to a single major version:

```php
return Semver::satisfies($package->getVersion(), '^' . $this->version);
```

That is fine for the per-version upgrade sets, but it makes it impossible to register a set that applies across majors - such as rector-phpunit's new `composer-based.php`, which should load for any installed PHPUnit and does its own per-rule version gating via `ComposerPackageConstraintInterface` and `ruleWithConfigurationComposerVersionBound()`.

A bare version keeps behaving exactly as before; anything that is not a bare version is used as a constraint:

```php
private function resolveVersionConstraint(): string
{
    if (Strings::match($this->version, self::BARE_VERSION_REGEX) !== null) {
        return '^' . $this->version;
    }

    return $this->version;
}
```

So both of these work:

```php
// unchanged - matches ^10.0
new ComposerTriggeredSet(SetGroup::PHPUNIT, 'phpunit/phpunit', '10.0', __DIR__ . '/../config/sets/phpunit100.php'),

// new - matches any PHPUnit 10 and up
new ComposerTriggeredSet(SetGroup::PHPUNIT, 'phpunit/phpunit', '>=10.0', __DIR__ . '/../config/sets/composer-based.php'),
```

This is what lets `withComposerBased(phpunit: true)` pick up a package's composer-based set regardless of which PHPUnit major is installed, without registering the same set once per major version.

Backward compatible - every existing `ComposerTriggeredSet` in rector-src and the extension packages passes a bare version and keeps the `^` behaviour. Covered by `ComposerTriggeredSetTest`, including the bare version cases.
