### PR TITLE
 [DeadCode] Skip assert() enforcement that produce NeverType on NarrowWideUnionReturnTypeRector

### DIFF
--- a/rules-tests/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector/Fixture/skip_assert.php.inc
+++ b/rules-tests/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector/Fixture/skip_assert.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\FunctionLike\NarrowWideUnionReturnTypeRector\Fixture;
+
+final class SkipAssert
+{
+    /**
+     * @var array{
+     *     cache: array{directory: null}
+     * }
+     */
+    protected array $config = [
+        'cache' => [
+            'directory' => null,
+        ],
+    ];
+
+    public function getCacheDirectory(): ?string
+    {
+        $dir = $this->config['cache']['directory'] ?? null;
+        \assert(\is_string($dir) || $dir === null, 'Invalid cache directory.');
+
+        return $dir;
+    }
+}
+

--- a/rules/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector.php
+++ b/rules/DeadCode/Rector/FunctionLike/NarrowWideUnionReturnTypeRector.php
@@ -20,6 +20,7 @@ use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\UnionType;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -272,6 +273,13 @@ CODE_SAMPLE
     private function resolveNativeReturnTypes(Expr $expr): array
     {
         if (! $expr instanceof Ternary || ! $this->hasVendorClassConstFetch($expr->cond)) {
+            $type = $this->nodeTypeResolver->getType($expr);
+
+            // native type may be narrowed by assertions even when the resolved scope is unreachable
+            if ($type instanceof NeverType) {
+                return [$type];
+            }
+
             return [$this->nodeTypeResolver->getNativeType($expr)];
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9838