### PR TITLE
[CodeQuality] Skip SimpleXMLElement on IssetOnPropertyObjectToPropertyExistsRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/skip_simple_xml_element.php.inc
+++ b/rules-tests/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector/Fixture/skip_simple_xml_element.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector\Fixture;
+
+use SimpleXMLElement;
+
+final class SkipSimpleXmlElement
+{
+    public function x(SimpleXMLElement $svg) {
+        $svgAttributes = $svg->attributes();
+
+        if (isset($svgAttributes->width) && isset($svgAttributes->height)) {
+            return true;
+        }
+
+        return isset($svg->viewBox);
+    }
+}

--- a/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
+++ b/rules/CodeQuality/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
@@ -221,6 +221,13 @@ CODE_SAMPLE
             return null;
         }
 
-        return $this->reflectionProvider->getClass($className);
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        // XML elements resolve properties from the XML document itself
+        if ($classReflection->is('SimpleXMLElement')) {
+            return null;
+        }
+
+        return $classReflection;
     }
 }


### PR DESCRIPTION
`SimpleXMLElement` resolves properties from the XML document at runtime, not from the class. `property_exists()` always returns `false` for them, so the rewrite breaks working code.

```diff
 public function x(SimpleXMLElement $svg) {
     $svgAttributes = $svg->attributes();

-    if (isset($svgAttributes->width) && isset($svgAttributes->height)) {
+    if (property_exists($svgAttributes, 'width') && $svgAttributes->width !== null && (property_exists($svgAttributes, 'height') && $svgAttributes->height !== null)) {
         return true;
     }

-    return isset($svg->viewBox);
+    return property_exists($svg, 'viewBox') && $svg->viewBox !== null;
 }
```

Now `SimpleXMLElement` and its children are skipped.