### PR TITLE
[CodingStyle] Remove MinMaxToClampRector from coding style level

### DIFF
--- a/src/Config/Level/CodingStyleLevel.php
+++ b/src/Config/Level/CodingStyleLevel.php
@@ -27,7 +27,6 @@ use Rector\CodingStyle\Rector\String_\UseClassKeywordForClassNameResolutionRecto
 use Rector\CodingStyle\Rector\Use_\SeparateMultiUseImportsRector;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
-use Rector\Php86\Rector\FuncCall\MinMaxToClampRector;
 use Rector\Transform\Rector\FuncCall\FuncCallToConstFetchRector;
 
 /**
@@ -72,7 +71,6 @@ final class CodingStyleLevel
         SplitGroupedPropertiesRector::class,
         SplitGroupedClassConstantsRector::class,
         RemoveUselessAliasInUseStatementRector::class,
-        MinMaxToClampRector::class,
     ];
 
     /**


### PR DESCRIPTION
`MinMaxToClampRector` already lives in the `Rector\Php86\Rector\FuncCall` namespace and is registered in `config/set/php86.php`, but it was still listed in the coding style level.

It is a PHP version feature rule (`clamp()` is new in PHP 8.6, the rule implements `MinPhpVersionInterface`), not a coding style one. This removes it from `CodingStyleLevel` so it only ships via the php86 set.

The rule itself is unchanged:

```diff
-$value = min(max($value, $min), $max);
+$value = clamp($value, $min, $max);
```
