### PR TITLE
[NetteUtils] Bind nette/utils rules to installed package version

### DIFF
--- a/config/set/nette-utils/composer-based.php
+++ b/config/set/nette-utils/composer-based.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\NetteUtils\Rector\StaticCall\UtilsJsonStaticCallNamedArgRector;
 
+// applies to any installed nette/utils version, the rules inside are bound
+// to the exact version they are available from
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([UtilsJsonStaticCallNamedArgRector::class]);
 };

--- a/rules/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector.php
+++ b/rules/NetteUtils/Rector/StaticCall/UtilsJsonStaticCallNamedArgRector.php
@@ -10,14 +10,25 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclarationDocblocks\Enum\NetteClassName;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\Tests\NetteUtils\Rector\StaticCall\UtilsJsonStaticCallNamedArgRector\UtilsJsonStaticCallNamedArgRectorTest
  */
-final class UtilsJsonStaticCallNamedArgRector extends AbstractRector
+final class UtilsJsonStaticCallNamedArgRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * The bool $pretty and bool $forceArrays params were added in nette/utils 4.0,
+     * before that both methods took int $flags
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('nette/utils', '>=4.0');
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Change `' . Json::class . '::encode()` and `decode()` to named args', [

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -739,7 +739,6 @@ final class RectorConfigBuilder
         $setMap = [
             SetGroup::TWIG => $twig,
             SetGroup::DOCTRINE => $doctrine,
-            SetGroup::NETTE_UTILS => $netteUtils,
             SetGroup::LARAVEL => $laravel,
             SetGroup::DRUPAL => $drupal,
         ];
@@ -758,6 +757,11 @@ final class RectorConfigBuilder
         if ($symfony) {
             // single set, as every rule inside is bound to the installed Symfony package version on its own
             $this->sets[] = SymfonySetList::COMPOSER_BASED;
+        }
+
+        if ($netteUtils) {
+            // single set, as every rule inside is bound to the installed nette/utils version on its own
+            $this->sets[] = SetList::NETTE_UTILS_COMPOSER_BASED;
         }
 
         return $this;

--- a/src/Set/Enum/SetGroup.php
+++ b/src/Set/Enum/SetGroup.php
@@ -36,11 +36,6 @@ final class SetGroup
     /**
      * Version-based set provider
      */
-    public const string NETTE_UTILS = 'nette-utils';
-
-    /**
-     * Version-based set provider
-     */
     public const string LARAVEL = 'laravel';
 
     /**

--- a/src/Set/SetProvider/CoreSetProvider.php
+++ b/src/Set/SetProvider/CoreSetProvider.php
@@ -29,11 +29,13 @@ final class CoreSetProvider implements SetProviderInterface
             new Set(SetGroup::CORE, 'Privatization', __DIR__ . '/../../../config/set/privatization.php'),
             new Set(SetGroup::CORE, 'Type Declarations', __DIR__ . '/../../../config/set/type-declaration.php'),
 
+            // applies to any installed nette/utils version, the rules inside are bound
+            // to the exact version they are available from
             new ComposerTriggeredSet(
                 SetGroup::NETTE_UTILS,
                 'nette/utils',
-                '4.0',
-                __DIR__ . '/../../../config/set/nette-utils/nette-utils4.php',
+                '>=2.0',
+                __DIR__ . '/../../../config/set/nette-utils/composer-based.php',
             ),
         ];
     }

--- a/src/Set/SetProvider/CoreSetProvider.php
+++ b/src/Set/SetProvider/CoreSetProvider.php
@@ -7,7 +7,6 @@ namespace Rector\Set\SetProvider;
 use Rector\Set\Contract\SetInterface;
 use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\Enum\SetGroup;
-use Rector\Set\ValueObject\ComposerTriggeredSet;
 use Rector\Set\ValueObject\Set;
 
 final class CoreSetProvider implements SetProviderInterface
@@ -28,15 +27,6 @@ final class CoreSetProvider implements SetProviderInterface
             new Set(SetGroup::CORE, 'Naming', __DIR__ . '/../../../config/set/naming.php'),
             new Set(SetGroup::CORE, 'Privatization', __DIR__ . '/../../../config/set/privatization.php'),
             new Set(SetGroup::CORE, 'Type Declarations', __DIR__ . '/../../../config/set/type-declaration.php'),
-
-            // applies to any installed nette/utils version, the rules inside are bound
-            // to the exact version they are available from
-            new ComposerTriggeredSet(
-                SetGroup::NETTE_UTILS,
-                'nette/utils',
-                '>=2.0',
-                __DIR__ . '/../../../config/set/nette-utils/composer-based.php',
-            ),
         ];
     }
 }

--- a/src/Set/ValueObject/SetList.php
+++ b/src/Set/ValueObject/SetList.php
@@ -31,6 +31,12 @@ final class SetList
     public const string NAMED_ARGS = __DIR__ . '/../../../config/set/named-args.php';
 
     /**
+     * Applies to any installed nette/utils version, the rules inside are bound
+     * to the exact version they are available from
+     */
+    public const string NETTE_UTILS_COMPOSER_BASED = __DIR__ . '/../../../config/set/nette-utils/composer-based.php';
+
+    /**
      * Opinionated rules that match rector coding standard
      */
     public const string RECTOR_PRESET = __DIR__ . '/../../../config/set/rector-preset.php';


### PR DESCRIPTION
Follows the approach of rectorphp/rector-symfony#979 for nette/utils.

Rules bound to a nette/utils version now declare the constraint themselves via `ComposerPackageConstraintInterface`, instead of relying on the version-named set they live in:

```php
final class UtilsJsonStaticCallNamedArgRector extends AbstractRector implements ComposerPackageConstraintInterface
{
    public function provideComposerPackageConstraint(): ComposerPackageConstraint
    {
        return new ComposerPackageConstraint('nette/utils', '>=4.0');
    }
}
```

The `bool $pretty` / `bool $forceArrays` params exist from nette/utils 4.0; before that both methods took `int $flags`, so the named args would produce broken code.

The `nette-utils4.php` set becomes `composer-based.php`, registered as a single set - same as PHPUnit and Symfony - as every rule inside is bound to the installed nette/utils version on its own:

```diff
         if ($symfony) {
             // single set, as every rule inside is bound to the installed Symfony package version on its own
             $this->sets[] = SymfonySetList::COMPOSER_BASED;
         }
+
+        if ($netteUtils) {
+            // single set, as every rule inside is bound to the installed nette/utils version on its own
+            $this->sets[] = SetList::NETTE_UTILS_COMPOSER_BASED;
+        }
```

With that, the `ComposerTriggeredSet` in `CoreSetProvider` and the now unused `SetGroup::NETTE_UTILS` group are dropped.

Side effect: the rule is also part of `named-args.php`, a plain set with no composer trigger. There it now skips itself on nette/utils 3 and lower, where it used to produce broken code:

```diff
 use Nette\Utils\Json;

-$encodedJson = Json::encode($data, true);
+$encodedJson = Json::encode($data, pretty: true);
```

Verified with `withComposerBased(netteUtils: true)`:

```
  Rule                                Package       Requires   Installed   Active
  UtilsJsonStaticCallNamedArgRector   nette/utils   >=4.0      4.1.5.0     yes
```