### PR TITLE
[Configuration] Load single composer-based Symfony set in withComposerBased()

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -739,7 +739,6 @@ final class RectorConfigBuilder
         $setMap = [
             SetGroup::TWIG => $twig,
             SetGroup::DOCTRINE => $doctrine,
-            SetGroup::SYMFONY => $symfony,
             SetGroup::NETTE_UTILS => $netteUtils,
             SetGroup::LARAVEL => $laravel,
             SetGroup::DRUPAL => $drupal,
@@ -754,6 +753,11 @@ final class RectorConfigBuilder
         if ($phpunit) {
             // single set, as every rule inside is bound to the installed PHPUnit version on its own
             $this->sets[] = PHPUnitSetList::COMPOSER_BASED;
+        }
+
+        if ($symfony) {
+            // single set, as every rule inside is bound to the installed Symfony package version on its own
+            $this->sets[] = SymfonySetList::COMPOSER_BASED;
         }
 
         return $this;


### PR DESCRIPTION
Same treatment as PHPUnit in #8255: `withComposerBased(symfony: true)` now loads the single composer-based Symfony set instead of the whole `SetGroup::SYMFONY` group.

Every rule in that set declares the exact Symfony package + version its target API was added in, so there is no need to load all version sets and let them overlap.

```diff
 if ($phpunit) {
     // single set, as every rule inside is bound to the installed PHPUnit version on its own
     $this->sets[] = PHPUnitSetList::COMPOSER_BASED;
 }
+
+if ($symfony) {
+    // single set, as every rule inside is bound to the installed Symfony package version on its own
+    $this->sets[] = SymfonySetList::COMPOSER_BASED;
+}
```

**Blocked until** `SymfonySetList::COMPOSER_BASED` lands in `rector-symfony` dev-main - CI is red until then.
