### PR TITLE
Fix bug with `composer-based` command and Symfony configuration

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -8,7 +8,6 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector;
-use Rector\Symfony\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector;
 use Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector;
 
 return RectorConfig::configure()
@@ -44,11 +43,9 @@ return RectorConfig::configure()
     ->withSkip([
         StringClassNameToClassConstantRector::class,
 
-        // adds (int) cast to methods that already return int, ping-pongs with RecastingRemovalRector
-        ConsoleExecuteReturnIntRector::class,
-
         // keep console command metadata in configure(), as more readable than a single long attribute
         CommandConfigureToAttributeRector::class,
+
         // tests
         '*/Fixture*',
         '*/Source*',

--- a/rector.php
+++ b/rector.php
@@ -8,6 +8,8 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector;
+use Rector\Symfony\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector;
+use Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector;
 
 return RectorConfig::configure()
     ->withPreparedSets(
@@ -24,7 +26,7 @@ return RectorConfig::configure()
         phpunitCodeQuality: true
     )
     ->withAttributesSets()
-    ->withComposerBased(phpunit: true)
+    ->withComposerBased(phpunit: true, symfony: true)
     ->withPhpSets()
     ->withPaths([
         __DIR__ . '/bin',
@@ -41,6 +43,12 @@ return RectorConfig::configure()
     ->withImportNames()
     ->withSkip([
         StringClassNameToClassConstantRector::class,
+
+        // adds (int) cast to methods that already return int, ping-pongs with RecastingRemovalRector
+        ConsoleExecuteReturnIntRector::class,
+
+        // keep console command metadata in configure(), as more readable than a single long attribute
+        CommandConfigureToAttributeRector::class,
         // tests
         '*/Fixture*',
         '*/Source*',

--- a/src/Console/Command/ComposerBasedCommand.php
+++ b/src/Console/Command/ComposerBasedCommand.php
@@ -206,6 +206,11 @@ final class ComposerBasedCommand extends Command
 
             $reflectionObject = new ReflectionObject($value);
             foreach ($reflectionObject->getProperties() as $reflectionProperty) {
+                // lazy-initialized property, e.g. PHPStan UnionType::$normalized
+                if (! $reflectionProperty->isInitialized($value)) {
+                    continue;
+                }
+
                 $printedPropertyValues[] = $this->printConfigurationValue($reflectionProperty->getValue($value));
             }
 


### PR DESCRIPTION
Spotted in: https://github.com/rectorphp/rector-src/pull/8246#issuecomment-5169035341

---

Adds `symfony: true` to `withComposerBased()` in `rector.php`, so rector-src is covered by the Symfony composer-bound rules.

## Fix: fatal error in `bin/rector composer-based`

The Symfony `composer-based.php` set builds a `UnionType` via `newInstanceWithoutConstructor()` and only sets `types`, leaving `$normalized` uninitialized. Rendering the configuration table then crashed:

```
PHP Fatal error:  Uncaught Error: Typed property PHPStan\Type\UnionType::$normalized
must not be accessed before initialization in src/Console/Command/ComposerBasedCommand.php:205
```

```diff
 foreach ($reflectionObject->getProperties() as $reflectionProperty) {
+    // lazy-initialized property, e.g. PHPStan UnionType::$normalized
+    if (! $reflectionProperty->isInitialized($value)) {
+        continue;
+    }
+
     $printedPropertyValues[] = $this->printConfigurationValue($reflectionProperty->getValue($value));
 }
```
