### PR TITLE
[CodeQuality] Move 4 early-return rules to code quality set

### DIFF
--- a/config/set/early-return.php
+++ b/config/set/early-return.php
@@ -4,21 +4,13 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
-use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\ChangeNestedIfsToEarlyReturnRector;
-use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
-use Rector\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\Return_\ReturnBinaryOrToEarlyReturnRector;
-use Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
         ChangeNestedForeachIfsToEarlyContinueRector::class,
-        ChangeIfElseValueAssignToEarlyReturnRector::class,
         ChangeNestedIfsToEarlyReturnRector::class,
-        RemoveAlwaysElseRector::class,
-        PreparedValueToEarlyReturnRector::class,
         ReturnBinaryOrToEarlyReturnRector::class,
-        ReturnEarlyIfVariableRector::class,
     ]);
 };

--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -172,7 +172,7 @@ CODE_SAMPLE
             return true;
         }
 
-        return array_any($classReflection->getParents(), fn(ClassReflection $parentClassReflection) => $parentClassReflection->getNativeReflection()->hasProperty($propertyName));
+        return array_any($classReflection->getParents(), fn (ClassReflection $parentClassReflection) => $parentClassReflection->getNativeReflection()->hasProperty($propertyName));
     }
 
     private function matchAssignedLocalPropertyName(Assign $assign): ?string

--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -72,6 +72,10 @@ use Rector\CodeQuality\Rector\Ternary\TernaryImplodeToImplodeRector;
 use Rector\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector;
 use Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector;
 use Rector\Contract\Rector\RectorInterface;
+use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
+use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
+use Rector\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector;
+use Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector;
 use Rector\Php52\Rector\Property\VarToPublicPropertyRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
@@ -154,6 +158,10 @@ final class CodeQualityLevel
         CallUserFuncWithArrowFunctionToInlineRector::class,
         FlipTypeControlToUseExclusiveTypeRector::class,
         InlineArrayReturnAssignRector::class,
+        RemoveAlwaysElseRector::class,
+        ChangeIfElseValueAssignToEarlyReturnRector::class,
+        PreparedValueToEarlyReturnRector::class,
+        ReturnEarlyIfVariableRector::class,
         InlineIsAInstanceOfRector::class,
         InlineConstructorDefaultToPropertyRector::class,
         TernaryEmptyArrayArrayDimFetchToCoalesceRector::class,


### PR DESCRIPTION
These 4 rules clean up local code quality rather than enforce the early-return coding style. Move their set registration from `early-return` to `CodeQualityLevel::RULES` (right after `InlineArrayReturnAssignRector`, same "assign then return" family).

Set membership only - the rule classes stay in `Rector\EarlyReturn\*`, no namespace change.

`RemoveAlwaysElseRector`:

```diff
 class SomeClass
 {
     public function run($value)
     {
         if ($value) {
             throw new \InvalidStateException;
-        } else {
-            return 10;
         }
+
+        return 10;
     }
 }
```

`ChangeIfElseValueAssignToEarlyReturnRector`:

```diff
 class SomeClass
 {
     public function run()
     {
         if ($this->hasDocBlock($tokens, $index)) {
-            $docToken = $tokens[$this->getDocBlockIndex($tokens, $index)];
-        } else {
-            $docToken = null;
+            return $tokens[$this->getDocBlockIndex($tokens, $index)];
         }

-        return $docToken;
+        return null;
     }
 }
```

`PreparedValueToEarlyReturnRector`:

```diff
 class SomeClass
 {
     public function run()
     {
-        $var = null;
-
         if (rand(0, 1)) {
-            $var = 1;
+            return 1;
         }

         if (rand(0, 1)) {
-            $var = 2;
+            return 2;
         }

-        return $var;
+        return null;
     }
 }
```

`ReturnEarlyIfVariableRector`:

```diff
 class SomeClass
 {
     public function run($value)
     {
         if ($value) {
-            $variable = 'yes';
-        } else {
-            $variable = 'no';
+            return 'yes';
         }

-        return $variable;
+        return 'no';
     }
 }
```

One unrelated hunk: `InlineConstructorDefaultToPropertyRector` had a pre-existing ECS violation on `main` (missing space in an arrow fn); `composer fix-cs` corrected it, so it rides along.
