### PR TITLE
[Config] Move 3 rules from coding style set to their proper sets

### DIFF
--- a/config/set/php53.php
+++ b/config/set/php53.php
@@ -6,9 +6,11 @@ use Rector\Config\RectorConfig;
 use Rector\Php53\Rector\FuncCall\DirNameFileConstantToDirConstantRector;
 use Rector\Php53\Rector\Ternary\TernaryToElvisRector;
 use Rector\Php53\Rector\Variable\ReplaceHttpServerVarsByServerRector;
+use Rector\Visibility\Rector\ClassMethod\ExplicitPublicClassMethodRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
+        ExplicitPublicClassMethodRector::class,
         TernaryToElvisRector::class,
         DirNameFileConstantToDirConstantRector::class,
         ReplaceHttpServerVarsByServerRector::class,

--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -75,6 +75,7 @@ use Rector\CodeQuality\Rector\Ternary\SwitchNegatedTernaryRector;
 use Rector\CodeQuality\Rector\Ternary\TernaryEmptyArrayArrayDimFetchToCoalesceRector;
 use Rector\CodeQuality\Rector\Ternary\TernaryImplodeToImplodeRector;
 use Rector\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector;
+use Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\Php52\Rector\Property\VarToPublicPropertyRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
@@ -126,6 +127,7 @@ final class CodeQualityLevel
         SimplifyDeMorganBinaryRector::class,
         NegatedAndsToPositiveOrsRector::class,
         SimplifyTautologyTernaryRector::class,
+        TernaryConditionVariableAssignmentRector::class,
         SingleInArrayToCompareRector::class,
         TernaryImplodeToImplodeRector::class,
         ConsecutiveNullCompareReturnsToNullCoalesceQueueRector::class,

--- a/src/Config/Level/CodingStyleLevel.php
+++ b/src/Config/Level/CodingStyleLevel.php
@@ -6,7 +6,6 @@ namespace Rector\Config\Level;
 
 use Rector\CodingStyle\Rector\Assign\SplitDoubleAssignRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
-use Rector\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector;
 use Rector\CodingStyle\Rector\ClassConst\SplitGroupedClassConstantsRector;
 use Rector\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector;
 use Rector\CodingStyle\Rector\ClassMethod\BinaryOpStandaloneAssignsToDirectRector;
@@ -28,13 +27,11 @@ use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\CodingStyle\Rector\Stmt\RemoveUselessAliasInUseStatementRector;
 use Rector\CodingStyle\Rector\String_\SimplifyQuoteEscapeRector;
 use Rector\CodingStyle\Rector\String_\UseClassKeywordForClassNameResolutionRector;
-use Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector;
 use Rector\CodingStyle\Rector\Use_\SeparateMultiUseImportsRector;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php86\Rector\FuncCall\MinMaxToClampRector;
 use Rector\Transform\Rector\FuncCall\FuncCallToConstFetchRector;
-use Rector\Visibility\Rector\ClassMethod\ExplicitPublicClassMethodRector;
 
 /**
  * Key 0 = level 0
@@ -59,10 +56,8 @@ final class CodingStyleLevel
         SeparateMultiUseImportsRector::class,
         NewlineBetweenClassLikeStmtsRector::class,
         NewlineAfterStatementRector::class,
-        RemoveFinalFromConstRector::class,
         NullableCompareToNullRector::class,
         ConsistentImplodeRector::class,
-        TernaryConditionVariableAssignmentRector::class,
         SimplifyQuoteEscapeRector::class,
         StringClassNameToClassConstantRector::class,
         CatchExceptionNameMatchingTypeRector::class,
@@ -81,7 +76,6 @@ final class CodingStyleLevel
         UseClassKeywordForClassNameResolutionRector::class,
         SplitGroupedPropertiesRector::class,
         SplitGroupedClassConstantsRector::class,
-        ExplicitPublicClassMethodRector::class,
         RemoveUselessAliasInUseStatementRector::class,
         BinaryOpStandaloneAssignsToDirectRector::class,
         MinMaxToClampRector::class,

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Config\Level;
 
 use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
+use Rector\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\DeadCode\Rector\Array_\RemoveDuplicatedArrayKeyRector;
 use Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector;
@@ -108,6 +109,7 @@ final class DeadCodeLevel
         RemoveUselessReturnExprInConstructRector::class,
         ReplaceBlockToItsStmtsRector::class,
         RemoveFilterVarOnExactTypeRector::class,
+        RemoveFinalFromConstRector::class,
 
         RemoveTypedPropertyDeadInstanceOfRector::class,
         RemoveDeadInstanceOfAssertRector::class,

--- a/tests/Bridge/SetRectorsResolverTest.php
+++ b/tests/Bridge/SetRectorsResolverTest.php
@@ -45,7 +45,7 @@ final class SetRectorsResolverTest extends TestCase
         $rectorRulesWithConfiguration = $this->setRectorsResolver->resolveFromFilePathsIncludingConfiguration(
             $configFilePaths
         );
-        $this->assertCount(61, $rectorRulesWithConfiguration);
+        $this->assertCount(62, $rectorRulesWithConfiguration);
     }
 
     public function testResolveWithConfiguration(): void


### PR DESCRIPTION
These 3 rules are not coding style, but belong to other sets:

**1) `RemoveFinalFromConstRector` → dead code set**

The `final` on a constant of a `final` class is dead noise:

```diff
 final class SomeClass
 {
-    final public const NAME = 'value';
+    public const NAME = 'value';
 }
```

Placed in the "easy picks" group, as it removes a redundant keyword only.

**2) `ExplicitPublicClassMethodRector` → php 5.3 set**

Explicit visibility is a PHP 5 upgrade step, same family as `VarToPublicPropertyRector`:

```diff
 class SomeClass
 {
-    function run()
+    public function run()
     {
     }
 }
```

**3) `TernaryConditionVariableAssignmentRector` → code quality set**

Not a style choice, but a simplification, next to the other ternary rules:

```diff
 function ternary($value)
 {
-    $value ? $a = 1 : $a = 0;
+    $a = $value ? 1 : 0;
 }
```

The rule classes keep their current namespace, only the set registration moves. The `SetRectorsResolverTest` count is bumped, as the php 5.3 set has one more rule now.