### PR TITLE
[CodingStyle] Remove ConsistentImplodeRector from coding style level, as already in PHP 8.0 set

### DIFF
--- a/src/Config/Level/CodingStyleLevel.php
+++ b/src/Config/Level/CodingStyleLevel.php
@@ -13,7 +13,6 @@ use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsPar
 use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
 use Rector\CodingStyle\Rector\FuncCall\CallUserFuncArrayToVariadicRector;
 use Rector\CodingStyle\Rector\FuncCall\CallUserFuncToMethodCallRector;
-use Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector;
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\CodingStyle\Rector\FuncCall\StrictArraySearchRector;
 use Rector\CodingStyle\Rector\FuncCall\StrictInArrayRector;
@@ -51,7 +50,6 @@ final class CodingStyleLevel
         SeparateMultiUseImportsRector::class,
         NewlineBetweenClassLikeStmtsRector::class,
         NewlineAfterStatementRector::class,
-        ConsistentImplodeRector::class,
         SimplifyQuoteEscapeRector::class,
         StringClassNameToClassConstantRector::class,
         CatchExceptionNameMatchingTypeRector::class,


### PR DESCRIPTION
`ConsistentImplodeRector` is registered in both `CodingStyleLevel` and the PHP 8.0 set. The rule is not a style preference - `implode($glue, $array)` argument order became the only supported one in PHP 8.0, as the swapped `implode($array, $glue)` signature was removed. So it belongs to the PHP 8.0 set only.

The rule stays where it already is, in `config/set/php80.php`:

```php
$rectorConfig->rules([
    // ...
    ConsistentImplodeRector::class,
]);
```

The change it makes:

```diff
-$itemsAsStrings = implode($items, '|');
+$itemsAsStrings = implode('|', $items);
```

Only the duplicate registration in `src/Config/Level/CodingStyleLevel.php` is dropped.
