### PR TITLE
[composer-based] Register each rule only once, add --composer-based process filter

### DIFF
--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -41,6 +41,16 @@ final class RectorConfig extends Container
     private array $ruleConfigurations = [];
 
     /**
+     * @var array<class-string<RectorInterface>, true>
+     */
+    private array $registeredRectorClasses = [];
+
+    /**
+     * @var array<string, true>
+     */
+    private array $registeredComposerBoundRuleConfigurations = [];
+
+    /**
      * @var string[]
      */
     private array $autotagInterfaces = [Command::class, ResettableInterface::class];
@@ -195,9 +205,6 @@ final class RectorConfig extends Container
             $ruleConfiguration = $this->ruleConfigurations[$rectorClass];
             $configurableRector->configure($ruleConfiguration);
         });
-
-        // for cache invalidation in case of sets change
-        SimpleParameterProvider::addParameter(Option::REGISTERED_RECTOR_RULES, $rectorClass);
     }
 
     /**
@@ -217,16 +224,25 @@ final class RectorConfig extends Container
         $packageVersion = $this->resolveInstalledPackageVersion($packageName);
         $isActive = $packageVersion !== null && Semver::satisfies($packageVersion, $versionConstraint);
 
-        // reported by the "composer-based" command, the inactive ones as well
-        SimpleParameterProvider::addParameter(Option::COMPOSER_BOUND_RULE_CONFIGURATIONS, [
-            new ComposerBoundRuleConfiguration(
-                $rectorClass,
-                $packageName,
-                $versionConstraint,
-                $configuration,
-                $isActive
-            ),
-        ]);
+        // the same rule configuration can be registered by multiple sets, report it only once
+        $configurationKey = $rectorClass . '|' . $packageName . '|' . $versionConstraint . '|' . serialize(
+            $configuration
+        );
+
+        if (! isset($this->registeredComposerBoundRuleConfigurations[$configurationKey])) {
+            $this->registeredComposerBoundRuleConfigurations[$configurationKey] = true;
+
+            // reported by the "composer-based" command, the inactive ones as well
+            SimpleParameterProvider::addParameter(Option::COMPOSER_BOUND_RULE_CONFIGURATIONS, [
+                new ComposerBoundRuleConfiguration(
+                    $rectorClass,
+                    $packageName,
+                    $versionConstraint,
+                    $configuration,
+                    $isActive
+                ),
+            ]);
+        }
 
         if (! $isActive) {
             return;
@@ -244,10 +260,17 @@ final class RectorConfig extends Container
         Assert::isAOf($rectorClass, RectorInterface::class);
 
         $this->singleton($rectorClass);
-        $this->tag($rectorClass, RectorInterface::class);
 
-        // for cache invalidation in case of change
-        SimpleParameterProvider::addParameter(Option::REGISTERED_RECTOR_RULES, $rectorClass);
+        // the same rule can be registered by multiple sets, tag it only once,
+        // otherwise it is run twice on every node and listed twice in the reports
+        if (! isset($this->registeredRectorClasses[$rectorClass])) {
+            $this->registeredRectorClasses[$rectorClass] = true;
+
+            $this->tag($rectorClass, RectorInterface::class);
+
+            // for cache invalidation in case of change
+            SimpleParameterProvider::addParameter(Option::REGISTERED_RECTOR_RULES, $rectorClass);
+        }
 
         if (is_a($rectorClass, RelatedConfigInterface::class, true)) {
             $configFile = $rectorClass::getConfigFile();
@@ -442,6 +465,8 @@ final class RectorConfig extends Container
     public function resetRuleConfigurations(): void
     {
         $this->ruleConfigurations = [];
+        $this->registeredRectorClasses = [];
+        $this->registeredComposerBoundRuleConfigurations = [];
     }
 
     /**

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -95,6 +95,13 @@ final readonly class ConfigurationFactory
 
         $showRulesSummary = (bool) $input->getOption(Option::RULES_SUMMARY);
 
+        $isComposerBased = (bool) $input->getOption(Option::COMPOSER_BASED);
+
+        // "--composer-based" narrows the run the same way "--only" does
+        if ($isComposerBased) {
+            SimpleParameterProvider::setParameter(Option::IS_RUN_NARROWED, true);
+        }
+
         return new Configuration(
             $isDryRun,
             $showProgressBar,
@@ -113,6 +120,7 @@ final readonly class ConfigurationFactory
             $onlySuffix,
             $levelOverflows,
             $showRulesSummary,
+            $isComposerBased,
         );
     }
 

--- a/src/Configuration/ConfigurationRuleFilter.php
+++ b/src/Configuration/ConfigurationRuleFilter.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Rector\Configuration;
 
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\ValueObject\Configuration;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerBoundRuleConfiguration;
 
 /**
  * Modify available rector rules based on the configuration options
@@ -34,6 +37,10 @@ final class ConfigurationRuleFilter
             return $this->filterOnlyRule($rectors, $onlyRule);
         }
 
+        if ($this->configuration->isComposerBased()) {
+            return $this->filterComposerBased($rectors);
+        }
+
         return $rectors;
     }
 
@@ -51,5 +58,56 @@ final class ConfigurationRuleFilter
         }
 
         return $activeRectors;
+    }
+
+    /**
+     * Keeps rules that declare a composer package constraint themselves, and rules whose configuration
+     * was registered with a composer package constraint.
+     *
+     * @param list<RectorInterface> $rectors
+     * @return list<RectorInterface>
+     */
+    private function filterComposerBased(array $rectors): array
+    {
+        $composerBoundRectorClasses = $this->resolveComposerBoundRectorClasses();
+
+        $activeRectors = [];
+        foreach ($rectors as $rector) {
+            if ($rector instanceof ComposerPackageConstraintInterface) {
+                $activeRectors[] = $rector;
+                continue;
+            }
+
+            if (in_array($rector::class, $composerBoundRectorClasses, true)) {
+                $activeRectors[] = $rector;
+            }
+        }
+
+        return $activeRectors;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolveComposerBoundRectorClasses(): array
+    {
+        $composerBoundRuleConfigurations = SimpleParameterProvider::provideArrayParameter(
+            Option::COMPOSER_BOUND_RULE_CONFIGURATIONS
+        );
+
+        $rectorClasses = [];
+        foreach ($composerBoundRuleConfigurations as $composerBoundRuleConfiguration) {
+            if (! $composerBoundRuleConfiguration instanceof ComposerBoundRuleConfiguration) {
+                continue;
+            }
+
+            if (! $composerBoundRuleConfiguration->isActive()) {
+                continue;
+            }
+
+            $rectorClasses[] = $composerBoundRuleConfiguration->getRectorClass();
+        }
+
+        return $rectorClasses;
     }
 }

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -268,6 +268,11 @@ final class Option
     public const string COMPOSER_BOUND_RULE_CONFIGURATIONS = 'composer_bound_rule_configurations';
 
     /**
+     * Run only rules bound to an installed composer package version
+     */
+    public const string COMPOSER_BASED = 'composer-based';
+
+    /**
      * @internal To filter files by specific suffix
      */
     public const string ONLY_SUFFIX = 'only-suffix';

--- a/src/Console/ProcessConfigureDecorator.php
+++ b/src/Console/ProcessConfigureDecorator.php
@@ -60,6 +60,13 @@ final class ProcessConfigureDecorator
         $command->addOption(Option::ONLY, null, InputOption::VALUE_REQUIRED, 'Fully qualified rule class name');
 
         $command->addOption(
+            Option::COMPOSER_BASED,
+            null,
+            InputOption::VALUE_NONE,
+            'Run only rules bound to an installed composer package version'
+        );
+
+        $command->addOption(
             Option::ONLY_SUFFIX,
             null,
             InputOption::VALUE_REQUIRED,

--- a/src/Parallel/Command/WorkerCommandLineFactory.php
+++ b/src/Parallel/Command/WorkerCommandLineFactory.php
@@ -123,6 +123,10 @@ final readonly class WorkerCommandLineFactory
             }
         }
 
+        if ((bool) $input->getOption(Option::COMPOSER_BASED)) {
+            $workerCommandArray[] = self::OPTION_DASHES . Option::COMPOSER_BASED;
+        }
+
         if ($input->getOption(Option::ONLY) !== null) {
             $workerCommandArray[] = self::OPTION_DASHES . Option::ONLY;
             $workerCommandArray[] = escapeshellarg((string) $input->getOption(Option::ONLY));

--- a/src/ValueObject/Configuration.php
+++ b/src/ValueObject/Configuration.php
@@ -35,7 +35,13 @@ final readonly class Configuration
         private ?string $onlySuffix = null,
         private array $levelOverflows = [],
         private bool $showRulesSummary = false,
+        private bool $isComposerBased = false,
     ) {
+    }
+
+    public function isComposerBased(): bool
+    {
+        return $this->isComposerBased;
     }
 
     public function isDryRun(): bool


### PR DESCRIPTION
## 1. Each rule is registered only once

`RectorConfig::rule()` tagged the class on every call. A rule registered by more than one set got one tag entry per set, and `giveTagged(RectorInterface::class)` handed the same singleton back once per entry.

That means the rule was **run repeatedly on every node**, and listed repeatedly in `list-rules` / `composer-based`:

```diff
  AnnotationWithValueToAttributeRector           phpunit/phpunit   >=10.0     11.5.56.0   yes
- AnnotationWithValueToAttributeRector           phpunit/phpunit   >=10.0     11.5.56.0   yes
  MockObjectArgCreateStubToCreateMockRector      phpunit/phpunit   >=11.0     11.5.56.0   yes
- MockObjectArgCreateStubToCreateMockRector      phpunit/phpunit   >=11.0     11.5.56.0   yes
- MockObjectArgCreateStubToCreateMockRector      phpunit/phpunit   >=11.0     11.5.56.0   yes
```

Reproduced with 3 `rule()` calls for the same class - `$container->tagged(RectorInterface::class)` returned 3 instances before, 1 after.

```diff
 $this->singleton($rectorClass);
-$this->tag($rectorClass, RectorInterface::class);

-// for cache invalidation in case of change
-SimpleParameterProvider::addParameter(Option::REGISTERED_RECTOR_RULES, $rectorClass);
+// the same rule can be registered by multiple sets, tag it only once,
+// otherwise it is run twice on every node and listed twice in the reports
+if (! isset($this->registeredRectorClasses[$rectorClass])) {
+    $this->registeredRectorClasses[$rectorClass] = true;
+
+    $this->tag($rectorClass, RectorInterface::class);
+
+    // for cache invalidation in case of change
+    SimpleParameterProvider::addParameter(Option::REGISTERED_RECTOR_RULES, $rectorClass);
+}
```

Same for composer bound rule *configurations* - the same rule class + package + constraint + configuration is reported once, no matter how many sets register it.

## 2. `--composer-based` process option

Runs only the rules that are bound to an installed composer package version - rules implementing `ComposerPackageConstraintInterface`, and rules whose configuration was registered through `ruleWithConfigurationComposerVersionBound()`.

```bash
vendor/bin/rector process src --composer-based --dry-run
```

Complements the `composer-based` command from #8247, which reports the same set of rules and configurations without running them.
