### PR TITLE
Show previous exceptions during bootstrap

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -143,14 +143,20 @@ try {
 
     // report fatal error in json format
     if ($outputFormat === JsonOutputFormatter::NAME) {
+        $errors = [];
+        do {
+            $errors[] = $throwable->getMessage();
+        } while ($throwable = $throwable->getPrevious());
         echo Json::encode([
-            'fatal_errors' => [$throwable->getMessage()],
+            'fatal_errors' => $errors,
         ]);
     } else {
         // report fatal errors in console format
         $symfonyStyleFactory = new SymfonyStyleFactory(new PrivatesAccessor());
         $symfonyStyle = $symfonyStyleFactory->create();
-        $symfonyStyle->error(str_replace("\r\n", "\n", $throwable->getMessage()));
+        do {
+            $symfonyStyle->error(str_replace("\r\n", "\n", $throwable->getMessage()));
+        } while ($throwable = $throwable->getPrevious());
     }
 
     exit(Command::FAILURE);

--- a/tests/Bin/RectorTest.php
+++ b/tests/Bin/RectorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Bin;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+final class RectorTest extends TestCase
+{
+    public static function outputProvider()
+    {
+
+        yield "Version" => [
+            'command'        => 'bin/rector --version',
+            'expectedOutput' => "Rector @package_version@\n",
+        ];
+
+        yield "Exception with previous console output" => [
+            'command'        => 'bin/rector -c tests/Bin/config/incorrect-phpstan-files.php',
+            'expectedOutput' => <<<TXT
+                
+                 [ERROR] Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory     
+                
+                 [ERROR] Unexpected item 'parameters › invalidParameters'.                      
+                
+                
+                TXT,
+        ];
+        yield "Exception with previous console output in JSON format" => [
+            'command'        => 'bin/rector -c tests/Bin/config/incorrect-phpstan-files.php --output-format json',
+            'expectedOutput' => '{"fatal_errors":["Rector\\\\NodeTypeResolver\\\\DependencyInjection\\\\PHPStanServicesFactory","Unexpected item \'parameters › invalidParameters\'."]}'
+        ];
+    }
+
+    #[DataProvider('outputProvider')]
+    public function testConsoleOutput(string $command, string $expectedOutput): void
+    {
+        $process = Process::fromShellCommandline($command);
+        $process->run();
+        $this->assertSame($expectedOutput, $process->getOutput());
+    }
+}

--- a/tests/Bin/RectorTest.php
+++ b/tests/Bin/RectorTest.php
@@ -4,34 +4,29 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Bin;
 
+use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
 final class RectorTest extends TestCase
 {
-    public static function outputProvider()
+    /**
+     * @return Iterator<string, array{command: string, expectedOutput: string}>
+     */
+    public static function outputProvider(): Iterator
     {
-
-        yield "Version" => [
-            'command'        => 'bin/rector --version',
+        yield 'Version' => [
+            'command' => 'bin/rector --version',
             'expectedOutput' => "Rector @package_version@\n",
         ];
-
-        yield "Exception with previous console output" => [
-            'command'        => 'bin/rector -c tests/Bin/config/incorrect-phpstan-files.php',
-            'expectedOutput' => <<<TXT
-                
-                 [ERROR] Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory     
-                
-                 [ERROR] Unexpected item 'parameters › invalidParameters'.                      
-                
-                
-                TXT,
+        yield 'Exception with previous console output' => [
+            'command' => 'bin/rector -c tests/Bin/config/incorrect-phpstan-files.php',
+            'expectedOutput' => "\n [ERROR] Rector\\NodeTypeResolver\\DependencyInjection\\PHPStanServicesFactory     \n\n [ERROR] Unexpected item 'parameters › invalidParameters'.                      \n\n",
         ];
-        yield "Exception with previous console output in JSON format" => [
-            'command'        => 'bin/rector -c tests/Bin/config/incorrect-phpstan-files.php --output-format json',
-            'expectedOutput' => '{"fatal_errors":["Rector\\\\NodeTypeResolver\\\\DependencyInjection\\\\PHPStanServicesFactory","Unexpected item \'parameters › invalidParameters\'."]}'
+        yield 'Exception with previous console output in JSON format' => [
+            'command' => 'bin/rector -c tests/Bin/config/incorrect-phpstan-files.php --output-format json',
+            'expectedOutput' => '{"fatal_errors":["Rector\\\\NodeTypeResolver\\\\DependencyInjection\\\\PHPStanServicesFactory","Unexpected item \'parameters › invalidParameters\'."]}',
         ];
     }
 

--- a/tests/Bin/RectorTest.php
+++ b/tests/Bin/RectorTest.php
@@ -17,15 +17,15 @@ final class RectorTest extends TestCase
     public static function outputProvider(): Iterator
     {
         yield 'Version' => [
-            'command' => 'bin/rector --version',
-            'expectedOutput' => "Rector @package_version@\n",
+            'command'        => PHP_BINARY . ' bin/rector --version',
+            'expectedOutput' => "Rector @package_version@" . PHP_EOL,
         ];
         yield 'Exception with previous console output' => [
-            'command' => 'bin/rector -c tests/Bin/config/incorrect-phpstan-files.php',
-            'expectedOutput' => "\n [ERROR] Rector\\NodeTypeResolver\\DependencyInjection\\PHPStanServicesFactory     \n\n [ERROR] Unexpected item 'parameters › invalidParameters'.                      \n\n",
+            'command'        => PHP_BINARY . ' bin/rector -c tests/Bin/config/incorrect-phpstan-files.php',
+            'expectedOutput' => PHP_EOL . " [ERROR] Rector\\NodeTypeResolver\\DependencyInjection\\PHPStanServicesFactory " . PHP_EOL . PHP_EOL . " [ERROR] Unexpected item 'parameters › invalidParameters'. " . PHP_EOL . PHP_EOL,
         ];
         yield 'Exception with previous console output in JSON format' => [
-            'command' => 'bin/rector -c tests/Bin/config/incorrect-phpstan-files.php --output-format json',
+            'command'        => PHP_BINARY . ' bin/rector -c tests/Bin/config/incorrect-phpstan-files.php --output-format json',
             'expectedOutput' => '{"fatal_errors":["Rector\\\\NodeTypeResolver\\\\DependencyInjection\\\\PHPStanServicesFactory","Unexpected item \'parameters › invalidParameters\'."]}',
         ];
     }
@@ -35,6 +35,6 @@ final class RectorTest extends TestCase
     {
         $process = Process::fromShellCommandline($command);
         $process->run();
-        $this->assertSame($expectedOutput, $process->getOutput());
+        $this->assertSame($expectedOutput, preg_replace("/ +/", " ", $process->getOutput()));
     }
 }

--- a/tests/Bin/config/incorrect-phpstan-files.php
+++ b/tests/Bin/config/incorrect-phpstan-files.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
@@ -8,4 +7,4 @@ use Rector\Config\RectorConfig;
 return RectorConfig::configure()
     ->withPhpSets()
     ->withPaths([__DIR__])
-    ->withPHPStanConfigs([__DIR__ . "/phpstan.neon"]);
+    ->withPHPStanConfigs([__DIR__ . '/phpstan.neon']);

--- a/tests/Bin/config/incorrect-phpstan-files.php
+++ b/tests/Bin/config/incorrect-phpstan-files.php
@@ -1,0 +1,11 @@
+<?php
+
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPhpSets()
+    ->withPaths([__DIR__])
+    ->withPHPStanConfigs([__DIR__ . "/phpstan.neon"]);

--- a/tests/Bin/config/phpstan.neon
+++ b/tests/Bin/config/phpstan.neon
@@ -1,0 +1,3 @@
+
+parameters:
+    invalidParameters: true


### PR DESCRIPTION
When an exception is displayed in the console, also output its previous exception when available.
This is especially helpful with PHPStan: if a configuration error occurs, you’ll see the underlying cause instead of only the top‑level failure.

# Before : 
```
[ERROR] Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory
```
or
```
{"fatal_errors":["Rector\\NodeTypeResolver\\DependencyInjection\\PHPStanServicesFactory"]}
```


# After : 
```
[ERROR] Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory

[ERROR] Unexpected item 'parameters › invalidParameters'.             
```
or
```
{"fatal_errors":["Rector\\NodeTypeResolver\\DependencyInjection\\PHPStanServicesFactory","Unexpected item 'parameters › invalidParameters'."]}
```