### PR TITLE
[Tests] Expect twig composer-based set in SetManagerTest

### DIFF
--- a/tests/Set/SetManager/SetManagerTest.php
+++ b/tests/Set/SetManager/SetManagerTest.php
@@ -20,7 +20,7 @@ final class SetManagerTest extends AbstractLazyTestCase
         $setManager = $this->createSetManagerWithProjectDirectory(getcwd());
 
         $twigComposerTriggeredSet = $setManager->matchComposerTriggered(SetGroup::TWIG);
-        $this->assertCount(7, $twigComposerTriggeredSet);
+        $this->assertCount(8, $twigComposerTriggeredSet);
     }
 
     /**
@@ -43,13 +43,20 @@ final class SetManagerTest extends AbstractLazyTestCase
     public static function provideInstalledTwigData(): Iterator
     {
         // here we cannot used features coming up in 2.4, as we only have 2.0
-        yield [__DIR__ . '/Fixture/project-twig-20', [realpath(TwigSetList::TWIG_20)]];
+        yield [
+            __DIR__ . '/Fixture/project-twig-20',
+            [realpath(TwigSetList::COMPOSER_BASED), realpath(TwigSetList::TWIG_20)],
+        ];
 
-        yield [__DIR__ . '/Fixture/project-twig-24', [realpath(TwigSetList::TWIG_20), realpath(TwigSetList::TWIG_24)]];
+        yield [
+            __DIR__ . '/Fixture/project-twig-24',
+            [realpath(TwigSetList::COMPOSER_BASED), realpath(TwigSetList::TWIG_20), realpath(TwigSetList::TWIG_24)],
+        ];
 
         yield [
             __DIR__ . '/Fixture/project-twig-127',
-            [realpath(TwigSetList::TWIG_112), realpath(TwigSetList::TWIG_127)]];
+            [realpath(TwigSetList::COMPOSER_BASED), realpath(TwigSetList::TWIG_112), realpath(TwigSetList::TWIG_127)],
+        ];
     }
 
     private function createSetManagerWithProjectDirectory(string $projectDirectory): SetManager


### PR DESCRIPTION
`rector-symfony`'s `TwigSetProvider` now provides a `twig/composer-based.php` set constrained to `twig/twig >=1.12`, on top of the 7 version-pinned sets. Every twig fixture project in `SetManagerTest` installs twig `>=1.12`, so the composer-based set is matched for all of them.

```diff
-        $this->assertCount(7, $twigComposerTriggeredSet);
+        $this->assertCount(8, $twigComposerTriggeredSet);
```

```diff
-        yield [__DIR__ . '/Fixture/project-twig-20', [realpath(TwigSetList::TWIG_20)]];
+        yield [
+            __DIR__ . '/Fixture/project-twig-20',
+            [realpath(TwigSetList::COMPOSER_BASED), realpath(TwigSetList::TWIG_20)],
+        ];
```

Test-only change; `vendor/bin/phpunit` is green with it.