### PR TITLE
[DeadCode] Skip RemoveParentDelegatingConstructorRector on protected parent constructor

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_protected_parent_construct.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Fixture/skip_protected_parent_construct.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Source\ProtectedConstructClass;
+
+final class SkipProtectedParentConstruct extends ProtectedConstructClass
+{
+    public function __construct($value)
+    {
+        parent::__construct($value);
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Source/ProtectedConstructClass.php
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector/Source/ProtectedConstructClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector\Source;
+
+class ProtectedConstructClass
+{
+    protected function __construct($value)
+    {
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
@@ -113,6 +113,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // removing public constructor would expose the narrower parent one
+        if (! $parentMethodReflection->isPublic()) {
+            return null;
+        }
+
         $soleStmt = $node->stmts[0];
         $parentCallArgs = $this->matchParentConstructorCallArgs($soleStmt);
         if ($parentCallArgs === null) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9842

The rule checked that the child constructor is public, but never checked the parent's visibility. Removing a public constructor that delegates to a `protected` parent one silently narrows visibility and breaks instantiation:

`Fatal error: Uncaught Error: Call to protected A::__construct() from global scope`

Buggy behavior before this PR:

```diff
 class A
 {
     protected function __construct($value)
     {
     }
 }

 class B extends A
 {
-    public function __construct($value)
-    {
-        parent::__construct($value);
-    }
 }

 new B('value'); // fatal error after the change
```

Now the rule bails out when the parent constructor is not public, so the code above is left untouched.
