### PR TITLE
[DeadCode] Move SimplifyBoolIdenticalTrueRector and UnwrapSprintfOneArgumentRector to dead-code set

### DIFF
--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -45,11 +45,9 @@ use Rector\CodeQuality\Rector\FuncCall\SimplifyInArrayValuesRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyStrposLowerRector;
 use Rector\CodeQuality\Rector\FuncCall\SingleInArrayToCompareRector;
 use Rector\CodeQuality\Rector\FuncCall\SortCallLikeNamedArgsRector;
-use Rector\CodeQuality\Rector\FuncCall\UnwrapSprintfOneArgumentRector;
 use Rector\CodeQuality\Rector\Identical\BooleanNotIdenticalToNotIdenticalRector;
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\CodeQuality\Rector\Identical\SimplifyArraySearchRector;
-use Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector;
 use Rector\CodeQuality\Rector\Identical\SimplifyConditionsRector;
 use Rector\CodeQuality\Rector\Identical\StrlenZeroToIdenticalEmptyStringRector;
 use Rector\CodeQuality\Rector\If_\ConsecutiveNullCompareReturnsToNullCoalesceQueueRector;
@@ -130,7 +128,6 @@ final class CodeQualityLevel
         TernaryImplodeToImplodeRector::class,
         ConsecutiveNullCompareReturnsToNullCoalesceQueueRector::class,
         UseIdenticalOverEqualWithSameTypeRector::class,
-        SimplifyBoolIdenticalTrueRector::class,
         BooleanNotIdenticalToNotIdenticalRector::class,
         AndAssignsToSeparateLinesRector::class,
         CompactToVariablesRector::class,
@@ -152,7 +149,6 @@ final class CodeQualityLevel
         VarToPublicPropertyRector::class,
         IssetOnPropertyObjectToPropertyExistsRector::class,
         NewStaticToNewSelfRector::class,
-        UnwrapSprintfOneArgumentRector::class,
         VariableConstFetchToClassConstFetchRector::class,
         SingularSwitchToIfRector::class,
         SwitchTrueToMatchRector::class,

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\Config\Level;
 
+use Rector\CodeQuality\Rector\FuncCall\UnwrapSprintfOneArgumentRector;
 use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
+use Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector;
 use Rector\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\DeadCode\Rector\Array_\RemoveDuplicatedArrayKeyRector;
@@ -110,6 +112,8 @@ final class DeadCodeLevel
         ReplaceBlockToItsStmtsRector::class,
         RemoveFilterVarOnExactTypeRector::class,
         RemoveFinalFromConstRector::class,
+        UnwrapSprintfOneArgumentRector::class,
+        SimplifyBoolIdenticalTrueRector::class,
 
         RemoveTypedPropertyDeadInstanceOfRector::class,
         RemoveDeadInstanceOfAssertRector::class,


### PR DESCRIPTION
Both rules remove dead code rather than improve quality, so they fit the dead-code set better.

`SimplifyBoolIdenticalTrueRector` - dead comparison against a bool:

```diff
-$match = in_array($value, $items, true) === true;
+$match = in_array($value, $items, true);
```

`UnwrapSprintfOneArgumentRector` - dead `sprintf()` call with nothing to format:

```diff
-$value = sprintf('Hi');
+$value = 'Hi';
```

Namespaces stay as-is; only the set registration moves from `CodeQualityLevel` to `DeadCodeLevel`. Precedent: `SimplifyUselessVariableRector` already lives in `DeadCodeLevel` with its `Rector\CodeQuality` namespace.