### PR TITLE
[CodeQuality] Skip InlineConstructorDefaultToPropertyRector on non-final class

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_non_final_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_non_final_class.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+class ValidatedBase
+{
+    private bool $validated = false;
+
+    protected function __construct()
+    {
+        $this->validate();
+        $this->validated = true;
+    }
+
+    private function validate(): void
+    {
+    }
+}
+
+final class SkipsParentConstructor extends ValidatedBase
+{
+    public function __construct()
+    {
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_non_final_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Fixture/skip_non_final_class.php.inc
@@ -1,23 +1,16 @@
 <?php
 
-class ValidatedBase
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Fixture;
+
+use Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Source\ValidatedBase;
+
+class SkipsParentConstructor extends ValidatedBase
 {
     private bool $validated = false;
 
-    protected function __construct()
+    public function __construct()
     {
         $this->validate();
         $this->validated = true;
-    }
-
-    private function validate(): void
-    {
-    }
-}
-
-final class SkipsParentConstructor extends ValidatedBase
-{
-    public function __construct()
-    {
     }
 }

--- a/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Source/ValidatedBase.php
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector/Source/ValidatedBase.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector\Source;
+
+abstract class ValidatedBase
+{
+    protected function validate(): void
+    {
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -82,6 +82,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        // A child class may bypass the constructor and depend on the declared property default
+        if (! $node->isFinal()) {
+            return null;
+        }
+
         $hasChanged = false;
 
         $constructClassMethod = $node->getMethod(MethodName::CONSTRUCT);

--- a/src/Bridge/SetProviderCollector.php
+++ b/src/Bridge/SetProviderCollector.php
@@ -25,8 +25,9 @@ final readonly class SetProviderCollector
     /**
      * @param SetProviderInterface[] $setProviders
      */
-    public function __construct(private array $setProviders = [])
-    {
+    public function __construct(
+        private array $setProviders = []
+    ) {
     }
 
     /**


### PR DESCRIPTION
Continues #8281 by @Junaid-PK (rebased on `main`, fixture restructured). Fixes rectorphp/rector#9837

`InlineConstructorDefaultToPropertyRector` moves initialization from runtime constructor flow to object creation. On a non-final class a child can omit `parent::__construct()` and still rely on the declared property default, so the move changes observable behavior.

Previously the rule fired on any class:

```diff
 class ValidatedBase
 {
-    private bool $validated = false;
+    private bool $validated = true;

     public function __construct()
     {
         $this->validate();
-        $this->validated = true;
     }
 }

 final class SkipsParentConstructor extends ValidatedBase
 {
     // never calls parent::__construct(), so $validated used to stay false
     public function __construct()
     {
     }
 }
```

Now non-final classes are left untouched; `final` classes are inlined as before.

The rule documentation and existing positive fixtures already use `final` classes, so this makes that boundary explicit.

Fixture follows the `Source/` + namespaced `Fixture/` convention: `Source/ValidatedBase.php` holds the parent, `Fixture/skip_non_final_class.php.inc` the non-final child that must stay unchanged.
