### PR TITLE
[Configuration] Resolve --only rule name with shell-eaten backslashes

### DIFF
--- a/src/Configuration/OnlyRuleResolver.php
+++ b/src/Configuration/OnlyRuleResolver.php
@@ -63,6 +63,19 @@ final readonly class OnlyRuleResolver
         }
 
         if (! str_contains($rule, '\\')) {
+            // the shell has eaten unescaped backslashes, e.g. --only=\Rector\Some\Rule
+            $flattenMatching = [];
+            foreach ($this->rectors as $rector) {
+                if (str_replace('\\', '', $rector::class) === $rule) {
+                    $flattenMatching[] = $rector::class;
+                }
+            }
+
+            $flattenMatching = array_unique($flattenMatching);
+            if (count($flattenMatching) === 1) {
+                return $flattenMatching[0];
+            }
+
             $message = sprintf(
                 'Rule "%s" was not found.%sThe rule has no namespace. Make sure to escape the backslashes, and add quotes around the rule name: --only="My\\Rector\\Rule"',
                 $rule,

--- a/tests/Configuration/OnlyRuleResolverTest.php
+++ b/tests/Configuration/OnlyRuleResolverTest.php
@@ -64,13 +64,22 @@ final class OnlyRuleResolverTest extends AbstractLazyTestCase
 
     public function testResolveMissingBackslash(): void
     {
+        $this->assertSame(
+            RemoveDoubleAssignRector::class,
+            $this->onlyRuleResolver->resolve('RectorDeadCodeRectorAssignRemoveDoubleAssignRector'),
+            'The shell eats unescaped backslashes, resolve the flattened rule name anyway'
+        );
+    }
+
+    public function testResolveMissingBackslashNotFound(): void
+    {
         $this->expectExceptionMessageIsOrContains(
-            'Rule "RectorDeadCodeRectorAssignRemoveDoubleAssignRector" was not found.' . PHP_EOL
+            'Rule "ThisRuleDoesNotExist" was not found.' . PHP_EOL
                 . 'The rule has no namespace. Make sure to escape the backslashes, and add quotes around the rule name: --only="My\\Rector\\Rule"'
         );
         $this->expectException(RectorRuleNotFoundException::class);
 
-        $this->onlyRuleResolver->resolve('RectorDeadCodeRectorAssignRemoveDoubleAssignRector');
+        $this->onlyRuleResolver->resolve('ThisRuleDoesNotExist');
     }
 
     public function testResolveNotFound(): void


### PR DESCRIPTION
Running this in a shell fails, because zsh/bash strip the unescaped backslashes before Rector ever sees the argument:

```bash
bin/rector p --only \Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector
```

```
In OnlyRuleResolver.php line 61:

  Rule "RectorCodeQualityRectorFuncCallChangeArrayPushToArrayAssignRector" was not found.
  The rule has no namespace. Make sure to escape the backslashes, and add quotes around the rule name: --only="My\Rector\Rule"
```

The rule name is correct, only the separators are gone. This adds a last-resort fallback: when the passed name contains no backslash at all, compare it against registered rules with their backslashes stripped. If exactly one matches, use it.

```diff
-$ bin/rector p --only \Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector
-  Rule "RectorCodeQualityRectorFuncCallChangeArrayPushToArrayAssignRector" was not found.
+$ bin/rector p --only \Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector
+  [OK] Rector is done!
```

Ambiguous or unknown flattened names still throw the same errors as before.