### PR TITLE
[Testing] Add PHPUnit Test Impact Analysis via jasonmccreary/phpunit-tia

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@ tests/FileFormatter/ValueObject/Fixture/composer_carriage_return_line_feed.json 
 # for 3rd party packages working with rector/rector-src as dependency
 rules-tests export-ignore
 tests export-ignore
+phpunit-tia.php export-ignore

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -12,6 +12,7 @@ return $config
     ->addPathToScan('bin', false)
     // prepared test tooling
     ->ignoreErrorsOnPackage('phpunit/phpunit', [ErrorType::DEV_DEPENDENCY_IN_PROD])
+    ->ignoreErrorsOnPackage('jasonmccreary/phpunit-tia', [ErrorType::DEV_DEPENDENCY_IN_PROD])
     // pinned v3.x version
     ->ignoreErrorsOnPackage('react/promise', [ErrorType::UNUSED_DEPENDENCY])
     // ensure use version ^3.2.0

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "webmozart/assert": "^2.4"
     },
     "require-dev": {
+        "jasonmccreary/phpunit-tia": "^0.1.1",
         "nette/robot-loader": "^4.1",
         "php-parallel-lint/php-parallel-lint": "^1.4",
         "phpstan/extension-installer": "^1.4",

--- a/phpunit-tia.php
+++ b/phpunit-tia.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Tests\Tia\FixtureResolver;
+
+return [
+    'resolvers' => [FixtureResolver::class],
+];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,13 @@
         </testsuite>
     </testsuites>
 
+    <!-- test impact analysis: only re-run tests hit by changed files, requires pcov/xdebug to record -->
+    <extensions>
+        <bootstrap class="JMac\Testing\PhpUnit\Tia\Extension">
+            <parameter name="storage" value="global"/>
+        </bootstrap>
+    </extensions>
+
     <php>
         <ini name="memory_limit" value="-1"/>
     </php>

--- a/src/Testing/PHPUnit/AbstractLazyTestCase.php
+++ b/src/Testing/PHPUnit/AbstractLazyTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Testing\PHPUnit;
 
+use JMac\Testing\PhpUnit\Tia\Traits\RunWithTia;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Version;
 use Rector\Config\RectorConfig;
@@ -11,10 +12,17 @@ use Rector\DependencyInjection\LazyContainerFactory;
 
 abstract class AbstractLazyTestCase extends TestCase
 {
+    // skips tests unaffected by the changed files, based on the recorded coverage graph
+    use RunWithTia {
+        RunWithTia::setUp as tiaSetUp;
+    }
+
     protected static ?RectorConfig $rectorConfig = null;
 
     protected function setUp(): void
     {
+        $this->tiaSetUp();
+
         // this is needed to have always the same preloaded nikic/php-parser classes
         // in both bare AbstractLazyTestCase lazy tests and AbstractRectorTestCase tests
         $this->includePreloadFilesAndScoperAutoload();

--- a/tests/Tia/FixtureResolver.php
+++ b/tests/Tia/FixtureResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Tia;
+
+use JMac\Testing\PhpUnit\Tia\Contracts\Resolver;
+
+/**
+ * Test impact analysis maps a changed file to a test via the recorded coverage graph. Fixture files
+ * never appear in that graph: "*.php.inc" is not executed code, and "Source/" or "Expected/" files are
+ * loaded by reflection, not by the test itself. Without this resolver, a fixture-only change would look
+ * like it affects nothing and the test would be skipped as unaffected.
+ *
+ * Every changed file below a test directory is therefore mapped to the closest test class above it.
+ */
+final class FixtureResolver implements Resolver
+{
+    /**
+     * @var string[]
+     */
+    private const TEST_DIRECTORIES = ['tests/', 'rules-tests/', 'utils/phpstan/tests/'];
+
+    /**
+     * @return list<string>
+     */
+    public function resolve(string $projectRoot, string $changedRelativePath): array
+    {
+        if (! $this->isInTestDirectory($changedRelativePath)) {
+            return [];
+        }
+
+        $rootDirectory = rtrim(str_replace('\\', '/', $projectRoot), '/');
+        $directory = dirname($rootDirectory . '/' . $changedRelativePath);
+
+        while (str_starts_with($directory . '/', $rootDirectory . '/') && $directory !== $rootDirectory) {
+            $testFilePaths = glob($directory . '/*Test.php');
+
+            if ($testFilePaths !== false && $testFilePaths !== []) {
+                return array_values($testFilePaths);
+            }
+
+            $directory = dirname($directory);
+        }
+
+        return [];
+    }
+
+    private function isInTestDirectory(string $changedRelativePath): bool
+    {
+        foreach (self::TEST_DIRECTORIES as $testDirectory) {
+            if (str_starts_with($changedRelativePath, $testDirectory)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Tia/FixtureResolverTest.php
+++ b/tests/Tia/FixtureResolverTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Tia;
+
+use Nette\Utils\FileSystem;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class FixtureResolverTest extends TestCase
+{
+    private string $projectRoot;
+
+    private FixtureResolver $fixtureResolver;
+
+    protected function setUp(): void
+    {
+        $this->projectRoot = sys_get_temp_dir() . '/rector_tia_fixture_resolver';
+
+        FileSystem::delete($this->projectRoot);
+
+        foreach ([
+            'rules-tests/SomeSet/Rector/If_/SomeRector/SomeRectorTest.php',
+            'rules-tests/SomeSet/Rector/If_/SomeRector/Fixture/some_fixture.php.inc',
+            'rules-tests/SomeSet/Rector/If_/SomeRector/Fixture/nested/deep_fixture.php.inc',
+            'rules-tests/SomeSet/Rector/If_/SomeRector/Source/SomeSource.php',
+            'rules-tests/SomeSet/Rector/If_/WithoutTestRector/Fixture/orphan.php.inc',
+            'src/SomeService.php',
+        ] as $relativeFilePath) {
+            FileSystem::write($this->projectRoot . '/' . $relativeFilePath, '');
+        }
+
+        $this->fixtureResolver = new FixtureResolver();
+    }
+
+    protected function tearDown(): void
+    {
+        FileSystem::delete($this->projectRoot);
+    }
+
+    /**
+     * @param string[] $expectedRelativeFilePaths
+     */
+    #[DataProvider('provideData')]
+    public function testResolve(string $changedRelativePath, array $expectedRelativeFilePaths): void
+    {
+        $resolvedFilePaths = $this->fixtureResolver->resolve($this->projectRoot, $changedRelativePath);
+
+        $expectedFilePaths = array_map(
+            fn (string $relativeFilePath): string => $this->projectRoot . '/' . $relativeFilePath,
+            $expectedRelativeFilePaths
+        );
+
+        $this->assertSame($expectedFilePaths, $resolvedFilePaths);
+    }
+
+    public static function provideData(): iterable
+    {
+        $testFilePath = 'rules-tests/SomeSet/Rector/If_/SomeRector/SomeRectorTest.php';
+
+        yield 'fixture file resolves to the sibling test' => [
+            'rules-tests/SomeSet/Rector/If_/SomeRector/Fixture/some_fixture.php.inc',
+            [$testFilePath],
+        ];
+
+        yield 'nested fixture file walks up to the test' => [
+            'rules-tests/SomeSet/Rector/If_/SomeRector/Fixture/nested/deep_fixture.php.inc',
+            [$testFilePath],
+        ];
+
+        yield 'source file resolves to the sibling test' => [
+            'rules-tests/SomeSet/Rector/If_/SomeRector/Source/SomeSource.php',
+            [$testFilePath],
+        ];
+
+        yield 'test file itself resolves to itself' => [$testFilePath, [$testFilePath]];
+
+        yield 'fixture without any test above it resolves to nothing' => [
+            'rules-tests/SomeSet/Rector/If_/WithoutTestRector/Fixture/orphan.php.inc',
+            [],
+        ];
+
+        yield 'file outside test directories is ignored' => ['src/SomeService.php', []];
+    }
+}


### PR DESCRIPTION
Ports [jasonmccreary/phpunit-tia](https://github.com/jasonmccreary/phpunit-tia) (Pest's Test Impact Analysis engine, for PHPUnit 13) into the test suite. TIA records a test -> source coverage graph, then skips tests that no changed file can reach.

## Wiring

The extension is registered in `phpunit.xml`, and the `RunWithTia` trait goes into `AbstractLazyTestCase` so every Rector test case - including `AbstractRectorTestCase` - picks it up:

```php
 abstract class AbstractLazyTestCase extends TestCase
 {
+    // skips tests unaffected by the changed files, based on the recorded coverage graph
+    use RunWithTia {
+        RunWithTia::setUp as tiaSetUp;
+    }
+
     protected function setUp(): void
     {
+        $this->tiaSetUp();
+
         $this->includePreloadFilesAndScoperAutoload();
     }
```

Graph storage is `global` (`~/.phpunit-tia/<project>-<hash>/`), so no `.gitignore` entry is needed.

## Fixtures are invisible to a coverage graph

This is the part that needed work. A fixture-only change - the most common change in this repo - is exactly what TIA gets wrong out of the box:

- `*.php.inc` is never executed, so it gets no coverage edge and no `.php` suffix match
- `Source/` and `Expected/` files are loaded by reflection, not by the test
- the package's generic sibling-directory fallback misses too, because fixtures sit in `Fixture/` while the edges point at `rules/`

So `SomeRectorTest` would be skipped as "unaffected" after editing its own fixture. `phpunit-tia.php` registers a `FixtureResolver` that maps any changed file below a test directory to the closest test class above it:

```
rules-tests/CodeQuality/Rector/If_/SomeRector/Fixture/nested/some_fixture.php.inc
  -> rules-tests/CodeQuality/Rector/If_/SomeRector/SomeRectorTest.php
```

False positives here only cost a re-run; a false negative silently skips a real test. Covered by `tests/Tia/FixtureResolverTest.php`.

## Please read before merging

**`src/Testing` ships.** `.gitattributes` export-ignores `tests` and `rules-tests`, but not `src/Testing`. Since `jasonmccreary/phpunit-tia` is `require-dev`, every repo that extends `AbstractLazyTestCase` / `AbstractRectorTestCase` without that package installed will fatal on the missing trait. That means `rector-doctrine`, `rector-symfony`, `rector-phpunit`, `rector-downgrade-php`, and any user with custom rule tests. Each needs `composer require --dev jasonmccreary/phpunit-tia` - **this should land as a coordinated set of PRs, which is why this is a draft.**

Moving the package to `require` instead is not an option: it declares `"conflict": {"phpunit/phpunit": "<13.2.6"}`, which would block install for every Rector user not on PHPUnit 13.2.6+.

`composer-dependency-analyser` flags the dev-dep-in-prod-code, ignored the same way `phpunit/phpunit` already is.

**Inert until a coverage driver exists.** Recording needs pcov or Xdebug. `tests.yaml` sets `coverage: none`, so CI records nothing and skips nothing - it only prints one line to stderr per run. This is a local-dev speedup until someone decides whether a pcov job is worth it. Replay is decoupled from recording, so a recorded graph still works on a machine without a driver.

## Verified

Full suite green (5332 tests, 6838 assertions), same single pre-existing warning as `main`. No measurable overhead: 34.3s on this branch vs 35.3s on `main`. ECS, PHPStan, Rector and `composer-dependency-analyser` all clean.

**Not verified:** the actual record -> skip cycle. No coverage extension is installed on this machine and none is available in `extension_dir`, so TIA stayed inactive for every local run. The wiring, the resolver and the no-driver fallback path are exercised; the graph replay itself is not.
