### PR TITLE
Remove AddOverrideAttributeToOverriddenMethodsRector from PHP 8.3 and polyfill sets

### DIFF
--- a/config/set/php-polyfills.php
+++ b/config/set/php-polyfills.php
@@ -11,7 +11,6 @@ use Rector\Php80\Rector\NotIdentical\MbStrContainsRector;
 use Rector\Php80\Rector\NotIdentical\StrContainsRector;
 use Rector\Php80\Rector\Ternary\GetDebugTypeRector;
 use Rector\Php83\Rector\BooleanAnd\JsonValidateRector;
-use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector;
 use Rector\Php84\Rector\Foreach_\ForeachToArrayAllRector;
 use Rector\Php84\Rector\Foreach_\ForeachToArrayAnyRector;
@@ -34,7 +33,6 @@ return static function (RectorConfig $rectorConfig): void {
 
         // PHP 8.3
         JsonValidateRector::class,
-        AddOverrideAttributeToOverriddenMethodsRector::class,
 
         // PHP 8.4
         ForeachToArrayAllRector::class,

--- a/config/set/php83.php
+++ b/config/set/php83.php
@@ -6,14 +6,12 @@ use Rector\Config\RectorConfig;
 use Rector\Php83\Rector\BooleanAnd\JsonValidateRector;
 use Rector\Php83\Rector\Class_\ReadOnlyAnonymousClassRector;
 use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
-use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Php83\Rector\FuncCall\CombineHostPortLdapUriRector;
 use Rector\Php83\Rector\FuncCall\DynamicClassConstFetchRector;
 use Rector\Php83\Rector\FuncCall\RemoveGetClassGetParentClassNoArgsRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
-        AddOverrideAttributeToOverriddenMethodsRector::class,
         AddTypeToConstRector::class,
         CombineHostPortLdapUriRector::class,
         RemoveGetClassGetParentClassNoArgsRector::class,

--- a/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
+++ b/rules/Php83/Rector/ClassMethod/AddOverrideAttributeToOverriddenMethodsRector.php
@@ -29,9 +29,7 @@ use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
 use Rector\ValueObject\PhpVersionFeature;
-use Rector\ValueObject\PolyfillPackage;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
-use Rector\VersionBonding\Contract\RelatedPolyfillInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -40,7 +38,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\Tests\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector\AddOverrideAttributeToOverriddenMethodsRectorTest
  */
-final class AddOverrideAttributeToOverriddenMethodsRector extends AbstractRector implements MinPhpVersionInterface, RelatedPolyfillInterface, ConfigurableRectorInterface
+final class AddOverrideAttributeToOverriddenMethodsRector extends AbstractRector implements MinPhpVersionInterface, ConfigurableRectorInterface
 {
     /**
      * @api
@@ -226,11 +224,6 @@ CODE_SAMPLE
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::OVERRIDE_ATTRIBUTE;
-    }
-
-    public function providePolyfillPackage(): string
-    {
-        return PolyfillPackage::PHP_83;
     }
 
     /**

--- a/src/Bridge/SetProviderCollector.php
+++ b/src/Bridge/SetProviderCollector.php
@@ -23,16 +23,10 @@ use Rector\Set\ValueObject\ComposerTriggeredSet;
 final readonly class SetProviderCollector
 {
     /**
-     * @var SetProviderInterface[]
+     * @param SetProviderInterface[] $setProviders
      */
-    private array $setProviders;
-
-    /**
-     * @param SetProviderInterface[] $extraSetProviders
-     */
-    public function __construct(array $extraSetProviders = [])
+    public function __construct(private array $setProviders = [])
     {
-        $this->setProviders = $extraSetProviders;
     }
 
     /**


### PR DESCRIPTION
The rule adds `#[Override]` to every single overridden method. In practice that spams the codebase with attributes without bringing real value, so it should not run automatically as part of `withPhpSets()`.

```diff
 class SomeChild extends SomeParent
 {
-    #[\Override]
     public function run()
     {
     }
 }
```

Changes:
- removed from `config/set/php83.php`
- removed from `config/set/php-polyfills.php`
- dropped `RelatedPolyfillInterface` from the rule, as `RegisterRelatedPolyfillRectorRule` (PHPStan) requires every polyfill-related rule to be registered in the polyfill set

The rule itself stays and can be registered explicitly:

```php
$rectorConfig->rule(AddOverrideAttributeToOverriddenMethodsRector::class);
```