### PR TITLE
[Php81] Skip ArrayToFirstClassCallableRector when the arg type does not accept a Closure

### DIFF
--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/callable_param.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/callable_param.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
+
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeObjectWithArrayArgument;
+
+final class CallableParam
+{
+    public function run(SomeObjectWithArrayArgument $someObjectWithArrayArgument)
+    {
+        $someObjectWithArrayArgument->withCallable([$this, 'name']);
+    }
+
+    public function name()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
+
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeObjectWithArrayArgument;
+
+final class CallableParam
+{
+    public function run(SomeObjectWithArrayArgument $someObjectWithArrayArgument)
+    {
+        $someObjectWithArrayArgument->withCallable($this->name(...));
+    }
+
+    public function name()
+    {
+    }
+}
+
+?>

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_array_param.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_array_param.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
+
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeObjectWithArrayArgument;
+
+final class SkipArrayParam
+{
+    public function run(SomeObjectWithArrayArgument $someObjectWithArrayArgument)
+    {
+        $someObjectWithArrayArgument->withArray([$this, 'name']);
+
+        SomeObjectWithArrayArgument::staticWithArray([$this, 'name']);
+    }
+
+    public function name()
+    {
+    }
+}

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_union_array_param.php.inc
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Fixture/skip_union_array_param.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Fixture;
+
+use Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source\SomeObjectWithArrayArgument;
+
+final class SkipUnionArrayParam
+{
+    public function run()
+    {
+        return new SomeObjectWithArrayArgument([$this, 'name']);
+    }
+
+    public function name()
+    {
+    }
+}

--- a/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Source/SomeObjectWithArrayArgument.php
+++ b/rules-tests/Php81/Rector/Array_/ArrayToFirstClassCallableRector/Source/SomeObjectWithArrayArgument.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\Tests\Php81\Rector\Array_\ArrayToFirstClassCallableRector\Source;
+
+final class SomeObjectWithArrayArgument
+{
+    public function __construct(
+        public string|array|SomeExternalObject|null $argument
+    ) {
+    }
+
+    public function withArray(array $argument): void
+    {
+    }
+
+    public function withCallable(callable $argument): void
+    {
+    }
+
+    public static function staticWithArray(array $argument): void
+    {
+    }
+}

--- a/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
+++ b/rules/Php81/Rector/Array_/ArrayToFirstClassCallableRector.php
@@ -90,6 +90,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): StaticCall|MethodCall|null
     {
+        if ($node->getAttribute(AttributeKey::IS_ARG_NOT_ACCEPTING_CLOSURE)) {
+            return null;
+        }
+
         if ($node->getAttribute(AttributeKey::IS_INSIDE_SYMFONY_PHP_CLOSURE)) {
             return null;
         }

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -117,6 +117,7 @@ use Rector\PhpParser\Comparing\NodeComparator;
 use Rector\PhpParser\Node\NodeFactory;
 use Rector\PhpParser\NodeTraverser\RectorNodeTraverser;
 use Rector\PhpParser\NodeVisitor\ArgNodeVisitor;
+use Rector\PhpParser\NodeVisitor\ArgNotAcceptingClosureNodeVisitor;
 use Rector\PhpParser\NodeVisitor\AssignedToNodeVisitor;
 use Rector\PhpParser\NodeVisitor\ByRefReturnNodeVisitor;
 use Rector\PhpParser\NodeVisitor\ByRefVariableNodeVisitor;
@@ -250,6 +251,7 @@ final class LazyContainerFactory
         ParamDefaultNodeVisitor::class,
         ClassConstFetchNodeVisitor::class,
         CallLikeThisBoundClosureArgsNodeVisitor::class,
+        ArgNotAcceptingClosureNodeVisitor::class,
     ];
 
     /**

--- a/src/NodeTypeResolver/Node/AttributeKey.php
+++ b/src/NodeTypeResolver/Node/AttributeKey.php
@@ -176,4 +176,10 @@ final class AttributeKey
     public const string IS_IN_TRY_BLOCK = 'is_in_try_block';
 
     public const string NEWLINE_ON_FLUENT_CALL = 'newline_on_fluent_call';
+
+    /**
+     * The arg value is passed to a parameter whose type does not accept a Closure,
+     * e.g. an array callable passed to a "string|array|null" parameter
+     */
+    public const string IS_ARG_NOT_ACCEPTING_CLOSURE = 'is_arg_not_accepting_closure';
 }

--- a/src/PhpParser/NodeVisitor/ArgNotAcceptingClosureNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/ArgNotAcceptingClosureNodeVisitor.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PhpParser\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Identifier;
+use PhpParser\NodeVisitorAbstract;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Type\ObjectType;
+use Rector\Contract\PhpParser\DecoratingNodeVisitorInterface;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\PHPStan\ParametersAcceptorSelectorVariantsWrapper;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\Reflection\ReflectionResolver;
+
+/**
+ * Mark array arguments passed to a parameter that cannot hold a Closure,
+ * e.g. "array" or "string|array|null", so an array callable is kept as is
+ *
+ * @see https://github.com/rectorphp/rector/issues/9563
+ */
+final class ArgNotAcceptingClosureNodeVisitor extends NodeVisitorAbstract implements DecoratingNodeVisitorInterface
+{
+    public function __construct(
+        private readonly ReflectionResolver $reflectionResolver
+    ) {
+    }
+
+    public function enterNode(Node $node): ?Node
+    {
+        if (! $node instanceof CallLike) {
+            return null;
+        }
+
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        $args = $node->getArgs();
+        if (! array_any($args, static fn (Arg $arg): bool => $arg->value instanceof Array_)) {
+            return null;
+        }
+
+        $functionLikeReflection = $this->reflectionResolver->resolveFunctionLikeReflectionFromCall($node);
+        if (! $functionLikeReflection instanceof FunctionReflection && ! $functionLikeReflection instanceof MethodReflection) {
+            return null;
+        }
+
+        $parameterReflections = ParametersAcceptorSelectorVariantsWrapper::select(
+            $functionLikeReflection,
+            $node,
+            ScopeFetcher::fetch($node)
+        )->getParameters();
+
+        $closureObjectType = new ObjectType('Closure');
+
+        foreach ($args as $position => $arg) {
+            if (! $arg->value instanceof Array_) {
+                continue;
+            }
+
+            $parameterReflection = $this->matchParameterReflection($arg, $position, $parameterReflections);
+            if (! $parameterReflection instanceof ParameterReflection) {
+                continue;
+            }
+
+            if (! $parameterReflection->getType()->accepts($closureObjectType, true)->no()) {
+                continue;
+            }
+
+            $arg->value->setAttribute(AttributeKey::IS_ARG_NOT_ACCEPTING_CLOSURE, true);
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param ParameterReflection[] $parameterReflections
+     */
+    private function matchParameterReflection(
+        Arg $arg,
+        int $position,
+        array $parameterReflections
+    ): ?ParameterReflection {
+        if ($arg->name instanceof Identifier) {
+            $argName = $arg->name->toString();
+
+            foreach ($parameterReflections as $parameterReflection) {
+                if ($parameterReflection->getName() === $argName) {
+                    return $parameterReflection;
+                }
+            }
+
+            return null;
+        }
+
+        if (isset($parameterReflections[$position])) {
+            return $parameterReflections[$position];
+        }
+
+        $lastParameterReflection = end($parameterReflections);
+        if ($lastParameterReflection instanceof ParameterReflection && $lastParameterReflection->isVariadic()) {
+            return $lastParameterReflection;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9563

A first class callable is a `Closure`. When the array callable is passed as an argument to a parameter that cannot hold a `Closure` — `array`, or a union like `string|array|SomeObject|null` — the converted code fatals at runtime:

```
Uncaught TypeError: DemoFile::__construct(): Argument #1 ($argument) must be of type SomeObjectAsArgument|array|string|null, Closure given
```

## Before / after

```php
final class SomeObjectWithArrayArgument
{
    public function __construct(
        public string|array|SomeExternalObject|null $argument
    ) {
    }
}
```

```diff
 public function run()
 {
-    return new SomeObjectWithArrayArgument([$this, 'name']);
+    return new SomeObjectWithArrayArgument([$this, 'name']); // unchanged now
 }
```

A `callable` parameter still converts:

```diff
 public function run(SomeObjectWithArrayArgument $someObjectWithArrayArgument)
 {
-    $someObjectWithArrayArgument->withCallable([$this, 'name']);
+    $someObjectWithArrayArgument->withCallable($this->name(...));
 }
```

## How

New `ArgNotAcceptingClosureNodeVisitor` (a `DecoratingNodeVisitorInterface`, so attribute decoration stays separate from node changes) resolves the called function/method reflection, matches each array argument to its parameter — by name for named args, by position otherwise, falling back to a trailing variadic — and marks the argument with `AttributeKey::IS_ARG_NOT_ACCEPTING_CLOSURE` when the parameter type rejects `Closure`. The rule bails out on that attribute.