### PR TITLE
[DeadCode] Move RemoveReadonlyPropertyVisibilityOnReadonlyClassRector to dead-code set

### DIFF
--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -20,7 +20,6 @@ use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\CodeQuality\Rector\Class_\ConvertStaticToSelfRector;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\CodeQuality\Rector\Class_\InnerFunctionToPrivateMethodRector;
-use Rector\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector;
 use Rector\CodeQuality\Rector\ClassConstFetch\VariableConstFetchToClassConstFetchRector;
 use Rector\CodeQuality\Rector\ClassMethod\ExplicitReturnNullRector;
 use Rector\CodeQuality\Rector\ClassMethod\InlineArrayReturnAssignRector;
@@ -169,7 +168,6 @@ final class CodeQualityLevel
         ConvertStaticToSelfRector::class,
         SortCallLikeNamedArgsRector::class,
         SortAttributeNamedArgsRector::class,
-        RemoveReadonlyPropertyVisibilityOnReadonlyClassRector::class,
         SafeDeclareStrictTypesRector::class,
     ];
 

--- a/src/Config/Level/DeadCodeLevel.php
+++ b/src/Config/Level/DeadCodeLevel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Config\Level;
 
+use Rector\CodeQuality\Rector\Class_\RemoveReadonlyPropertyVisibilityOnReadonlyClassRector;
 use Rector\CodeQuality\Rector\FuncCall\UnwrapSprintfOneArgumentRector;
 use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
 use Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector;
@@ -114,6 +115,7 @@ final class DeadCodeLevel
         RemoveFinalFromConstRector::class,
         UnwrapSprintfOneArgumentRector::class,
         SimplifyBoolIdenticalTrueRector::class,
+        RemoveReadonlyPropertyVisibilityOnReadonlyClassRector::class,
 
         RemoveTypedPropertyDeadInstanceOfRector::class,
         RemoveDeadInstanceOfAssertRector::class,


### PR DESCRIPTION
The rule removes redundant visibility-less `readonly` noise on `readonly` classes, where the property `readonly` modifier is already implied. That is dead code removal rather than code quality, so it fits the dead-code set better.

```diff
 final readonly class SomeClass
 {
-    public readonly string $name;
+    public string $name;

-    public function __construct(private readonly int $age)
+    public function __construct(private int $age)
     {
     }
 }
```

The rule class stays in the `CodeQuality` namespace; only the set registration moves from `CodeQualityLevel` to `DeadCodeLevel`.