### PR TITLE
[DeadCode] Remove whole assign statement on unused createStub() in tests

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/create_stub_in_test.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/create_stub_in_test.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class CreateStubInTest extends TestCase
+{
+    public function test($params)
+    {
+        $user = $this->createStub('SomeClass');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class CreateStubInTest extends TestCase
+{
+    public function test($params)
+    {
+    }
+}
+
+?>

--- a/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
+++ b/rules/DeadCode/SideEffect/SideEffectNodeDetector.php
@@ -96,7 +96,7 @@ final readonly class SideEffectNodeDetector
             return false;
         }
 
-        return $this->nodeNameResolver->isName($node->name, 'createMock');
+        return $this->nodeNameResolver->isNames($node->name, ['createMock', 'createStub']);
     }
 
     private function isPhpParser(New_ $new): bool


### PR DESCRIPTION
`SideEffectNodeDetector` already treats `createMock()` inside a `PHPUnit\Framework\TestCase` as side-effect free, so `RemoveUnusedVariableAssignRector` removes the whole statement. `createStub()` was not covered, so only the variable was dropped and a dangling call was left behind.

Before:

```diff
 final class SomeTest extends TestCase
 {
     public function test()
     {
-        $user = $this->createStub(User::class);
+        $this->createStub(User::class);
     }
 }
```

After:

```diff
 final class SomeTest extends TestCase
 {
     public function test()
     {
-        $user = $this->createStub(User::class);
     }
 }
```