### PR TITLE
[composer-based] Report rule configuration bound to installed package version

### DIFF
--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -25,6 +25,7 @@ use Rector\Validation\RectorConfigValidator;
 use Rector\ValueObject\Configuration\LevelOverflow;
 use Rector\ValueObject\PhpVersion;
 use Rector\ValueObject\PolyfillPackage;
+use Rector\VersionBonding\ValueObject\ComposerBoundRuleConfiguration;
 use Symfony\Component\Console\Command\Command;
 use Webmozart\Assert\Assert;
 
@@ -214,11 +215,20 @@ final class RectorConfig extends Container
         string $versionConstraint
     ): void {
         $packageVersion = $this->resolveInstalledPackageVersion($packageName);
-        if ($packageVersion === null) {
-            return;
-        }
+        $isActive = $packageVersion !== null && Semver::satisfies($packageVersion, $versionConstraint);
 
-        if (! Semver::satisfies($packageVersion, $versionConstraint)) {
+        // reported by the "composer-based" command, the inactive ones as well
+        SimpleParameterProvider::addParameter(Option::COMPOSER_BOUND_RULE_CONFIGURATIONS, [
+            new ComposerBoundRuleConfiguration(
+                $rectorClass,
+                $packageName,
+                $versionConstraint,
+                $configuration,
+                $isActive
+            ),
+        ]);
+
+        if (! $isActive) {
             return;
         }
 

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -262,6 +262,12 @@ final class Option
     public const string COMPOSER_BASED_SETS = 'composer_based_sets';
 
     /**
+     * @internal To report rule configuration bound to an installed package version
+     * @see \Rector\Config\RectorConfig::ruleWithConfigurationComposerVersionBound()
+     */
+    public const string COMPOSER_BOUND_RULE_CONFIGURATIONS = 'composer_bound_rule_configurations';
+
+    /**
      * @internal To filter files by specific suffix
      */
     public const string ONLY_SUFFIX = 'only-suffix';

--- a/src/Console/Command/ComposerBasedCommand.php
+++ b/src/Console/Command/ComposerBasedCommand.php
@@ -176,7 +176,7 @@ final class ComposerBasedCommand extends Command
 
         if (is_array($value)) {
             $printedItems = array_map(
-                fn (mixed $item): string => $this->printConfigurationValue($item),
+                $this->printConfigurationValue(...),
                 $value
             );
 

--- a/src/Console/Command/ComposerBasedCommand.php
+++ b/src/Console/Command/ComposerBasedCommand.php
@@ -94,7 +94,7 @@ final class ComposerBasedCommand extends Command
             $isActive = $installedVersion !== null && Semver::satisfies($installedVersion, $constraint);
 
             $tableRows[] = [
-                $rector::class,
+                $this->printShortClassName($rector::class),
                 $packageName,
                 $constraint,
                 $installedVersion ?? '-',
@@ -131,7 +131,7 @@ final class ComposerBasedCommand extends Command
             $installedVersion = $this->installedPackageResolver->resolvePackageVersion($packageName);
 
             $tableRows[] = [
-                $composerBoundRuleConfiguration->getRectorClass(),
+                $this->printShortClassName($composerBoundRuleConfiguration->getRectorClass()),
                 $packageName,
                 $composerBoundRuleConfiguration->getVersionConstraint(),
                 $installedVersion ?? '-',
@@ -169,9 +169,7 @@ final class ComposerBasedCommand extends Command
                 $printedPropertyValues[] = $this->printConfigurationValue($reflectionProperty->getValue($value));
             }
 
-            $shortClassName = Strings::after($value::class, '\\', -1) ?? $value::class;
-
-            return $shortClassName . '(' . implode(', ', $printedPropertyValues) . ')';
+            return $this->printShortClassName($value::class) . '(' . implode(', ', $printedPropertyValues) . ')';
         }
 
         if (is_array($value)) {
@@ -188,5 +186,10 @@ final class ComposerBasedCommand extends Command
         }
 
         return (string) $value;
+    }
+
+    private function printShortClassName(string $className): string
+    {
+        return Strings::after($className, '\\', -1) ?? $className;
     }
 }

--- a/src/Console/Command/ComposerBasedCommand.php
+++ b/src/Console/Command/ComposerBasedCommand.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Rector\Console\Command;
 
 use Composer\Semver\Semver;
+use Nette\Utils\Strings;
 use Rector\Composer\InstalledPackageResolver;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerBoundRuleConfiguration;
+use ReflectionObject;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -38,20 +43,32 @@ final class ComposerBasedCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $tableRows = $this->createTableRows();
+        $configurationTableRows = $this->createConfigurationTableRows();
 
-        if ($tableRows === []) {
+        if ($tableRows === [] && $configurationTableRows === []) {
             $this->symfonyStyle->warning('No composer package bound rule is loaded');
 
             return Command::SUCCESS;
         }
 
-        $this->symfonyStyle->title('Composer package bound rules');
-        $this->symfonyStyle->table(['Rule', 'Package', 'Requires', 'Installed', 'Active'], $tableRows);
+        if ($tableRows !== []) {
+            $this->symfonyStyle->title('Composer package bound rules');
+            $this->symfonyStyle->table(['Rule', 'Package', 'Requires', 'Installed', 'Active'], $tableRows);
+        }
 
-        $activeCount = count(array_filter($tableRows, static fn (array $tableRow): bool => $tableRow[4] === 'yes'));
+        if ($configurationTableRows !== []) {
+            $this->symfonyStyle->title('Composer package bound rule configuration');
+            $this->symfonyStyle->table(
+                ['Rule', 'Package', 'Requires', 'Installed', 'Active', 'Configuration'],
+                $configurationTableRows
+            );
+        }
+
+        $allTableRows = [...$tableRows, ...$configurationTableRows];
+        $activeCount = count(array_filter($allTableRows, static fn (array $tableRow): bool => $tableRow[4] === 'yes'));
 
         $this->symfonyStyle->note(
-            sprintf('%d of %d composer package bound rules are active', $activeCount, count($tableRows))
+            sprintf('%d of %d composer package bound items are active', $activeCount, count($allTableRows))
         );
 
         return Command::SUCCESS;
@@ -92,5 +109,84 @@ final class ComposerBasedCommand extends Command
         );
 
         return $tableRows;
+    }
+
+    /**
+     * @return array<array{string, string, string, string, string, string}>
+     */
+    private function createConfigurationTableRows(): array
+    {
+        $composerBoundRuleConfigurations = SimpleParameterProvider::provideArrayParameter(
+            Option::COMPOSER_BOUND_RULE_CONFIGURATIONS
+        );
+
+        $tableRows = [];
+
+        foreach ($composerBoundRuleConfigurations as $composerBoundRuleConfiguration) {
+            if (! $composerBoundRuleConfiguration instanceof ComposerBoundRuleConfiguration) {
+                continue;
+            }
+
+            $packageName = $composerBoundRuleConfiguration->getPackageName();
+            $installedVersion = $this->installedPackageResolver->resolvePackageVersion($packageName);
+
+            $tableRows[] = [
+                $composerBoundRuleConfiguration->getRectorClass(),
+                $packageName,
+                $composerBoundRuleConfiguration->getVersionConstraint(),
+                $installedVersion ?? '-',
+                $composerBoundRuleConfiguration->isActive() ? 'yes' : 'no',
+                $this->printConfiguration($composerBoundRuleConfiguration->getConfiguration()),
+            ];
+        }
+
+        return $tableRows;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    private function printConfiguration(array $configuration): string
+    {
+        $printedItems = [];
+
+        foreach ($configuration as $key => $value) {
+            $printedValue = $this->printConfigurationValue($value);
+
+            $printedItems[] = is_string($key) ? $key . ': ' . $printedValue : $printedValue;
+        }
+
+        return implode(PHP_EOL, $printedItems);
+    }
+
+    private function printConfigurationValue(mixed $value): string
+    {
+        if (is_object($value)) {
+            $printedPropertyValues = [];
+
+            $reflectionObject = new ReflectionObject($value);
+            foreach ($reflectionObject->getProperties() as $reflectionProperty) {
+                $printedPropertyValues[] = $this->printConfigurationValue($reflectionProperty->getValue($value));
+            }
+
+            $shortClassName = Strings::after($value::class, '\\', -1) ?? $value::class;
+
+            return $shortClassName . '(' . implode(', ', $printedPropertyValues) . ')';
+        }
+
+        if (is_array($value)) {
+            $printedItems = array_map(
+                fn (mixed $item): string => $this->printConfigurationValue($item),
+                $value
+            );
+
+            return '[' . implode(', ', $printedItems) . ']';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return (string) $value;
     }
 }

--- a/src/VersionBonding/ValueObject/ComposerBoundRuleConfiguration.php
+++ b/src/VersionBonding/ValueObject/ComposerBoundRuleConfiguration.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\VersionBonding\ValueObject;
+
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+
+/**
+ * @see \Rector\Config\RectorConfig::ruleWithConfigurationComposerVersionBound()
+ */
+final readonly class ComposerBoundRuleConfiguration
+{
+    /**
+     * @param class-string<ConfigurableRectorInterface> $rectorClass
+     * @param mixed[] $configuration
+     */
+    public function __construct(
+        private string $rectorClass,
+        private string $packageName,
+        private string $versionConstraint,
+        private array $configuration,
+        private bool $isActive
+    ) {
+    }
+
+    /**
+     * @return class-string<ConfigurableRectorInterface>
+     */
+    public function getRectorClass(): string
+    {
+        return $this->rectorClass;
+    }
+
+    public function getPackageName(): string
+    {
+        return $this->packageName;
+    }
+
+    public function getVersionConstraint(): string
+    {
+        return $this->versionConstraint;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getConfiguration(): array
+    {
+        return $this->configuration;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+}

--- a/tests/Console/Command/ComposerBasedCommandTest.php
+++ b/tests/Console/Command/ComposerBasedCommandTest.php
@@ -6,7 +6,11 @@ namespace Rector\Tests\Console\Command;
 
 use PHPUnit\Framework\TestCase;
 use Rector\Composer\InstalledPackageResolver;
+use Rector\Config\RectorConfig;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Console\Command\ComposerBasedCommand;
+use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Tests\Console\Command\Source\ComposerBoundRector;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -19,6 +23,9 @@ final class ComposerBasedCommandTest extends TestCase
     protected function setUp(): void
     {
         $this->bufferedOutput = new BufferedOutput();
+
+        // the parameter provider is static, reset it between tests
+        SimpleParameterProvider::setParameter(Option::COMPOSER_BOUND_RULE_CONFIGURATIONS, []);
     }
 
     public function testName(): void
@@ -48,7 +55,7 @@ final class ComposerBasedCommandTest extends TestCase
 
         $this->assertStringContainsString('phpunit/phpunit', $output);
         $this->assertStringContainsString('>=9.0', $output);
-        $this->assertStringContainsString('1 of 1 composer package bound rules are active', $output);
+        $this->assertStringContainsString('1 of 1 composer package bound items are active', $output);
     }
 
     public function testNotInstalledPackage(): void
@@ -61,7 +68,53 @@ final class ComposerBasedCommandTest extends TestCase
         $output = $this->bufferedOutput->fetch();
 
         $this->assertStringContainsString('not-installed/package', $output);
-        $this->assertStringContainsString('0 of 1 composer package bound rules are active', $output);
+        $this->assertStringContainsString('0 of 1 composer package bound items are active', $output);
+    }
+
+    public function testRuleConfiguration(): void
+    {
+        $rectorConfig = new RectorConfig();
+
+        // this project requires PHPUnit
+        $rectorConfig->ruleWithConfigurationComposerVersionBound(
+            RenameClassRector::class,
+            [
+                'SomeOldClass' => 'SomeNewClass',
+            ],
+            'phpunit/phpunit',
+            '>=9.0'
+        );
+
+        $composerBasedCommand = $this->createComposerBasedCommand([]);
+        $composerBasedCommand->run(new ArrayInput([]), $this->bufferedOutput);
+
+        $output = $this->bufferedOutput->fetch();
+
+        $this->assertStringContainsString('Composer package bound rule configuration', $output);
+        $this->assertStringContainsString('SomeOldClass: SomeNewClass', $output);
+        $this->assertStringContainsString('>=9.0', $output);
+    }
+
+    public function testInactiveRuleConfigurationIsReported(): void
+    {
+        $rectorConfig = new RectorConfig();
+
+        $rectorConfig->ruleWithConfigurationComposerVersionBound(
+            RenameClassRector::class,
+            [
+                'SomeOldClass' => 'SomeNewClass',
+            ],
+            'not-installed/package',
+            '>=1.0'
+        );
+
+        $composerBasedCommand = $this->createComposerBasedCommand([]);
+        $composerBasedCommand->run(new ArrayInput([]), $this->bufferedOutput);
+
+        $output = $this->bufferedOutput->fetch();
+
+        $this->assertStringContainsString('not-installed/package', $output);
+        $this->assertStringContainsString('0 of 1 composer package bound items are active', $output);
     }
 
     /**


### PR DESCRIPTION
Follow up to #8246. The `composer-based` command listed rules that declare a `ComposerPackageConstraint`, but not the configuration registered through `ruleWithConfigurationComposerVersionBound()`. That configuration is exactly the interesting part - it is what decides whether e.g. one `AnnotationToAttribute` pair is applied or not, and there was no way to see it.

`RectorConfig::ruleWithConfigurationComposerVersionBound()` now records every call as a `ComposerBoundRuleConfiguration`, including the ones that do not match, and the command prints a second table:

```
Composer package bound rule configuration
=========================================

 --------------------------------------------------- ----------------- -------------- ----------- -------- ------------------------------------------------------------------------------
  Rule                                                Package           Requires       Installed   Active   Configuration
 --------------------------------------------------- ----------------- -------------- ----------- -------- ------------------------------------------------------------------------------
  ...\Class_\AnnotationWithValueToAttributeRector     phpunit/phpunit   >=10.0         13.2.6.0    yes      AnnotationWithValueToAttribute(backupStaticProperties, PHPUnit\Framework\Attributes\BackupStaticProperties, [true, false], false)
                                                                                                            AnnotationWithValueToAttribute(excludeGlobalVariableFromBackup, PHPUnit\Framework\Attributes\ExcludeGlobalVariableFromBackup, [], false)
  Rector\Php80\Rector\Class_\AnnotationToAttributeRector   phpunit/phpunit   >=10.0 <13.0   13.2.6.0    no       AnnotationToAttribute(runClassInSeparateProcess, PHPUnit\Framework\Attributes\RunClassInSeparateProcess, [], false)
 --------------------------------------------------- ----------------- -------------- ----------- -------- ------------------------------------------------------------------------------

 ! [NOTE] 11 of 12 composer package bound items are active
```

That last row is the point: on PHPUnit 13 the `RunClassInSeparateProcess` attribute no longer exists, the pair is bound to `>=10.0 <13.0`, and the command shows it as inactive together with the exact pair it would have applied.

Configuration values are printed compactly - value objects as `ShortClassName(prop, prop, ...)`, arrays as `[a, b]`, string keys as `key: value`.

Output above is a real run against rector-phpunit with `PHPUnitSetList::COMPOSER_BASED`.

Covered by two more cases in `ComposerBasedCommandTest` - an active configuration and one whose package is not installed.
