### PR TITLE
Skip constructor defaults on extensible classes

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_non_final_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_non_final_class.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+class ValidatedBase
+{
+    private bool $validated = false;
+
+    protected function __construct()
+    {
+        $this->validate();
+        $this->validated = true;
+    }
+
+    private function validate(): void
+    {
+    }
+}
+
+final class SkipsParentConstructor extends ValidatedBase
+{
+    public function __construct()
+    {
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -82,6 +82,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        // A child class may bypass the constructor and depend on the declared property default
+        if (! $node->isFinal()) {
+            return null;
+        }
+
         $hasChanged = false;
 
         $constructClassMethod = $node->getMethod(MethodName::CONSTRUCT);


### PR DESCRIPTION
Fixes rectorphp/rector#9837

## Summary

- skip `InlineConstructorDefaultToPropertyRector` for non-final classes
- preserve a declared property default when a child class bypasses the parent constructor
- add a regression fixture covering that inheritance path

The transformation moves initialization from runtime constructor flow to object creation. For an extensible class, a child can omit `parent::__construct()`, so moving the assignment changes observable behavior. The rule documentation and existing positive fixtures already use final classes; this makes that safety boundary explicit.

## Verification

- targeted rule suite: 20 tests, 21 assertions
- full PHPUnit suite: 5,407 tests, 6,926 assertions, 2 skipped
- full PHPStan analysis: no errors
- ECS on both changed files: no errors