### PR TITLE
[DeadCode] Skip RecastingRemovalRector on array dim fetch value

### DIFF
--- a/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/skip_array_dim_fetch.php.inc
+++ b/rules-tests/DeadCode/Rector/Cast/RecastingRemovalRector/Fixture/skip_array_dim_fetch.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Cast\RecastingRemovalRector\Fixture;
+
+class SkipArrayDimFetch
+{
+    public function run()
+    {
+        $list = ['id' => 1, 'name' => 'Tom'];
+
+        $id = (int) $list['id'];
+        $name = (string) $list['name'];
+
+        return [$id, $name];
+    }
+}

--- a/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
+++ b/rules/DeadCode/Rector/Cast/RecastingRemovalRector.php
@@ -6,6 +6,7 @@ namespace Rector\DeadCode\Rector\Cast;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Cast;
 use PhpParser\Node\Expr\Cast\Array_;
 use PhpParser\Node\Expr\Cast\Bool_;
@@ -143,6 +144,11 @@ CODE_SAMPLE
 
     private function shouldSkip(Expr $expr): bool
     {
+        // array dim fetch value can be anything, the type is often inaccurate
+        if ($expr instanceof ArrayDimFetch) {
+            return true;
+        }
+
         $type = $this->getType($expr);
 
         if ($type instanceof UnionType) {


### PR DESCRIPTION
Array dim fetch values can hold anything at runtime. PHPStan often reports a narrow type (e.g. `int[]`) where the real type is `mixed[]`, so removing the cast changes behavior.

```diff
 $list = ['id' => 1, 'name' => 'Tom'];

-$id = (int) $list['id'];
-$name = (string) $list['name'];
+$id = $list['id'];
+$name = $list['name'];
```

Now skipped.