### PR TITLE
[DeadCode] Skip RemoveDefaultValueFromAssignedPropertyRector on early return in constructor-called method

### DIFF
--- a/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_early_return_in_called_method.php.inc
+++ b/rules-tests/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector/Fixture/skip_early_return_in_called_method.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Property\RemoveDefaultValueFromAssignedPropertyRector\Fixture;
+
+final class SkipEarlyReturnInCalledMethod
+{
+    private array $unknownLeadIds = [];
+
+    public function __construct(
+        private readonly array $campaignMembers,
+    ) {
+        $this->fetchLeads();
+    }
+
+    private function fetchLeads(): void
+    {
+        if ($this->campaignMembers === []) {
+            return;
+        }
+
+        $this->unknownLeadIds = $this->campaignMembers;
+    }
+}

--- a/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
+++ b/rules/DeadCode/Rector/Property/RemoveDefaultValueFromAssignedPropertyRector.php
@@ -8,8 +8,10 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use Rector\Configuration\Parameter\FeatureFlags;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
@@ -85,7 +87,7 @@ CODE_SAMPLE
         }
 
         // early return can skip the assign, so the default value is still needed
-        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($constructClassMethod, Return_::class)) {
+        if ($this->hasEarlyReturn($node, $constructClassMethod)) {
             return null;
         }
 
@@ -136,6 +138,47 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    /**
+     * The constructor itself, or any local method it calls, can skip the assign with an early return
+     */
+    private function hasEarlyReturn(Class_ $class, ClassMethod $constructClassMethod): bool
+    {
+        if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($constructClassMethod, Return_::class)) {
+            return true;
+        }
+
+        foreach ((array) $constructClassMethod->stmts as $stmt) {
+            if (! $stmt instanceof Expression) {
+                continue;
+            }
+
+            if (! $stmt->expr instanceof MethodCall) {
+                continue;
+            }
+
+            $methodCall = $stmt->expr;
+            if (! $this->isName($methodCall->var, 'this')) {
+                continue;
+            }
+
+            $methodName = $this->getName($methodCall->name);
+            if ($methodName === null) {
+                continue;
+            }
+
+            $calledClassMethod = $class->getMethod($methodName);
+            if (! $calledClassMethod instanceof ClassMethod) {
+                continue;
+            }
+
+            if ($this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($calledClassMethod, Return_::class)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function isAssignedViaArrayDimFetch(Class_ $class, string $propertyName): bool


### PR DESCRIPTION
`RemoveDefaultValueFromAssignedPropertyRector` already bails out when the constructor itself contains a `return`, since the assign can be skipped. But the property may also be assigned in a method *called* from the constructor - and that method can early return too.

Reported on this real-world case (Mautic `Fetcher`), where `[]` was wrongly removed from `$unknownLeadIds` / `$unknownContactIds`:

```diff
 class Fetcher
 {
-    private array $unknownLeadIds = [];
+    private array $unknownLeadIds;

     public function __construct(...)
     {
         $this->fetchLeads();
     }

     private function fetchLeads(): void
     {
         if (!$campaignMembers = $this->organizer->getLeadIds()) {
             return; // <-- assign never happens, property stays uninitialized
         }

         // ...
         $this->unknownLeadIds = array_values(array_diff($campaignMembers, $this->knownLeadIds));
     }
 }
```

After the change the whole class is skipped, as `fetchLeads()` may return before the assign.