### PR TITLE
[Sets] Drop PHPUnitSetProvider from the collector

### DIFF
--- a/src/Bridge/SetProviderCollector.php
+++ b/src/Bridge/SetProviderCollector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Bridge;
 
 use Rector\Doctrine\Set\SetProvider\DoctrineSetProvider;
-use Rector\PHPUnit\Set\SetProvider\PHPUnitSetProvider;
 use Rector\Set\Contract\SetInterface;
 use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\SetProvider\CoreSetProvider;
@@ -34,7 +33,6 @@ final readonly class SetProviderCollector
             // register all known set providers here
             new PHPSetProvider(),
             new CoreSetProvider(),
-            new PHPUnitSetProvider(),
             new DoctrineSetProvider(),
             new TwigSetProvider(),
         ];


### PR DESCRIPTION
Companion to rectorphp/rector-phpunit#758, same shape as #8292 for Symfony.

That PR moves every per-version rule into `composer-based.php`, each bound to the `phpunit/phpunit` version its target API is available from, so no `ComposerTriggeredSet` is left in the package. What `PHPUnitSetProvider` still listed were three plain sets, all reachable through `PHPUnitSetList::COMPOSER_BASED`, `PHPUNIT_CODE_QUALITY` and `ANNOTATIONS_TO_ATTRIBUTES`.

```diff
-use Rector\PHPUnit\Set\SetProvider\PHPUnitSetProvider;
 use Rector\Set\Contract\SetInterface;

         $setProviders = [
             new PHPSetProvider(),
             new CoreSetProvider(),
-            new PHPUnitSetProvider(),
             new DoctrineSetProvider(),
             new TwigSetProvider(),
         ];
```

No behavior change for `withComposerBased(phpunit: true)` — it adds `PHPUnitSetList::COMPOSER_BASED` directly and never routes through `SetGroup::PHPUNIT`.

**Merge this before rectorphp/rector-phpunit#758**, which deletes the class. The reverse order leaves main instantiating a class that no longer exists.

`tests/Set` green: 12 tests, 15 assertions.
