### PR TITLE
Deprecate symfonyRoute and symfonyValidator args in withAttributesSets()

### DIFF
--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -243,6 +243,11 @@ final class Option
     public const string DEPRECATED_PHP_SETS_METHODS = 'deprecated_php_sets_methods';
 
     /**
+     * @internal For reporting deprecated withAttributesSets() arguments
+     */
+    public const string DEPRECATED_ATTRIBUTES_SETS_ARGS = 'deprecated_attributes_sets_args';
+
+    /**
      * @internal For collect skipped start with short open tag files to be reported
      */
     public const string SKIPPED_START_WITH_SHORT_OPEN_TAG_FILES = 'skipped_start_with_short_open_tag_files';

--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -27,8 +27,6 @@ use Rector\Doctrine\Set\DoctrineSetList;
 use Rector\Enum\Config\Defaults;
 use Rector\Exception\Configuration\InvalidConfigurationException;
 use Rector\Php\PhpVersionResolver\ComposerJsonPhpVersionResolver;
-use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
-use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\Contract\SetProviderInterface;
 use Rector\Set\Enum\SetGroup;
@@ -462,6 +460,9 @@ final class RectorConfigBuilder
 
     /**
      * Upgrade your annotations to attributes
+     *
+     * @param bool $symfonyRoute Deprecated, included in $symfony
+     * @param bool $symfonyValidator Deprecated, included in $symfony
      */
     public function withAttributesSets(
         bool $symfony = false,
@@ -486,27 +487,13 @@ final class RectorConfigBuilder
             $this->sets[] = SymfonySetList::ANNOTATIONS_TO_ATTRIBUTES;
         }
 
-        // dx for more granular upgrade
+        // both are part of $symfony set, no longer applied on their own
         if ($symfonyRoute) {
-            if ($symfony) {
-                throw new InvalidConfigurationException(
-                    '$symfonyRoute is already included in $symfony. Use $symfony only'
-                );
-            }
-
-            $this->withConfiguredRule(AnnotationToAttributeRector::class, [
-                new AnnotationToAttribute('Symfony\Component\Routing\Annotation\Route'),
-            ]);
+            SimpleParameterProvider::addParameter(Option::DEPRECATED_ATTRIBUTES_SETS_ARGS, 'symfonyRoute');
         }
 
         if ($symfonyValidator) {
-            if ($symfony) {
-                throw new InvalidConfigurationException(
-                    '$symfonyValidator is already included in $symfony. Use $symfony only'
-                );
-            }
-
-            $this->sets[] = SymfonySetList::SYMFONY_52_VALIDATOR_ATTRIBUTES;
+            SimpleParameterProvider::addParameter(Option::DEPRECATED_ATTRIBUTES_SETS_ARGS, 'symfonyValidator');
         }
 
         if ($doctrine || $all) {

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -186,6 +186,7 @@ EOF
         $this->deprecatedRulesReporter->reportDeprecatedRectorUnsupportedMethods();
         $this->deprecatedRulesReporter->reportDeprecatedCacheMetaExtensions();
         $this->deprecatedRulesReporter->reportDeprecatedPhpSetsMethods();
+        $this->deprecatedRulesReporter->reportDeprecatedAttributesSetsArgs();
 
         $this->missConfigurationReporter->reportSkippedNeverRegisteredRules();
         $this->missConfigurationReporter->reportUnusedSkips($processResult);

--- a/src/Reporting/DeprecatedRulesReporter.php
+++ b/src/Reporting/DeprecatedRulesReporter.php
@@ -84,6 +84,21 @@ final readonly class DeprecatedRulesReporter
         }
     }
 
+    public function reportDeprecatedAttributesSetsArgs(): void
+    {
+        /** @var string[] $deprecatedAttributesSetsArgs */
+        $deprecatedAttributesSetsArgs = SimpleParameterProvider::provideArrayParameter(
+            Option::DEPRECATED_ATTRIBUTES_SETS_ARGS
+        );
+
+        foreach (array_unique($deprecatedAttributesSetsArgs) as $deprecatedAttributesSetsArg) {
+            $this->symfonyStyle->warning(sprintf(
+                'The "->withAttributesSets(%s: true)" argument is deprecated and no longer applied. It is already included in the "symfony: true" argument, use it instead.',
+                $deprecatedAttributesSetsArg
+            ));
+        }
+    }
+
     public function reportDeprecatedRectorUnsupportedMethods(): void
     {
         // to be added in related PR

--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Config;
 
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
@@ -12,15 +11,10 @@ use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\RenameProperty;
-use Rector\Symfony\Set\TwigSetList;
+use Rector\Symfony\Set\SymfonySetList;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 
-/**
- * On macOS, this file order config cause this container read other tests' config.
- * so, this #[RunTestsInSeparateProcesses] is needed.
- */
-#[RunTestsInSeparateProcesses]
 final class RectorConfigTest extends AbstractLazyTestCase
 {
     public function test(): void
@@ -28,8 +22,8 @@ final class RectorConfigTest extends AbstractLazyTestCase
         $rectorConfig = $this->getContainer();
 
         $rectorConfig->configure()
-            ->withSets([TwigSetList::TWIG_134])
-            ->withRules([ReturnTypeFromReturnNewRector::class])($rectorConfig);
+            ->withSets([SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION])
+            ->withRules([ReturnTypeFromReturnNewRector::class]);
 
         // only collect root withRules()
         $this->assertCount(1, SimpleParameterProvider::provideArrayParameter(Option::ROOT_STANDALONE_REGISTERED_RULES));

--- a/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
+++ b/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
@@ -6,10 +6,12 @@ namespace Rector\Tests\DependencyInjection;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Configuration\RenamedClassesDataCollector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 
+#[RunTestsInSeparateProcesses]
 final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractLazyTestCase
 {
     /**


### PR DESCRIPTION
Both `symfonyRoute` and `symfonyValidator` args are already covered by the `symfony` arg of `withAttributesSets()`. They are no longer applied on their own and now report a deprecation warning instead.

```diff
 return RectorConfig::configure()
-    ->withAttributesSets(symfonyRoute: true, symfonyValidator: true);
+    ->withAttributesSets(symfony: true);
```

Passing them still runs, but prints:

```
[WARNING] The "->withAttributesSets(symfonyRoute: true)" argument is deprecated and no
          longer applied. It is already included in the "symfony: true" argument, use
          it instead.
```

Previously both args threw an `InvalidConfigurationException` when combined with `symfony: true`; that exception is gone, as the args are now no-ops.

This will be handled by composer-based sets :+1: 