### PR TITLE
[Php71] Skip AssignArrayToStringRector on a variable re-assigned as string

### DIFF
--- a/rules/Php71/Rector/Assign/AssignArrayToStringRector.php
+++ b/rules/Php71/Rector/Assign/AssignArrayToStringRector.php
@@ -237,6 +237,61 @@ CODE_SAMPLE
         return false;
     }
 
+    /**
+     * The variable is filled as a string later on, so it has to stay a string here as well
+     */
+    private function isReAssignedAsString(
+        Variable $variable,
+        Namespace_|FileNode|ClassMethod|Function_|Closure $node
+    ): bool {
+        if ($node->stmts === null) {
+            return false;
+        }
+
+        $variableName = $this->getName($variable);
+        if ($variableName === null) {
+            return false;
+        }
+
+        $isReAssignedAsString = false;
+
+        $this->traverseNodesWithCallable($node->stmts, function (Node $node) use (
+            $variable,
+            $variableName,
+            &$isReAssignedAsString
+        ): ?int {
+            if (! $node instanceof Assign) {
+                return null;
+            }
+
+            if (! $node->var instanceof Variable) {
+                return null;
+            }
+
+            if (! $this->isName($node->var, $variableName)) {
+                return null;
+            }
+
+            if ($node->var->getStartTokenPos() <= $variable->getStartTokenPos()) {
+                return null;
+            }
+
+            // an empty string assign is a candidate for the very same re-type, so it is no proof of a string
+            if ($this->isEmptyString($node->expr)) {
+                return null;
+            }
+
+            if (! $this->nodeTypeResolver->getNativeType($node->expr)->isString()->yes()) {
+                return null;
+            }
+
+            $isReAssignedAsString = true;
+            return NodeVisitor::STOP_TRAVERSAL;
+        });
+
+        return $isReAssignedAsString;
+    }
+
     private function refactorAssign(
         Assign $assign,
         Namespace_|FileNode|ClassMethod|Function_|Closure $node
@@ -255,6 +310,10 @@ CODE_SAMPLE
         }
 
         if ($type instanceof UnionType) {
+            return null;
+        }
+
+        if ($this->isReAssignedAsString($assign->var, $node)) {
             return null;
         }
 

--- a/tests/Set/SetManager/SetManagerTest.php
+++ b/tests/Set/SetManager/SetManagerTest.php
@@ -20,7 +20,7 @@ final class SetManagerTest extends AbstractLazyTestCase
         $setManager = $this->createSetManagerWithProjectDirectory(getcwd());
 
         $twigComposerTriggeredSet = $setManager->matchComposerTriggered(SetGroup::TWIG);
-        $this->assertCount(8, $twigComposerTriggeredSet);
+        $this->assertCount(1, $twigComposerTriggeredSet);
     }
 
     /**
@@ -42,21 +42,13 @@ final class SetManagerTest extends AbstractLazyTestCase
      */
     public static function provideInstalledTwigData(): Iterator
     {
-        // here we cannot used features coming up in 2.4, as we only have 2.0
-        yield [
-            __DIR__ . '/Fixture/project-twig-20',
-            [realpath(TwigSetList::COMPOSER_BASED), realpath(TwigSetList::TWIG_20)],
-        ];
+        // the composer-based set covers every Twig version, as each rule inside it is bound
+        // to the exact twig/twig version it needs
+        yield [__DIR__ . '/Fixture/project-twig-20', [realpath(TwigSetList::COMPOSER_BASED)]];
 
-        yield [
-            __DIR__ . '/Fixture/project-twig-24',
-            [realpath(TwigSetList::COMPOSER_BASED), realpath(TwigSetList::TWIG_20), realpath(TwigSetList::TWIG_24)],
-        ];
+        yield [__DIR__ . '/Fixture/project-twig-24', [realpath(TwigSetList::COMPOSER_BASED)]];
 
-        yield [
-            __DIR__ . '/Fixture/project-twig-127',
-            [realpath(TwigSetList::COMPOSER_BASED), realpath(TwigSetList::TWIG_112), realpath(TwigSetList::TWIG_127)],
-        ];
+        yield [__DIR__ . '/Fixture/project-twig-127', [realpath(TwigSetList::COMPOSER_BASED)]];
     }
 
     private function createSetManagerWithProjectDirectory(string $projectDirectory): SetManager


### PR DESCRIPTION
Main is red on `AssignArrayToStringRectorTest`, fixture `skip_reassigned_as_string.php.inc`. Not caused by any commit here — **phpstan/phpstan 2.2.8** was released, and CI resolves it while a local `vendor/` still on 2.2.7 stays green. Reproducible with `composer update phpstan/phpstan`.

2.2.8 infers a possibly undefined variable as `ErrorType`, where it used to report a union of its possible types. The rule leaned on that union:

```php
if (empty($where)) {
    $where = '';           // native type of $where was array{}|''|null|…, now *ERROR*
} else {
    $where = 'WHERE ' . implode(' AND ', $where);
}

$sql = 'SELECT …' . $where;
```

Neither the `isArray()` nor the `UnionType` guard matches an `ErrorType`, so the empty string became an array and broke the concatenation below:

```diff
 if (empty($where)) {
-    $where = '';
+    $where = [];
 } else {
     $where = 'WHERE ' . implode(' AND ', $where);
 }
```

Guarding on `ErrorType` is not the fix — a first assignment like `$string = '';` reports `*ERROR*` for the same reason, and those must keep converting.

What actually makes `$where` a string here is that it is assigned a string further down, so the rule now checks exactly that. An empty string assign does not count as proof, since it is itself a candidate for the same re-type — that keeps `fixture.php.inc` converting its second `$string = '';`.

Full suite green on 2.2.8: 5372 tests, 6884 assertions.

### Second commit

`SetManagerTest` still expected 8 Twig composer-triggered sets. rectorphp/rector-symfony#1010 is merged, so `TwigSetProvider` now registers only its composer-based trigger — every rule of the per-version Twig sets is already in it, bound to the `twig/twig` version it needs. Folded in here so this PR is green on its own; it was #8294, now closed.