### PR TITLE
[NodeAnalyzer] Detect always terminated stmts with statements before the return

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_if_else_with_stmts_before_return.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_if_else_with_stmts_before_return.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class AlwaysTerminatedIfElseWithStmtsBeforeReturn
+{
+    public function run($a)
+    {
+        if ($a) {
+            echo 'if';
+            return 'A';
+        } else {
+            echo 'else';
+            return 'B';
+        }
+
+        echo 'never executed';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class AlwaysTerminatedIfElseWithStmtsBeforeReturn
+{
+    public function run($a)
+    {
+        if ($a) {
+            echo 'if';
+            return 'A';
+        } else {
+            echo 'else';
+            return 'B';
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_switch_with_stmts_before_return.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_switch_with_stmts_before_return.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class AlwaysTerminatedSwitchWithStmtsBeforeReturn
+{
+    public function run($a)
+    {
+        switch ($a) {
+            case 'a':
+                echo 'a';
+                return 'A';
+            default:
+                echo 'default';
+                return 'B';
+        }
+
+        echo 'never executed';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class AlwaysTerminatedSwitchWithStmtsBeforeReturn
+{
+    public function run($a)
+    {
+        switch ($a) {
+            case 'a':
+                echo 'a';
+                return 'A';
+            default:
+                echo 'default';
+                return 'B';
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_try_catch_with_stmts_before_return.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_try_catch_with_stmts_before_return.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+
+class AlwaysTerminatedTryCatchWithStmtsBeforeReturn
+{
+    public function run()
+    {
+        try {
+            echo 'try';
+            return something();
+        } catch (Exception $e) {
+            echo 'catch';
+            return null;
+        }
+
+        echo 'never executed';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+
+class AlwaysTerminatedTryCatchWithStmtsBeforeReturn
+{
+    public function run()
+    {
+        try {
+            echo 'try';
+            return something();
+        } catch (Exception $e) {
+            echo 'catch';
+            return null;
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_switch_case_nested_loop_break.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_switch_case_nested_loop_break.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+final class SkipSwitchCaseNestedLoopBreak
+{
+    public function run($a, array $items)
+    {
+        switch ($a) {
+            case 'a':
+                foreach ($items as $item) {
+                    break;
+                }
+
+                return 'A';
+            default:
+                return 'B';
+        }
+
+        echo 'kept, as break targets are not resolved';
+    }
+}

--- a/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Exit_;
 use PhpParser\Node\Expr\Throw_;
+use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\ClassLike;
@@ -25,9 +26,11 @@ use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\TryCatch;
+use PhpParser\NodeVisitor;
+use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpParser\Node\FileNode;
 
-final class TerminatedNodeAnalyzer
+final readonly class TerminatedNodeAnalyzer
 {
     /**
      * @var array<class-string<Node>>
@@ -43,6 +46,11 @@ final class TerminatedNodeAnalyzer
      * @var array<class-string<Node>>
      */
     private const array ALLOWED_CONTINUE_CURRENT_STMTS = [InlineHTML::class, Nop::class];
+
+    public function __construct(
+        private SimpleCallableNodeTraverser $simpleCallableNodeTraverser
+    ) {
+    }
 
     /**
      * @param StmtsAware $stmtsAware
@@ -62,18 +70,18 @@ final class TerminatedNodeAnalyzer
         }
 
         if ($node instanceof TryCatch) {
-            return $this->isTerminatedInLastStmtsTryCatch($node, $currentStmt);
+            return $this->isTerminatedInLastStmtsTryCatch($node);
         }
 
         if ($node instanceof If_) {
-            return $this->isTerminatedInLastStmtsIf($node, $currentStmt);
+            return $this->isTerminatedInLastStmtsIf($node);
         }
 
         /** @var Switch_ $node */
-        return $this->isTerminatedInLastStmtsSwitch($node, $currentStmt);
+        return $this->isTerminatedInLastStmtsSwitch($node);
     }
 
-    private function isTerminatedNode(Node $previousNode, Node $currentStmt): bool
+    private function isTerminatedNode(Stmt $previousNode, Stmt $currentStmt): bool
     {
         if (in_array($previousNode::class, self::TERMINABLE_NODES, true)) {
             return true;
@@ -90,9 +98,14 @@ final class TerminatedNodeAnalyzer
         return false;
     }
 
-    private function isTerminatedInLastStmtsSwitch(Switch_ $switch, Stmt $stmt): bool
+    private function isTerminatedInLastStmtsSwitch(Switch_ $switch): bool
     {
         if ($switch->cases === []) {
+            return false;
+        }
+
+        // a break/continue jumps out of the Switch_, so the next stmt is still executable
+        if ($this->hasEscapingJump($switch)) {
             return false;
         }
 
@@ -106,7 +119,7 @@ final class TerminatedNodeAnalyzer
                 continue;
             }
 
-            if (! $this->isTerminatedInLastStmts($case->stmts, $stmt)) {
+            if (! $this->isTerminatedInLastStmts($case->stmts)) {
                 return false;
             }
         }
@@ -114,25 +127,52 @@ final class TerminatedNodeAnalyzer
         return $hasDefault;
     }
 
-    private function isTerminatedInLastStmtsTryCatch(TryCatch $tryCatch, Stmt $stmt): bool
+    private function hasEscapingJump(Switch_ $switch): bool
     {
-        if ($tryCatch->finally instanceof Finally_ && $this->isTerminatedInLastStmts(
-            $tryCatch->finally->stmts,
-            $stmt
-        )) {
+        $hasEscapingJump = false;
+
+        foreach ($switch->cases as $case) {
+            $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
+                $case->stmts,
+                static function (Node $node) use (&$hasEscapingJump): ?int {
+                    // nested scopes bring their own jump targets
+                    if ($node instanceof FunctionLike || $node instanceof ClassLike) {
+                        return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                    }
+
+                    if (! $node instanceof Break_ && ! $node instanceof Continue_ && ! $node instanceof Goto_) {
+                        return null;
+                    }
+
+                    $hasEscapingJump = true;
+                    return NodeVisitor::STOP_TRAVERSAL;
+                }
+            );
+
+            if ($hasEscapingJump) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isTerminatedInLastStmtsTryCatch(TryCatch $tryCatch): bool
+    {
+        if ($tryCatch->finally instanceof Finally_ && $this->isTerminatedInLastStmts($tryCatch->finally->stmts)) {
             return true;
         }
 
         foreach ($tryCatch->catches as $catch) {
-            if (! $this->isTerminatedInLastStmts($catch->stmts, $stmt)) {
+            if (! $this->isTerminatedInLastStmts($catch->stmts)) {
                 return false;
             }
         }
 
-        return $this->isTerminatedInLastStmts($tryCatch->stmts, $stmt);
+        return $this->isTerminatedInLastStmts($tryCatch->stmts);
     }
 
-    private function isTerminatedInLastStmtsIf(If_ $if, Stmt $stmt): bool
+    private function isTerminatedInLastStmtsIf(If_ $if): bool
     {
         // Without ElseIf_[] and Else_, after If_ is possibly executable
         if ($if->elseifs === [] && ! $if->else instanceof Else_) {
@@ -140,12 +180,12 @@ final class TerminatedNodeAnalyzer
         }
 
         foreach ($if->elseifs as $elseif) {
-            if (! $this->isTerminatedInLastStmts($elseif->stmts, $stmt)) {
+            if (! $this->isTerminatedInLastStmts($elseif->stmts)) {
                 return false;
             }
         }
 
-        if (! $this->isTerminatedInLastStmts($if->stmts, $stmt)) {
+        if (! $this->isTerminatedInLastStmts($if->stmts)) {
             return false;
         }
 
@@ -153,13 +193,13 @@ final class TerminatedNodeAnalyzer
             return false;
         }
 
-        return $this->isTerminatedInLastStmts($if->else->stmts, $stmt);
+        return $this->isTerminatedInLastStmts($if->else->stmts);
     }
 
     /**
      * @param Stmt[] $stmts
      */
-    private function isTerminatedInLastStmts(array $stmts, Node $node): bool
+    private function isTerminatedInLastStmts(array $stmts): bool
     {
         if ($stmts === []) {
             return false;
@@ -167,10 +207,6 @@ final class TerminatedNodeAnalyzer
 
         $lastKey = array_key_last($stmts);
         $lastNode = $stmts[$lastKey];
-
-        if (isset($stmts[$lastKey - 1]) && ! $this->isTerminatedNode($stmts[$lastKey - 1], $node)) {
-            return false;
-        }
 
         if ($lastNode instanceof Expression) {
             return $lastNode->expr instanceof Exit_ || $lastNode->expr instanceof Throw_;


### PR DESCRIPTION
`TerminatedNodeAnalyzer` bailed out whenever the **second-to-last** statement of a `try`/`catch`, `if`/`else` or `switch` branch was not itself a terminator:

```php
if (isset($stmts[$lastKey - 1]) && ! $this->isTerminatedNode($stmts[$lastKey - 1], $node)) {
    return false;
}
```

That guard came from #6837, to stop a `break` inside a switch case being read as always terminated. It is too broad: any branch that does real work before its `return` trips it.

This moves the check to the `Switch_` branch, where a `break`/`continue` genuinely escapes to the statement after the switch. The generic path now only looks at the last statement, as intended.

## Effect

`RemoveUnreachableStatementRector` now sees through branches that do work before returning:

```diff
 try {
     echo 'try';
     return something();
 } catch (Exception $e) {
     echo 'catch';
     return null;
 }
-
-echo 'never executed';
```

Bare-return branches already worked; only the ones with preceding statements were missed.

## Downstream

This also fixes `ConsoleExecuteReturnIntRector` in rector-symfony appending a second, unreachable `return 0;`:

```php
public function execute(InputInterface $input, OutputInterface $output)
{
    try {
        $output->writeln('working');
        return 0;
    } catch (\Exception $exception) {
        $output->writeln($exception->getMessage());
        return 1;
    }
}
```

```diff
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $output->writeln('working');
             return 0;
         } catch (\Exception $exception) {
             $output->writeln($exception->getMessage());
             return 1;
         }
-        return 0;
     }
```

## Notes

- `#6837`'s `skip_switch_break_not_unreachable.php.inc` still passes.
- The escaping-jump lookup descends into nested loops, so a `break` belonging to an inner loop still counts as escaping. That stays conservative (skip rather than remove) and matches the previous behaviour; `skip_switch_case_nested_loop_break.php.inc` locks it in.
- `isTerminatedNode()` params narrowed to `Stmt`, as `type-perfect` requires once the generic call site is gone.