### PR TITLE
[Configuration] Load single composer-based PHPUnit set in withComposerBased()

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -739,7 +739,6 @@ final class RectorConfigBuilder
         $setMap = [
             SetGroup::TWIG => $twig,
             SetGroup::DOCTRINE => $doctrine,
-            SetGroup::PHPUNIT => $phpunit,
             SetGroup::SYMFONY => $symfony,
             SetGroup::NETTE_UTILS => $netteUtils,
             SetGroup::LARAVEL => $laravel,
@@ -750,6 +749,11 @@ final class RectorConfigBuilder
             if ($isEnabled) {
                 $this->setGroups[] = $setPath;
             }
+        }
+
+        if ($phpunit) {
+            // single set, as every rule inside is bound to the installed PHPUnit version on its own
+            $this->sets[] = PHPUnitSetList::COMPOSER_BASED;
         }
 
         return $this;


### PR DESCRIPTION
`withComposerBased(phpunit: true)` went through the set group machinery: `SetGroup::PHPUNIT` -> `SetProviderCollector` -> `SetManager::matchBySetGroups()` -> installed package resolving -> every matching `phpunit40.php` ... `phpunit130.php` set **plus** `composer-based.php`.

The `composer-based.php` set already binds each rule and rule configuration to the installed `phpunit/phpunit` version on its own, via `ComposerPackageConstraintInterface` and `ruleWithConfigurationComposerVersionBound()`. So the group lookup and the per-version sets are not needed - a single set include is enough.

```diff
 $setMap = [
     SetGroup::TWIG => $twig,
     SetGroup::DOCTRINE => $doctrine,
-    SetGroup::PHPUNIT => $phpunit,
     SetGroup::SYMFONY => $symfony,
     ...
 ];

+if ($phpunit) {
+    $this->sets[] = PHPUnitSetList::COMPOSER_BASED;
+}
```

Behavior for the user stays the same:

```php
return RectorConfig::configure()
    ->withComposerBased(phpunit: true);
```

```diff
 final class SomeTest extends TestCase
 {
-    /**
-     * @dataProvider provideData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
     public function test(): void
     {
     }
 }
```