### PR TITLE
[Sets] Drop Symfony per-version set providers from the collector

### DIFF
--- a/src/Bridge/SetProviderCollector.php
+++ b/src/Bridge/SetProviderCollector.php
@@ -11,12 +11,6 @@ use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\SetProvider\CoreSetProvider;
 use Rector\Set\SetProvider\PHPSetProvider;
 use Rector\Set\ValueObject\ComposerTriggeredSet;
-use Rector\Symfony\Set\SetProvider\Symfony3SetProvider;
-use Rector\Symfony\Set\SetProvider\Symfony4SetProvider;
-use Rector\Symfony\Set\SetProvider\Symfony5SetProvider;
-use Rector\Symfony\Set\SetProvider\Symfony6SetProvider;
-use Rector\Symfony\Set\SetProvider\Symfony7SetProvider;
-use Rector\Symfony\Set\SetProvider\Symfony8SetProvider;
 use Rector\Symfony\Set\SetProvider\TwigSetProvider;
 
 /**
@@ -41,12 +35,6 @@ final readonly class SetProviderCollector
             new PHPSetProvider(),
             new CoreSetProvider(),
             new PHPUnitSetProvider(),
-            new Symfony3SetProvider(),
-            new Symfony4SetProvider(),
-            new Symfony5SetProvider(),
-            new Symfony6SetProvider(),
-            new Symfony7SetProvider(),
-            new Symfony8SetProvider(),
             new DoctrineSetProvider(),
             new TwigSetProvider(),
         ];


### PR DESCRIPTION
Companion to rectorphp/rector-symfony#1010.

`Symfony3SetProvider` … `Symfony8SetProvider` registered 208 per-version `ComposerTriggeredSet`s. Every rule in them is already in `config/sets/symfony/composer-based.php`, where it carries its own package version constraint — verified rule by rule in that PR, 0 rules missing. rector-symfony removes those providers, so the collector stops asking them for sets.

`SymfonySetProvider` goes with them, in the same rector-symfony PR: the composer-based set is reachable through `SymfonySetList::COMPOSER_BASED`, which is exactly what `withComposerBased(symfony: true)` adds, and the remaining Symfony sets through their own `SymfonySetList` constants.

```diff
 use Rector\Set\SetProvider\PHPSetProvider;
-use Rector\Symfony\Set\SetProvider\Symfony3SetProvider;
-use Rector\Symfony\Set\SetProvider\Symfony4SetProvider;
-use Rector\Symfony\Set\SetProvider\Symfony5SetProvider;
-use Rector\Symfony\Set\SetProvider\Symfony6SetProvider;
-use Rector\Symfony\Set\SetProvider\Symfony7SetProvider;
-use Rector\Symfony\Set\SetProvider\Symfony8SetProvider;
-use Rector\Symfony\Set\SetProvider\SymfonySetProvider;
 use Rector\Symfony\Set\SetProvider\TwigSetProvider;

         $setProviders = [
             new PHPSetProvider(),
             new CoreSetProvider(),
             new PHPUnitSetProvider(),
-            new SymfonySetProvider(),
-            new Symfony3SetProvider(),
-            new Symfony4SetProvider(),
-            new Symfony5SetProvider(),
-            new Symfony6SetProvider(),
-            new Symfony7SetProvider(),
-            new Symfony8SetProvider(),
             new DoctrineSetProvider(),
             new TwigSetProvider(),
         ];
```

`TwigSetProvider` stays — `SetGroup::TWIG` is wired into `withComposerBased()`, so its composer-based trigger is still resolved through `SetManager`.

### Follow-up, not in this PR

rector-symfony#1010 also trims `TwigSetProvider` to its single composer-based trigger. Once that is released and pulled in here, `SetManagerTest` needs updating — `testMatchComposerTriggered()` asserts 8 Twig triggered sets, and `provideInstalledTwigData()` expects the per-version Twig sets alongside the composer-based one.