### PR TITLE
Fix e2e scoped build on rector/rector

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -147,6 +147,7 @@ try {
         do {
             $errors[] = $throwable->getMessage();
         } while ($throwable = $throwable->getPrevious());
+
         echo Json::encode([
             'fatal_errors' => $errors,
         ]);

--- a/build/target-repository/e2e/attributes/rector.php
+++ b/build/target-repository/e2e/attributes/rector.php
@@ -7,7 +7,7 @@ use Rector\Symfony\Set\SymfonySetList;
 use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->sets([SymfonySetList::SYMFONY_52]);
+    $rectorConfig->sets([SymfonySetList::ANNOTATIONS_TO_ATTRIBUTES]);
 
     $rectorConfig->phpVersion(PhpVersion::PHP_80);
     $rectorConfig->paths([__DIR__ . '/src']);

--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -28,7 +28,7 @@ final class RectorConfigTest extends AbstractLazyTestCase
         $rectorConfig = $this->getContainer();
 
         $rectorConfig->configure()
-            ->withSets([TwigSetList::TWIG_134])
+            ->withSets([TwigSetList::COMPOSER_BASED])
             ->withRules([ReturnTypeFromReturnNewRector::class])($rectorConfig);
 
         // only collect root withRules()


### PR DESCRIPTION
To fix https://github.com/rectorphp/rector/issues/9845

for error:

```
Undefined class constant 'SYMFONY_52'
```

Ref https://github.com/rectorphp/rector/actions/runs/31177053003/job/92861240228