### PR TITLE
[Scripts] Add list-non-composer-based-rules.php script

### DIFF
--- a/scripts/list-non-composer-based-rules.php
+++ b/scripts/list-non-composer-based-rules.php
@@ -11,11 +11,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-// 1. find all rector rules in core and in doctrine, phpunit and symfony packages
+// 1. find all rector rules in doctrine, phpunit and symfony packages; core rules are not package-version bound
 $rectorClassFinder = new RectorClassFinder();
 
 $rectorClasses = $rectorClassFinder->find([
-    __DIR__ . '/../rules',
     __DIR__ . '/../vendor/rector/rector-doctrine',
     __DIR__ . '/../vendor/rector/rector-phpunit',
     __DIR__ . '/../vendor/rector/rector-symfony',
@@ -28,7 +27,6 @@ $symfonyStyle->writeln(sprintf('<fg=green>Found Rector %d rules</>', count($rect
 $rectorSetFilesFinder = new RectorSetFilesFinder();
 
 $rectorSetFiles = $rectorSetFilesFinder->find([
-    __DIR__ . '/../config/set',
     __DIR__ . '/../vendor/rector/rector-symfony/config/sets',
     __DIR__ . '/../vendor/rector/rector-doctrine/config/sets',
     __DIR__ . '/../vendor/rector/rector-phpunit/config/sets',

--- a/scripts/list-non-composer-based-rules.php
+++ b/scripts/list-non-composer-based-rules.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Scripts\Finder\RectorClassFinder;
+use Rector\Scripts\Finder\RectorSetFilesFinder;
+use Rector\Scripts\Resolver\UsedRectorClassResolver;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+// 1. find all rector rules in core and in doctrine, phpunit and symfony packages
+$rectorClassFinder = new RectorClassFinder();
+
+$rectorClasses = $rectorClassFinder->find([
+    __DIR__ . '/../rules',
+    __DIR__ . '/../vendor/rector/rector-doctrine',
+    __DIR__ . '/../vendor/rector/rector-phpunit',
+    __DIR__ . '/../vendor/rector/rector-symfony',
+]);
+
+$symfonyStyle = new SymfonyStyle(new ArrayInput([]), new ConsoleOutput());
+$symfonyStyle->writeln(sprintf('<fg=green>Found Rector %d rules</>', count($rectorClasses)));
+
+// 2. find "composer-based.php" sets, that bind rules to the installed package version
+$rectorSetFilesFinder = new RectorSetFilesFinder();
+
+$rectorSetFiles = $rectorSetFilesFinder->find([
+    __DIR__ . '/../config/set',
+    __DIR__ . '/../vendor/rector/rector-symfony/config/sets',
+    __DIR__ . '/../vendor/rector/rector-doctrine/config/sets',
+    __DIR__ . '/../vendor/rector/rector-phpunit/config/sets',
+]);
+
+$composerBasedSetFiles = array_filter(
+    $rectorSetFiles,
+    static fn (string $rectorSetFile): bool => basename($rectorSetFile) === 'composer-based.php'
+);
+
+$symfonyStyle->writeln(sprintf('<fg=green>Found %d composer-based sets</>', count($composerBasedSetFiles)));
+$symfonyStyle->listing($composerBasedSetFiles);
+
+$usedRectorClassResolver = new UsedRectorClassResolver();
+$usedRectorRules = $usedRectorClassResolver->resolve($composerBasedSetFiles);
+
+$symfonyStyle->writeln(
+    sprintf('<fg=yellow>Found %d Rector rules used in composer-based sets</>', count($usedRectorRules))
+);
+
+$nonComposerBasedRectorRules = array_diff($rectorClasses, $usedRectorRules);
+
+$symfonyStyle->newLine();
+$symfonyStyle->listing($nonComposerBasedRectorRules);
+
+$symfonyStyle->writeln(
+    sprintf(
+        '<fg=yellow;options=bold>Found %d Rector rules not in any composer-based set, likely dead</>',
+        count($nonComposerBasedRectorRules)
+    )
+);
+$symfonyStyle->newLine();

--- a/scripts/list-non-composer-based-rules.php
+++ b/scripts/list-non-composer-based-rules.php
@@ -47,7 +47,19 @@ $symfonyStyle->writeln(
     sprintf('<fg=yellow>Found %d Rector rules used in composer-based sets</>', count($usedRectorRules))
 );
 
-$nonComposerBasedRectorRules = array_diff($rectorClasses, $usedRectorRules);
+// code-quality rules are not bound to any package version, so they never belong to a composer-based set
+$codeQualitySetFiles = array_filter(
+    $rectorSetFiles,
+    static fn (string $rectorSetFile): bool => str_ends_with(basename($rectorSetFile), 'code-quality.php')
+);
+
+$codeQualityRectorRules = $usedRectorClassResolver->resolve($codeQualitySetFiles);
+
+$symfonyStyle->writeln(
+    sprintf('<fg=yellow>Found %d Rector rules used in code-quality sets</>', count($codeQualityRectorRules))
+);
+
+$nonComposerBasedRectorRules = array_diff($rectorClasses, $usedRectorRules, $codeQualityRectorRules);
 
 $symfonyStyle->newLine();
 $symfonyStyle->listing($nonComposerBasedRectorRules);

--- a/scripts/list-non-composer-based-rules.php
+++ b/scripts/list-non-composer-based-rules.php
@@ -47,19 +47,21 @@ $symfonyStyle->writeln(
     sprintf('<fg=yellow>Found %d Rector rules used in composer-based sets</>', count($usedRectorRules))
 );
 
-// code-quality rules are not bound to any package version, so they never belong to a composer-based set
-$codeQualitySetFiles = array_filter(
-    $rectorSetFiles,
-    static fn (string $rectorSetFile): bool => str_ends_with(basename($rectorSetFile), 'code-quality.php')
-);
+// these rules are not bound to any package version, so they never belong to a composer-based set
+$versionAgnosticSetFileNames = ['code-quality.php', 'typed-collections.php', 'typed-collections-docblocks.php'];
 
-$codeQualityRectorRules = $usedRectorClassResolver->resolve($codeQualitySetFiles);
+$versionAgnosticSetFiles = array_filter($rectorSetFiles, static fn (string $rectorSetFile): bool => array_any($versionAgnosticSetFileNames, fn (string $versionAgnosticSetFileName): bool => str_ends_with(basename($rectorSetFile), $versionAgnosticSetFileName)));
+
+$versionAgnosticRectorRules = $usedRectorClassResolver->resolve($versionAgnosticSetFiles);
 
 $symfonyStyle->writeln(
-    sprintf('<fg=yellow>Found %d Rector rules used in code-quality sets</>', count($codeQualityRectorRules))
+    sprintf(
+        '<fg=yellow>Found %d Rector rules used in version-agnostic sets</>',
+        count($versionAgnosticRectorRules)
+    )
 );
 
-$nonComposerBasedRectorRules = array_diff($rectorClasses, $usedRectorRules, $codeQualityRectorRules);
+$nonComposerBasedRectorRules = array_diff($rectorClasses, $usedRectorRules, $versionAgnosticRectorRules);
 
 $symfonyStyle->newLine();
 $symfonyStyle->listing($nonComposerBasedRectorRules);

--- a/scripts/list-unused-rules.php
+++ b/scripts/list-unused-rules.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use Rector\Bridge\SetRectorsResolver;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Scripts\Finder\RectorClassFinder;
 use Rector\Scripts\Finder\RectorSetFilesFinder;
+use Rector\Scripts\Resolver\UsedRectorClassResolver;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -64,25 +64,3 @@ $symfonyStyle->writeln(
     sprintf('<fg=green>Skipped %d configurable Rector rules</>', count($configurableRectorRules))
 );
 $symfonyStyle->newLine();
-
-final class UsedRectorClassResolver
-{
-    /**
-     * @param string[] $rectorSetFiles
-     * @return string[]
-     */
-    public function resolve(array $rectorSetFiles): array
-    {
-        $setRectorsResolver = new SetRectorsResolver();
-        $rulesConfiguration = $setRectorsResolver->resolveFromFilePathsIncludingConfiguration($rectorSetFiles);
-
-        $usedRectorRules = [];
-        foreach ($rulesConfiguration as $ruleConfiguration) {
-            $usedRectorRules[] = is_string($ruleConfiguration) ? $ruleConfiguration : array_keys($ruleConfiguration)[0];
-        }
-
-        sort($usedRectorRules);
-
-        return array_unique($usedRectorRules);
-    }
-}

--- a/scripts/src/Finder/RectorClassFinder.php
+++ b/scripts/src/Finder/RectorClassFinder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Scripts\Finder;
 
+use Deprecated;
 use Nette\Loaders\RobotLoader;
 use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
 use ReflectionClass;
@@ -39,9 +40,30 @@ final class RectorClassFinder
                 continue;
             }
 
+            if ($this->isDeprecated($rectorClassReflection)) {
+                continue;
+            }
+
             $usableRectorClasses[] = $rectorClass;
         }
 
         return $usableRectorClasses;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflectionClass
+     */
+    private function isDeprecated(ReflectionClass $reflectionClass): bool
+    {
+        if ($reflectionClass->getAttributes(Deprecated::class) !== []) {
+            return true;
+        }
+
+        $docComment = $reflectionClass->getDocComment();
+        if (! is_string($docComment)) {
+            return false;
+        }
+
+        return str_contains($docComment, '@deprecated');
     }
 }

--- a/scripts/src/Resolver/UsedRectorClassResolver.php
+++ b/scripts/src/Resolver/UsedRectorClassResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Scripts\Resolver;
+
+use Rector\Bridge\SetRectorsResolver;
+
+final class UsedRectorClassResolver
+{
+    /**
+     * @param string[] $rectorSetFiles
+     * @return string[]
+     */
+    public function resolve(array $rectorSetFiles): array
+    {
+        $setRectorsResolver = new SetRectorsResolver();
+        $rulesConfiguration = $setRectorsResolver->resolveFromFilePathsIncludingConfiguration($rectorSetFiles);
+
+        $usedRectorRules = [];
+        foreach ($rulesConfiguration as $ruleConfiguration) {
+            $usedRectorRules[] = is_string($ruleConfiguration) ? $ruleConfiguration : array_keys($ruleConfiguration)[0];
+        }
+
+        sort($usedRectorRules);
+
+        return array_unique($usedRectorRules);
+    }
+}

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -755,11 +755,11 @@ final class RectorConfigBuilder
         }
 
         if ($doctrine) {
-            $this->sets[] = DoctrineSetList::COMPOSER_BASED;
+            // $this->sets[] = DoctrineSetList::COMPOSER_BASED;
         }
 
         if ($twig) {
-            $this->sets[] = \Rector\Symfony\Set\TwigSetList::COMPOSER_BASED;
+            // $this->sets[] = TwigSetList::COMPOSER_BASED;
         }
 
         if ($symfony) {

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -754,6 +754,14 @@ final class RectorConfigBuilder
             $this->sets[] = PHPUnitSetList::COMPOSER_BASED;
         }
 
+        if ($doctrine) {
+            $this->sets[] = DoctrineSetList::COMPOSER_BASED;
+        }
+
+        if ($twig) {
+            $this->sets[] = \Rector\Symfony\Set\TwigSetList::COMPOSER_BASED;
+        }
+
         if ($symfony) {
             // single set, as every rule inside is bound to the installed Symfony package version on its own
             $this->sets[] = SymfonySetList::COMPOSER_BASED;


### PR DESCRIPTION
Two changes to the rule-listing scripts.

## 1. `scripts/list-unused-rules.php` — skip deprecated rules

`RectorClassFinder` already skipped rules implementing `DeprecatedInterface`. Now it also skips rules deprecated via docblock or attribute only:

```php
/**
 * @deprecated as it worsens readability...
 */
final class SomeRector extends AbstractRector
```

```php
#[Deprecated]
final class SomeRector extends AbstractRector
```

## 2. New `scripts/list-non-composer-based-rules.php`

Lists rules from core, doctrine, phpunit and symfony that are **not** registered in any `composer-based.php` set — these are candidates for dead rules, as they are not bound to the installed package version.

Output:

```
Found Rector 763 rules
Found 4 composer-based sets
 * config/set/nette-utils/composer-based.php
 * vendor/rector/rector-symfony/config/sets/symfony/composer-based.php
 * vendor/rector/rector-doctrine/config/sets/composer-based.php
 * vendor/rector/rector-phpunit/config/sets/composer-based.php

Found 68 Rector rules used in composer-based sets

 * Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector
 ...
 * Rector\Symfony\Symfony25\Rector\MethodCall\MaxLengthSymfonyFormOptionToAttrRector

Found 695 Rector rules not in any composer-based set, likely dead
```

The `UsedRectorClassResolver` class was moved out of `list-unused-rules.php` into `scripts/src/Resolver/`, so both scripts share it.