### PR TITLE
[Testing] Allow a test case to resolve package versions from a standalone composer.json

### DIFF
--- a/src/Composer/InstalledPackageResolver.php
+++ b/src/Composer/InstalledPackageResolver.php
@@ -33,12 +33,30 @@ final class InstalledPackageResolver
 
     private readonly string $projectDirectory;
 
-    public function __construct(?string $projectDirectory = null)
-    {
+    /**
+     * @param null|string $composerJsonFilePath a standalone "composer.json" to read the versions from, instead of the
+     *                                          installed packages; used to test rules bonded to a composer package
+     */
+    public function __construct(
+        ?string $projectDirectory = null,
+        private ?string $composerJsonFilePath = null
+    ) {
         // fallback to root project directory
         $this->projectDirectory = $projectDirectory ?? (string) getcwd();
 
         Assert::directory($this->projectDirectory);
+    }
+
+    /**
+     * @api used in tests to resolve the versions from a standalone "composer.json"
+     */
+    public function changeComposerJsonFilePath(?string $composerJsonFilePath): void
+    {
+        $this->composerJsonFilePath = $composerJsonFilePath;
+
+        // the previous file is no longer the source, drop what was read from it
+        $this->resolvedInstalledPackages = null;
+        $this->projectComposerJson = null;
     }
 
     /**
@@ -49,6 +67,10 @@ final class InstalledPackageResolver
         // already cached, even only empty array
         if ($this->resolvedInstalledPackages !== null) {
             return $this->resolvedInstalledPackages;
+        }
+
+        if ($this->composerJsonFilePath !== null) {
+            return $this->resolvedInstalledPackages = $this->createPackagesFromConstraints();
         }
 
         $installedPackagesFilePath = $this->resolveVendorDir() . '/composer/installed.json';
@@ -106,6 +128,27 @@ final class InstalledPackageResolver
     }
 
     /**
+     * There is no vendor to read the installed versions from, so the constraints themselves are the only source
+     *
+     * @return array<string, InstalledPackage>
+     */
+    private function createPackagesFromConstraints(): array
+    {
+        $installedPackages = [];
+
+        foreach ($this->resolvePackageConstraints() as $packageName => $constraint) {
+            $version = $this->resolveConstraintLowestVersion($constraint);
+            if ($version === null) {
+                continue;
+            }
+
+            $installedPackages[$packageName] = new InstalledPackage($packageName, $version);
+        }
+
+        return $installedPackages;
+    }
+
+    /**
      * @return null|string the lowest version allowed by the constraint, if the installed version is out of it
      */
     private function matchConstraintVersion(string $installedVersion, string $constraint): ?string
@@ -114,7 +157,20 @@ final class InstalledPackageResolver
             if (Semver::satisfies($installedVersion, $constraint)) {
                 return null;
             }
+        } catch (UnexpectedValueException) {
+            // non-comparable version or constraint, e.g. a dev one
+            return null;
+        }
 
+        return $this->resolveConstraintLowestVersion($constraint);
+    }
+
+    /**
+     * @return null|string the lowest version the constraint allows, null if there is no comparable one
+     */
+    private function resolveConstraintLowestVersion(string $constraint): ?string
+    {
+        try {
             $lowestVersion = new VersionParser()
                 ->parseConstraints($constraint)
                 ->getLowerBound()
@@ -171,7 +227,7 @@ final class InstalledPackageResolver
             return $this->projectComposerJson;
         }
 
-        $projectComposerJsonFilePath = $this->projectDirectory . '/composer.json';
+        $projectComposerJsonFilePath = $this->composerJsonFilePath ?? $this->projectDirectory . '/composer.json';
         if (! file_exists($projectComposerJsonFilePath)) {
             return $this->projectComposerJson = [];
         }

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 use Rector\Application\ApplicationFileProcessor;
 use Rector\Autoloading\AdditionalAutoloader;
 use Rector\Autoloading\BootstrapFilesIncluder;
+use Rector\Composer\InstalledPackageResolver;
 use Rector\Configuration\ConfigurationFactory;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
@@ -77,6 +78,16 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
         $cacheKey = sha1($configFile . static::class);
 
         if (! isset(self::$cacheByRuleAndConfig[$cacheKey])) {
+            // rules bonded to a composer package are filtered out unless the package is installed.
+            // the composer package constraint filter keeps the very first resolver it is given, so the binding must
+            // stay untouched; only the file it reads changes, on every test case, so it never leaks to the next one
+            if (! $rectorConfig->bound(InstalledPackageResolver::class)) {
+                $rectorConfig->singleton(InstalledPackageResolver::class);
+            }
+
+            $rectorConfig->make(InstalledPackageResolver::class)
+                ->changeComposerJsonFilePath($this->provideComposerJsonFilePath());
+
             // reset
             /** @var RewindableGenerator<int, ResettableInterface> $resettables */
             $resettables = $rectorConfig->tagged(ResettableInterface::class);
@@ -131,6 +142,18 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
     protected static function yieldFilesFromDirectory(string $directory, string $suffix = '*.php.inc'): Iterator
     {
         return FixtureFileFinder::yieldDirectory($directory, $suffix);
+    }
+
+    /**
+     * Override to test a rule that implements @see \Rector\VersionBonding\Contract\ComposerPackageConstraintInterface
+     * against a package that is not installed. The versions are read from the "require" and "require-dev" sections of
+     * the provided "composer.json", instead of the installed packages.
+     *
+     * @api used by extensions
+     */
+    protected function provideComposerJsonFilePath(): ?string
+    {
+        return null;
     }
 
     protected function doTestFile(string $fixtureFilePath, bool $includeFixtureDirectoryAsSource = false): void

--- a/tests/Composer/Fixture/InstalledPackageResolver/standalone_composer_json/composer.json
+++ b/tests/Composer/Fixture/InstalledPackageResolver/standalone_composer_json/composer.json
@@ -1,0 +1,10 @@
+{
+    "require": {
+        "symfony/framework-bundle": "^2.6",
+        "nette/utils": ">=3.2",
+        "webmozart/assert": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    }
+}

--- a/tests/Composer/InstalledPackageResolverTest.php
+++ b/tests/Composer/InstalledPackageResolverTest.php
@@ -46,4 +46,38 @@ final class InstalledPackageResolverTest extends TestCase
         // not required in the "composer.json" at all
         $this->assertSame('1.11.0.0', $installedPackageResolver->resolvePackageVersion('webmozart/assert'));
     }
+
+    public function testStandaloneComposerJsonResolvesVersionsWithoutVendor(): void
+    {
+        $installedPackageResolver = new InstalledPackageResolver(
+            null,
+            __DIR__ . '/Fixture/InstalledPackageResolver/standalone_composer_json/composer.json'
+        );
+
+        // the package is not installed anywhere, the constraint is the only source
+        $this->assertSame('2.6.0.0', $installedPackageResolver->resolvePackageVersion('symfony/framework-bundle'));
+
+        // require-dev is respected as well
+        $this->assertSame('10.5.0.0', $installedPackageResolver->resolvePackageVersion('phpunit/phpunit'));
+
+        // an open constraint has no lowest version to fall back to
+        $this->assertNull($installedPackageResolver->resolvePackageVersion('webmozart/assert'));
+
+        // not required in the "composer.json" at all
+        $this->assertNull($installedPackageResolver->resolvePackageVersion('symfony/console'));
+    }
+
+    public function testChangeComposerJsonFilePathDropsPreviousVersions(): void
+    {
+        $installedPackageResolver = new InstalledPackageResolver(getcwd());
+        $this->assertNull($installedPackageResolver->resolvePackageVersion('symfony/framework-bundle'));
+
+        $installedPackageResolver->changeComposerJsonFilePath(
+            __DIR__ . '/Fixture/InstalledPackageResolver/standalone_composer_json/composer.json'
+        );
+        $this->assertSame('2.6.0.0', $installedPackageResolver->resolvePackageVersion('symfony/framework-bundle'));
+
+        $installedPackageResolver->changeComposerJsonFilePath(null);
+        $this->assertNull($installedPackageResolver->resolvePackageVersion('symfony/framework-bundle'));
+    }
 }


### PR DESCRIPTION
A rule that implements `ComposerPackageConstraintInterface` is filtered out unless the bonded package is installed — `RectorNodeTraverser::prepareNodeVisitors()` applies `ComposerPackageConstraintFilter` unconditionally, so this hits the rule's own test run too. Every fixture then reports no change and the test fails.

That leaves an extension unable to test a rule bonded to a package it cannot add to `require-dev`. Concretely, in `rector-symfony` `RedirectToRouteRector` bonds to `symfony/framework-bundle`, which does not resolve against that repo's dev constraints at any major.

A test case can now name a standalone `composer.json` to read the versions from:

```php
final class RedirectToRouteRectorTest extends AbstractRectorTestCase
{
    // ...

    protected function provideComposerJsonFilePath(): ?string
    {
        return __DIR__ . '/config/composer.json';
    }
}
```

```json
{
    "require": {
        "symfony/framework-bundle": "^2.6"
    }
}
```

The `require` and `require-dev` constraints become the resolved versions, each one taking the lowest version it allows — `^2.6` resolves to `2.6.0.0`. No vendor directory is read in this mode. An open constraint such as `*` has no lowest version and stays unresolved, same as a package that is not listed at all.

## Notes

- `InstalledPackageResolver` gets an optional second constructor argument. Default behaviour is untouched: without it, versions still come from `vendor/composer/installed.json` with the `composer.json` constraints applied on top.
- The lower-bound logic is extracted from `matchConstraintVersion()` into `resolveConstraintLowestVersion()` and shared by both modes.
- `changeComposerJsonFilePath()` exists because `ComposerPackageConstraintFilter` keeps the first resolver it is handed for the whole process. The test case binds the resolver as a singleton once, then re-points it per test case, so a custom `composer.json` cannot leak into the next one. Re-binding the container entry instead would leave the filter holding a stale instance.

Verified against `rector-symfony`: with the rule bonded and this branch in place, its suite is green at 584 tests, including the 7 `RedirectToRouteRector` cases that fail without it.

`tests/Composer/InstalledPackageResolverTest` covers the new mode and the re-point. The 32 failures in the full suite are present on `main` as well and are unrelated.