### PR TITLE
[Sets] Deprecate ComposerTriggeredSet in favor of ComposerPackageConstraintInterface

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -317,6 +317,15 @@ parameters:
             message: '#Fetching (deprecated )?class constant (.*?) of (deprecated )?class (Rector\\Set\\ValueObject\\DowngradeLevelSetList|Rector\\Symfony\\Set\\(.*?))#'
             path: src/Configuration/RectorConfigBuilder.php
 
+        # the deprecated ComposerTriggeredSet is still resolved internally, until every extension bonds its rules
+        -
+            message: '#deprecated class Rector\\Set\\ValueObject\\ComposerTriggeredSet#'
+            paths:
+                - src/Set/SetManager.php
+                - src/Bridge/SetProviderCollector.php
+                - tests/Set/ValueObject/ComposerTriggeredSetTest.php
+                - tests/Set/SetManager/SetManagerTest.php
+
         # runtime comparison
         - '#Comparison operation ".*" between int<\d+, \d+> and \d+ is always true#'
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -317,12 +317,15 @@ parameters:
             message: '#Fetching (deprecated )?class constant (.*?) of (deprecated )?class (Rector\\Set\\ValueObject\\DowngradeLevelSetList|Rector\\Symfony\\Set\\(.*?))#'
             path: src/Configuration/RectorConfigBuilder.php
 
-        # the deprecated ComposerTriggeredSet is still resolved internally, until every extension bonds its rules
+        # the deprecated set objects are still resolved internally, until every extension bonds its rules
         -
-            message: '#deprecated class Rector\\Set\\ValueObject\\ComposerTriggeredSet#'
+            message: '#deprecated (class|interface) Rector\\(Set|Bridge)\\#'
             paths:
                 - src/Set/SetManager.php
+                - src/Set/SetProvider/CoreSetProvider.php
+                - src/Set/SetProvider/PHPSetProvider.php
                 - src/Bridge/SetProviderCollector.php
+                - src/Configuration/RectorConfigBuilder.php
                 - tests/Set/ValueObject/ComposerTriggeredSetTest.php
                 - tests/Set/SetManager/SetManagerTest.php
 

--- a/src/Bridge/SetProviderCollector.php
+++ b/src/Bridge/SetProviderCollector.php
@@ -16,6 +16,13 @@ use Rector\Symfony\Set\SetProvider\TwigSetProvider;
  * @api
  *
  * Utils class to ease building bridges by 3rd-party tools
+ *
+ * @deprecated Bond the rules themselves instead, by implementing the ComposerPackageConstraintInterface. A set
+ * described as an object only existed to be matched against the installed packages; a bonded rule states the exact
+ * package version its target API is available from and applies from there upwards, so a plain set file is enough.
+ *
+ * @see \Rector\VersionBonding\Contract\ComposerPackageConstraintInterface
+ * @see https://github.com/rectorphp/rector-src/pull/8296
  */
 final readonly class SetProviderCollector
 {

--- a/src/Set/Contract/SetInterface.php
+++ b/src/Set/Contract/SetInterface.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\Set\Contract;
 
+/**
+ * @deprecated Bond the rules themselves instead, by implementing the ComposerPackageConstraintInterface. A set
+ * described as an object only existed to be matched against the installed packages; a bonded rule states the exact
+ * package version its target API is available from and applies from there upwards, so a plain set file is enough.
+ *
+ * @see \Rector\VersionBonding\Contract\ComposerPackageConstraintInterface
+ * @see https://github.com/rectorphp/rector-src/pull/8296
+ */
 interface SetInterface
 {
     public function getGroupName(): string;

--- a/src/Set/Contract/SetProviderInterface.php
+++ b/src/Set/Contract/SetProviderInterface.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\Set\Contract;
 
+/**
+ * @deprecated Bond the rules themselves instead, by implementing the ComposerPackageConstraintInterface. A set
+ * described as an object only existed to be matched against the installed packages; a bonded rule states the exact
+ * package version its target API is available from and applies from there upwards, so a plain set file is enough.
+ *
+ * @see \Rector\VersionBonding\Contract\ComposerPackageConstraintInterface
+ * @see https://github.com/rectorphp/rector-src/pull/8296
+ */
 interface SetProviderInterface
 {
     /**

--- a/src/Set/SetManager.php
+++ b/src/Set/SetManager.php
@@ -11,6 +11,13 @@ use Rector\Set\ValueObject\ComposerTriggeredSet;
 
 /**
  * @see \Rector\Tests\Set\SetManager\SetManagerTest
+ *
+ * @deprecated Bond the rules themselves instead, by implementing the ComposerPackageConstraintInterface. A set
+ * described as an object only existed to be matched against the installed packages; a bonded rule states the exact
+ * package version its target API is available from and applies from there upwards, so a plain set file is enough.
+ *
+ * @see \Rector\VersionBonding\Contract\ComposerPackageConstraintInterface
+ * @see https://github.com/rectorphp/rector-src/pull/8296
  */
 final readonly class SetManager
 {

--- a/src/Set/SetProvider/CoreSetProvider.php
+++ b/src/Set/SetProvider/CoreSetProvider.php
@@ -9,6 +9,14 @@ use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\Enum\SetGroup;
 use Rector\Set\ValueObject\Set;
 
+/**
+ * @deprecated Bond the rules themselves instead, by implementing the ComposerPackageConstraintInterface. A set
+ * described as an object only existed to be matched against the installed packages; a bonded rule states the exact
+ * package version its target API is available from and applies from there upwards, so a plain set file is enough.
+ *
+ * @see \Rector\VersionBonding\Contract\ComposerPackageConstraintInterface
+ * @see https://github.com/rectorphp/rector-src/pull/8296
+ */
 final class CoreSetProvider implements SetProviderInterface
 {
     /**

--- a/src/Set/SetProvider/PHPSetProvider.php
+++ b/src/Set/SetProvider/PHPSetProvider.php
@@ -9,6 +9,14 @@ use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\Enum\SetGroup;
 use Rector\Set\ValueObject\Set;
 
+/**
+ * @deprecated Bond the rules themselves instead, by implementing the ComposerPackageConstraintInterface. A set
+ * described as an object only existed to be matched against the installed packages; a bonded rule states the exact
+ * package version its target API is available from and applies from there upwards, so a plain set file is enough.
+ *
+ * @see \Rector\VersionBonding\Contract\ComposerPackageConstraintInterface
+ * @see https://github.com/rectorphp/rector-src/pull/8296
+ */
 final class PHPSetProvider implements SetProviderInterface
 {
     /**

--- a/src/Set/ValueObject/ComposerTriggeredSet.php
+++ b/src/Set/ValueObject/ComposerTriggeredSet.php
@@ -12,6 +12,13 @@ use Webmozart\Assert\Assert;
 
 /**
  * @api used by extensions
+ *
+ * @deprecated Bond the rules themselves instead, by implementing the ComposerPackageConstraintInterface. A set
+ * triggered on a single major version has to be repeated for every version an upgrade passes through, while a bonded
+ * rule states the exact package version its target API is available from and applies from there upwards.
+ *
+ * @see \Rector\VersionBonding\Contract\ComposerPackageConstraintInterface
+ *
  * @see \Rector\Tests\Set\ValueObject\ComposerTriggeredSetTest
  */
 final readonly class ComposerTriggeredSet implements SetInterface

--- a/src/Set/ValueObject/ComposerTriggeredSet.php
+++ b/src/Set/ValueObject/ComposerTriggeredSet.php
@@ -18,6 +18,7 @@ use Webmozart\Assert\Assert;
  * rule states the exact package version its target API is available from and applies from there upwards.
  *
  * @see \Rector\VersionBonding\Contract\ComposerPackageConstraintInterface
+ * @see https://github.com/rectorphp/rector-src/pull/8296
  *
  * @see \Rector\Tests\Set\ValueObject\ComposerTriggeredSetTest
  */

--- a/src/Set/ValueObject/Set.php
+++ b/src/Set/ValueObject/Set.php
@@ -9,6 +9,13 @@ use Webmozart\Assert\Assert;
 
 /**
  * @api used by extensions
+ *
+ * @deprecated Bond the rules themselves instead, by implementing the ComposerPackageConstraintInterface. A set
+ * described as an object only existed to be matched against the installed packages; a bonded rule states the exact
+ * package version its target API is available from and applies from there upwards, so a plain set file is enough.
+ *
+ * @see \Rector\VersionBonding\Contract\ComposerPackageConstraintInterface
+ * @see https://github.com/rectorphp/rector-src/pull/8296
  */
 final readonly class Set implements SetInterface
 {


### PR DESCRIPTION
`ComposerPackageConstraintInterface` from #7877 turned out to replace `ComposerTriggeredSet` outright, not just complement it, so the class is now marked deprecated.

```php
/**
 * @deprecated Bond the rules themselves instead, by implementing the ComposerPackageConstraintInterface. A set
 * triggered on a single major version has to be repeated for every version an upgrade passes through, while a bonded
 * rule states the exact package version its target API is available from and applies from there upwards.
 *
 * @see \Rector\VersionBonding\Contract\ComposerPackageConstraintInterface
 */
final readonly class ComposerTriggeredSet implements SetInterface
```

The comparison table in #7877 framed the triggered set as the tool for *upgrade paths* — one set per version jump. In practice that is the weakness: a project going from PHPUnit 6 to 12 had to pick up six sets in order, and every rule had to be repeated in each of them to survive a direct jump. A bonded rule needs none of that:

```php
public function provideComposerPackageConstraint(): ComposerPackageConstraint
{
    // createMock() was added in PHPUnit 5.4, so this applies to 5.4 and everything after
    return new ComposerPackageConstraint('phpunit/phpunit', '>=5.4');
}
```

It is also more precise than `^` matching allows — `>=12.0.3`, `>=13.2`, or `>=8.4 <10.0` for an API that was later removed.

Both extensions have moved:

* rectorphp/rector-symfony#1010 — 208 triggered sets removed, all covered by the composer-based set
* rectorphp/rector-phpunit#757 and #758 — every per-version rule bonded, no triggered set left

Twig is the last user, through `TwigSetProvider`. So the class keeps working, and the internal resolving in `SetManager` and `SetProviderCollector` is ignored in `phpstan.neon` rather than rewritten, until that one moves over too.

### The rest of the set object machinery goes with it

A set described as an *object* only ever existed so it could be matched against the installed packages. Once the rules carry that information themselves, a plain set file is enough, so these are deprecated too:

* `SetInterface` and `Set`
* `SetProviderInterface`, `SetManager`, `SetProviderCollector`
* `CoreSetProvider` and `PHPSetProvider`

Every note links back to this PR, so anyone hitting the deprecation in an IDE can read the reasoning here.

Nothing is removed and nothing changes at runtime — the sets are still served from these classes, so their internal use is ignored in `phpstan.neon` rather than rewritten.

Green: 5373 tests, PHPStan and ECS clean.