### PR TITLE
[VersionBonding] Cap polyfill rules by explicitly picked withPhpSets() version

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -147,6 +147,7 @@ try {
         do {
             $errors[] = $throwable->getMessage();
         } while ($throwable = $throwable->getPrevious());
+
         echo Json::encode([
             'fatal_errors' => $errors,
         ]);

--- a/src/Configuration/OnlyRuleResolver.php
+++ b/src/Configuration/OnlyRuleResolver.php
@@ -7,6 +7,7 @@ namespace Rector\Configuration;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\Exception\Configuration\RectorRuleNameAmbiguousException;
 use Rector\Exception\Configuration\RectorRuleNotFoundException;
+use ReflectionClass;
 
 /**
  * @see \Rector\Tests\Configuration\OnlyRuleResolverTest
@@ -106,7 +107,7 @@ final readonly class OnlyRuleResolver
             return false;
         }
 
-        $reflectionClass = new \ReflectionClass($className);
+        $reflectionClass = new ReflectionClass($className);
         if ($reflectionClass->isAbstract()) {
             return false;
         }

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -46,6 +46,14 @@ final class Option
     public const string POLYFILL_PACKAGES = 'polyfill_packages';
 
     /**
+     * PHP version explicitly picked in withPhpSets(), e.g. withPhpSets(php82: true).
+     * Polyfilled rules above this version are skipped, as the version is an intended ceiling.
+     *
+     * @internal
+     */
+    public const string POLYFILL_CEILING_PHP_VERSION = 'polyfill_ceiling_php_version';
+
+    /**
      * @internal Use @see \Rector\Config\RectorConfig::importNames() instead
      * @var string
      */

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -191,6 +191,8 @@ final class RectorConfigBuilder
 
     private ?bool $isWithPhpLevelUsed = null;
 
+    private ?int $pickedPhpSetsVersion = null;
+
     /**
      * @var array<class-string<SetProviderInterface>,bool>
      */
@@ -219,6 +221,13 @@ final class RectorConfigBuilder
         // not to miss it by accident
         if ($this->isWithPhpSetsUsed === true) {
             $this->sets[] = SetList::PHP_POLYFILLS;
+        }
+
+        if ($this->pickedPhpSetsVersion !== null) {
+            SimpleParameterProvider::setParameter(
+                Option::POLYFILL_CEILING_PHP_VERSION,
+                $this->pickedPhpSetsVersion
+            );
         }
 
         // merge sets together
@@ -600,6 +609,9 @@ final class RectorConfigBuilder
         if ($pickedPhpVersions === []) {
             return $this->addPhpLevelSets(ComposerJsonPhpVersionResolver::resolveFromCwdOrFail());
         }
+
+        // explicitly picked version is a ceiling, even for polyfilled rules
+        $this->pickedPhpSetsVersion = $pickedPhpVersions[0];
 
         return $this->addPhpLevelSets($pickedPhpVersions[0]);
     }

--- a/src/VersionBonding/PhpVersionedFilter.php
+++ b/src/VersionBonding/PhpVersionedFilter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\VersionBonding;
 
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\Php\PhpVersionProvider;
 use Rector\Php\PolyfillPackagesProvider;
@@ -28,10 +30,13 @@ final readonly class PhpVersionedFilter
     public function filter(array $rectors): array
     {
         $minProjectPhpVersion = $this->phpVersionProvider->provide();
+        $ceilingPhpVersion = $this->resolveCeilingPhpVersion();
 
         $activeRectors = [];
         foreach ($rectors as $rector) {
-            if ($rector instanceof RelatedPolyfillInterface) {
+            // polyfill package can raise the rule above the project PHP version,
+            // but never above an explicitly picked withPhpSets() version
+            if ($rector instanceof RelatedPolyfillInterface && $ceilingPhpVersion === null) {
                 $polyfillPackageNames = $this->polyfillPackagesProvider->provide();
 
                 if (in_array($rector->providePolyfillPackage(), $polyfillPackageNames, true)) {
@@ -45,12 +50,30 @@ final readonly class PhpVersionedFilter
                 continue;
             }
 
+            $maxPhpVersion = $rector instanceof RelatedPolyfillInterface && $ceilingPhpVersion !== null
+                ? $ceilingPhpVersion
+                : $minProjectPhpVersion;
+
             // does satisfy version? → include
-            if ($rector->provideMinPhpVersion() <= $minProjectPhpVersion) {
+            if ($rector->provideMinPhpVersion() <= $maxPhpVersion) {
                 $activeRectors[] = $rector;
             }
         }
 
         return $activeRectors;
+    }
+
+    private function resolveCeilingPhpVersion(): ?int
+    {
+        if (! SimpleParameterProvider::hasParameter(Option::POLYFILL_CEILING_PHP_VERSION)) {
+            return null;
+        }
+
+        $ceilingPhpVersion = SimpleParameterProvider::provideIntParameter(Option::POLYFILL_CEILING_PHP_VERSION);
+        if ($ceilingPhpVersion <= 0) {
+            return null;
+        }
+
+        return $ceilingPhpVersion;
     }
 }

--- a/tests/Configuration/OnlyRuleResolverTest.php
+++ b/tests/Configuration/OnlyRuleResolverTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Configuration;
 
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\Configuration\OnlyRuleResolver;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector;

--- a/tests/VersionBonding/Fixture/PolyfillPhp83Rector.php
+++ b/tests/VersionBonding/Fixture/PolyfillPhp83Rector.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\VersionBonding\Fixture;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersion;
+use Rector\ValueObject\PolyfillPackage;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Rector\VersionBonding\Contract\RelatedPolyfillInterface;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class PolyfillPhp83Rector extends AbstractRector implements MinPhpVersionInterface, RelatedPolyfillInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Test rector bound to PHP 8.3 polyfill', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return null;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersion::PHP_83;
+    }
+
+    public function providePolyfillPackage(): string
+    {
+        return PolyfillPackage::PHP_83;
+    }
+}

--- a/tests/VersionBonding/PhpVersionedFilterTest.php
+++ b/tests/VersionBonding/PhpVersionedFilterTest.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Rector\Tests\VersionBonding;
 
 use PHPUnit\Framework\TestCase;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Php\PhpVersionProvider;
 use Rector\Php\PolyfillPackagesProvider;
 use Rector\Tests\VersionBonding\Fixture\NoInterfaceRector;
+use Rector\Tests\VersionBonding\Fixture\PolyfillPhp83Rector;
+use Rector\ValueObject\PhpVersion;
+use Rector\ValueObject\PolyfillPackage;
 use Rector\VersionBonding\PhpVersionedFilter;
 
 final class PhpVersionedFilterTest extends TestCase
@@ -20,6 +25,14 @@ final class PhpVersionedFilterTest extends TestCase
         $polyfillPackagesProvider = new PolyfillPackagesProvider();
 
         $this->phpVersionedFilter = new PhpVersionedFilter($phpVersionProvider, $polyfillPackagesProvider);
+
+        SimpleParameterProvider::setParameter(Option::POLYFILL_PACKAGES, [PolyfillPackage::PHP_83]);
+    }
+
+    protected function tearDown(): void
+    {
+        SimpleParameterProvider::setParameter(Option::POLYFILL_PACKAGES, []);
+        SimpleParameterProvider::setParameter(Option::POLYFILL_CEILING_PHP_VERSION, 0);
     }
 
     public function testRectorWithoutInterfaceIsIncluded(): void
@@ -29,5 +42,33 @@ final class PhpVersionedFilterTest extends TestCase
 
         $this->assertCount(1, $filtered);
         $this->assertSame($noInterfaceRector, $filtered[0]);
+    }
+
+    public function testPolyfilledRectorIsIncluded(): void
+    {
+        $polyfillPhp83Rector = new PolyfillPhp83Rector();
+        $filtered = $this->phpVersionedFilter->filter([$polyfillPhp83Rector]);
+
+        $this->assertCount(1, $filtered);
+        $this->assertSame($polyfillPhp83Rector, $filtered[0]);
+    }
+
+    public function testPolyfilledRectorAbovePickedPhpSetsVersionIsSkipped(): void
+    {
+        SimpleParameterProvider::setParameter(Option::POLYFILL_CEILING_PHP_VERSION, PhpVersion::PHP_82);
+
+        $filtered = $this->phpVersionedFilter->filter([new PolyfillPhp83Rector()]);
+        $this->assertCount(0, $filtered);
+    }
+
+    public function testPolyfilledRectorBelowPickedPhpSetsVersionIsIncluded(): void
+    {
+        SimpleParameterProvider::setParameter(Option::POLYFILL_CEILING_PHP_VERSION, PhpVersion::PHP_83);
+
+        $polyfillPhp83Rector = new PolyfillPhp83Rector();
+        $filtered = $this->phpVersionedFilter->filter([$polyfillPhp83Rector]);
+
+        $this->assertCount(1, $filtered);
+        $this->assertSame($polyfillPhp83Rector, $filtered[0]);
     }
 }


### PR DESCRIPTION
When a PHP version is picked explicitly, the `SetList::PHP_POLYFILLS` set is still loaded on top of the picked level sets. `PhpVersionedFilter` then activated any `RelatedPolyfillInterface` rule whose polyfill package sits in root `composer.json`, ignoring the picked version entirely.

So this config:

```php
return RectorConfig::configure()
    ->withPhpSets(php82: true);
```

with `symfony/polyfill-php83` required, still ran `AddOverrideAttributeToOverriddenMethodsRector` (and `JsonValidateRector`), producing PHP 8.3 code from a PHP 8.2 target:

```diff
 final class SomeClass extends ParentClass
 {
+    #[\Override]
     public function run()
     {
     }
 }
```

An explicitly picked version is an intended ceiling, so polyfilled rules above it are now skipped.

Unchanged behaviour when no version is picked — `withPhpSets()` resolving from `composer.json` keeps the full ahead-of-version polyfill activation, which is the point of the set:

```php
// composer.json: "php": "^8.2", "symfony/polyfill-php83": "^1.0"
return RectorConfig::configure()
    ->withPhpSets();
// -> AddOverrideAttributeToOverriddenMethodsRector still active
```

## Implementation

- `withPhpSets()` stores the explicitly picked version, `RectorConfigBuilder::__invoke()` passes it as `Option::POLYFILL_CEILING_PHP_VERSION`.
- `PhpVersionedFilter` skips the polyfill-package bypass when a ceiling is set, and gates `RelatedPolyfillInterface` rules on the ceiling instead of the project PHP version. The latter matters when `composer.json` allows a higher PHP than the picked set, e.g. `"php": "^8.4"` with `withPhpSets(php82: true)`.