### PR TITLE
[CodeQuality] Skip InlineConstructorDefaultToPropertyRector on property defined in parent, when parent::__construct() is called

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/own_property_with_parent_construct.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/own_property_with_parent_construct.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Source\AbstractParentWithFilledProperty;
+
+final class OwnPropertyWithParentConstruct extends AbstractParentWithFilledProperty
+{
+    private array $ownTypes;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->ownTypes = ['refresh_token'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Source\AbstractParentWithFilledProperty;
+
+final class OwnPropertyWithParentConstruct extends AbstractParentWithFilledProperty
+{
+    private array $ownTypes = ['refresh_token'];
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_property_filled_in_parent_constructor.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_property_filled_in_parent_constructor.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Source\AbstractParentWithFilledProperty;
+
+final class SkipPropertyFilledInParentConstructor extends AbstractParentWithFilledProperty
+{
+    protected array $allowedGrantTypes;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->allowedGrantTypes = ['refresh_token'];
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Source/AbstractParentWithFilledProperty.php
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Source/AbstractParentWithFilledProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Source;
+
+abstract class AbstractParentWithFilledProperty
+{
+    protected array $allowedGrantTypes = [];
+
+    public function __construct()
+    {
+        $this->allowedGrantTypes[] = 'authorization_code';
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -171,6 +171,7 @@ CODE_SAMPLE
             // unknown parent, keep it safe
             return true;
         }
+
         return array_any($classReflection->getParents(), fn(ClassReflection $parentClassReflection) => $parentClassReflection->getNativeReflection()->hasProperty($propertyName));
     }
 

--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -171,14 +171,7 @@ CODE_SAMPLE
             // unknown parent, keep it safe
             return true;
         }
-
-        foreach ($classReflection->getParents() as $parentClassReflection) {
-            if ($parentClassReflection->getNativeReflection()->hasProperty($propertyName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($classReflection->getParents(), fn(ClassReflection $parentClassReflection) => $parentClassReflection->getNativeReflection()->hasProperty($propertyName));
     }
 
     private function matchAssignedLocalPropertyName(Assign $assign): ?string

--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -8,16 +8,19 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\Reflection\ClassReflection;
 use Rector\NodeAnalyzer\ExprAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PhpParser\NodeFinder\PropertyFetchFinder;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\MethodName;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -30,7 +33,8 @@ final class InlineConstructorDefaultToPropertyRector extends AbstractRector
     public function __construct(
         private readonly ExprAnalyzer $exprAnalyzer,
         private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly PropertyFetchFinder $propertyFetchFinder
+        private readonly PropertyFetchFinder $propertyFetchFinder,
+        private readonly ReflectionResolver $reflectionResolver
     ) {
     }
 
@@ -89,6 +93,8 @@ CODE_SAMPLE
             return null;
         }
 
+        $hasParentConstructCall = false;
+
         foreach ($constructClassMethod->stmts as $key => $stmt) {
             // code that is possibly breaking flow
             if ($stmt instanceof If_) {
@@ -96,6 +102,11 @@ CODE_SAMPLE
             }
 
             if (! $stmt instanceof Expression) {
+                continue;
+            }
+
+            if ($this->isParentConstructCall($stmt->expr)) {
+                $hasParentConstructCall = true;
                 continue;
             }
 
@@ -112,6 +123,11 @@ CODE_SAMPLE
 
             $defaultExpr = $assign->expr;
             if ($this->exprAnalyzer->isDynamicExpr($defaultExpr)) {
+                continue;
+            }
+
+            // parent constructor may set the very same property, keep assign order as is
+            if ($hasParentConstructCall && $this->isPropertyDefinedInParentClass($node, $propertyName)) {
                 continue;
             }
 
@@ -133,6 +149,36 @@ CODE_SAMPLE
         }
 
         return $node;
+    }
+
+    private function isParentConstructCall(Expr $expr): bool
+    {
+        if (! $expr instanceof StaticCall) {
+            return false;
+        }
+
+        if (! $this->isName($expr->class, 'parent')) {
+            return false;
+        }
+
+        return $this->isName($expr->name, MethodName::CONSTRUCT);
+    }
+
+    private function isPropertyDefinedInParentClass(Class_ $class, string $propertyName): bool
+    {
+        $classReflection = $this->reflectionResolver->resolveClassReflection($class);
+        if (! $classReflection instanceof ClassReflection) {
+            // unknown parent, keep it safe
+            return true;
+        }
+
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if ($parentClassReflection->getNativeReflection()->hasProperty($propertyName)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function matchAssignedLocalPropertyName(Assign $assign): ?string


### PR DESCRIPTION
When `parent::__construct()` is called first, the parent constructor may write to a property that the child also declares. Moving the child's constructor assign to a property default flips the order — the default now applies *before* the parent constructor runs, so the parent's write wins instead of being overwritten.

Real-world case (Mautic `Client extends FOS\OAuthServerBundle\Model\Client`):

```php
// parent
class Client implements ClientInterface
{
    protected array $allowedGrantTypes = [];

    public function __construct()
    {
        $this->allowedGrantTypes[] = OAuth2::GRANT_TYPE_AUTH_CODE;
    }
}
```

```diff
 class Client extends BaseClient
 {
-    protected array $allowedGrantTypes;
+    protected array $allowedGrantTypes = [OAuth2::GRANT_TYPE_AUTH_CODE, OAuth2::GRANT_TYPE_REFRESH_TOKEN];

     public function __construct()
     {
         parent::__construct();
-
-        $this->allowedGrantTypes = [
-            OAuth2::GRANT_TYPE_AUTH_CODE,
-            OAuth2::GRANT_TYPE_REFRESH_TOKEN,
-        ];
     }
 }
```

Before the change the value ends up `[auth_code, refresh_token]`; after it, the parent appends on top of the default and it becomes `[auth_code, refresh_token, auth_code]`.

## Fix

Skip the property when both hold:

1. `parent::__construct()` is called above the assign
2. the property is also defined in a parent class (checked via `ReflectionProvider`)

Properties owned only by the child still get inlined as before, even with a `parent::__construct()` call present.
