### PR TITLE
[Configuration] Deprecate withPhp53Sets() ... withPhp74Sets(), suggest withPhpLevel()

### DIFF
--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -238,6 +238,11 @@ final class Option
     public const string CACHE_META_EXTENSIONS = 'cache_meta_extensions';
 
     /**
+     * @internal For reporting deprecated withPhp53Sets() ... withPhp74Sets() methods
+     */
+    public const string DEPRECATED_PHP_SETS_METHODS = 'deprecated_php_sets_methods';
+
+    /**
      * @internal For collect skipped start with short open tag files to be reported
      */
     public const string SKIPPED_START_WITH_SHORT_OPEN_TAG_FILES = 'skipped_start_with_short_open_tag_files';

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -616,53 +616,58 @@ final class RectorConfigBuilder
         return $this->addPhpLevelSets($pickedPhpVersions[0]);
     }
 
-    /**
-     * Following methods are suitable for PHP 7.4 and lower, before named args
-     * Let's keep them without warning, in case Rector is run on both PHP 7.4 and PHP 8.0 in CI
-     */
+    #[Deprecated(message: 'Use "withPhpLevel()" instead, it raises PHP level one rule at a time.')]
     public function withPhp53Sets(): self
     {
-        return $this->addPhpLevelSets(PhpVersion::PHP_53);
+        return $this->reportDeprecatedPhpSetsMethod(__FUNCTION__);
     }
 
+    #[Deprecated(message: 'Use "withPhpLevel()" instead, it raises PHP level one rule at a time.')]
     public function withPhp54Sets(): self
     {
-        return $this->addPhpLevelSets(PhpVersion::PHP_54);
+        return $this->reportDeprecatedPhpSetsMethod(__FUNCTION__);
     }
 
+    #[Deprecated(message: 'Use "withPhpLevel()" instead, it raises PHP level one rule at a time.')]
     public function withPhp55Sets(): self
     {
-        return $this->addPhpLevelSets(PhpVersion::PHP_55);
+        return $this->reportDeprecatedPhpSetsMethod(__FUNCTION__);
     }
 
+    #[Deprecated(message: 'Use "withPhpLevel()" instead, it raises PHP level one rule at a time.')]
     public function withPhp56Sets(): self
     {
-        return $this->addPhpLevelSets(PhpVersion::PHP_56);
+        return $this->reportDeprecatedPhpSetsMethod(__FUNCTION__);
     }
 
+    #[Deprecated(message: 'Use "withPhpLevel()" instead, it raises PHP level one rule at a time.')]
     public function withPhp70Sets(): self
     {
-        return $this->addPhpLevelSets(PhpVersion::PHP_70);
+        return $this->reportDeprecatedPhpSetsMethod(__FUNCTION__);
     }
 
+    #[Deprecated(message: 'Use "withPhpLevel()" instead, it raises PHP level one rule at a time.')]
     public function withPhp71Sets(): self
     {
-        return $this->addPhpLevelSets(PhpVersion::PHP_71);
+        return $this->reportDeprecatedPhpSetsMethod(__FUNCTION__);
     }
 
+    #[Deprecated(message: 'Use "withPhpLevel()" instead, it raises PHP level one rule at a time.')]
     public function withPhp72Sets(): self
     {
-        return $this->addPhpLevelSets(PhpVersion::PHP_72);
+        return $this->reportDeprecatedPhpSetsMethod(__FUNCTION__);
     }
 
+    #[Deprecated(message: 'Use "withPhpLevel()" instead, it raises PHP level one rule at a time.')]
     public function withPhp73Sets(): self
     {
-        return $this->addPhpLevelSets(PhpVersion::PHP_73);
+        return $this->reportDeprecatedPhpSetsMethod(__FUNCTION__);
     }
 
+    #[Deprecated(message: 'Use "withPhpLevel()" instead, it raises PHP level one rule at a time.')]
     public function withPhp74Sets(): self
     {
-        return $this->addPhpLevelSets(PhpVersion::PHP_74);
+        return $this->reportDeprecatedPhpSetsMethod(__FUNCTION__);
     }
 
     // there is no withPhp80Sets() and above,
@@ -1189,6 +1194,13 @@ final class RectorConfigBuilder
         $this->isWithPhpSetsUsed = true;
 
         $this->sets = array_merge($this->sets, PhpLevelSetResolver::resolveFromPhpVersion($phpVersion));
+
+        return $this;
+    }
+
+    private function reportDeprecatedPhpSetsMethod(string $methodName): self
+    {
+        SimpleParameterProvider::addParameter(Option::DEPRECATED_PHP_SETS_METHODS, $methodName);
 
         return $this;
     }

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -185,6 +185,7 @@ EOF
         $this->deprecatedRulesReporter->reportDeprecatedSkippedRules();
         $this->deprecatedRulesReporter->reportDeprecatedRectorUnsupportedMethods();
         $this->deprecatedRulesReporter->reportDeprecatedCacheMetaExtensions();
+        $this->deprecatedRulesReporter->reportDeprecatedPhpSetsMethods();
 
         $this->missConfigurationReporter->reportSkippedNeverRegisteredRules();
         $this->missConfigurationReporter->reportUnusedSkips($processResult);

--- a/src/Console/Notifier.php
+++ b/src/Console/Notifier.php
@@ -35,7 +35,7 @@ final class Notifier
         }
 
         throw new InvalidConfigurationException(
-            'The "->withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. Use more explicit "->withPhp53Sets()" ... "->withPhp74Sets()" in lower PHP versions instead.'
+            'The "->withPhpSets()" method uses named arguments. Its suitable for PHP 8.0+. Use "->withPhpLevel()" in lower PHP versions instead.'
         );
     }
 }

--- a/src/Reporting/DeprecatedRulesReporter.php
+++ b/src/Reporting/DeprecatedRulesReporter.php
@@ -69,6 +69,21 @@ final readonly class DeprecatedRulesReporter
         }
     }
 
+    public function reportDeprecatedPhpSetsMethods(): void
+    {
+        /** @var string[] $deprecatedPhpSetsMethods */
+        $deprecatedPhpSetsMethods = SimpleParameterProvider::provideArrayParameter(
+            Option::DEPRECATED_PHP_SETS_METHODS
+        );
+
+        foreach (array_unique($deprecatedPhpSetsMethods) as $deprecatedPhpSetsMethod) {
+            $this->symfonyStyle->warning(sprintf(
+                'The "->%s()" method is deprecated and no longer applied. Use "->withPhpLevel()" instead, to raise PHP level one rule at a time.',
+                $deprecatedPhpSetsMethod
+            ));
+        }
+    }
+
     public function reportDeprecatedRectorUnsupportedMethods(): void
     {
         // to be added in related PR


### PR DESCRIPTION
The 9 `withPhp53Sets()` ... `withPhp74Sets()` methods existed only as a PHP 7.4-compatible workaround for `withPhpSets()`, which uses named arguments and therefore requires PHP 8.0+.

`withPhpLevel()` covers the same need with a positional argument, so it runs on PHP 7.4 too, and it raises the PHP level one rule at a time instead of enabling every set at once.

The methods are kept and marked `@deprecated`. They no longer add any sets, they only report a warning.

```diff
 return RectorConfig::configure()
     ->withPaths([__DIR__ . '/src'])
-    ->withPhp74Sets();
+    ->withPhpLevel(20);
```

Warning reported on run:

```
 [WARNING] The "->withPhp74Sets()" method is deprecated and no longer applied. Use
           "->withPhpLevel()" instead, to raise PHP level one rule at a time.
```

`Notifier::errorWithPhpSetsNotSuitableForPHP74AndLower()` pointed users at the now-deprecated methods, so its message points to `withPhpLevel()` instead.