### PR TITLE
Add --php option to process command to run only PHP rules

### DIFF
--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -102,6 +102,13 @@ final readonly class ConfigurationFactory
             SimpleParameterProvider::setParameter(Option::IS_RUN_NARROWED, true);
         }
 
+        $isPhpOnly = (bool) $input->getOption(Option::PHP);
+
+        // "--php" narrows the run the same way "--only" does
+        if ($isPhpOnly) {
+            SimpleParameterProvider::setParameter(Option::IS_RUN_NARROWED, true);
+        }
+
         return new Configuration(
             $isDryRun,
             $showProgressBar,
@@ -121,6 +128,7 @@ final readonly class ConfigurationFactory
             $levelOverflows,
             $showRulesSummary,
             $isComposerBased,
+            $isPhpOnly,
         );
     }
 

--- a/src/Configuration/ConfigurationRuleFilter.php
+++ b/src/Configuration/ConfigurationRuleFilter.php
@@ -13,6 +13,7 @@ use Rector\VersionBonding\ValueObject\ComposerBoundRuleConfiguration;
 
 /**
  * Modify available rector rules based on the configuration options
+ * @see \Rector\Tests\Configuration\ConfigurationRuleFilterTest
  */
 final class ConfigurationRuleFilter
 {

--- a/src/Configuration/ConfigurationRuleFilter.php
+++ b/src/Configuration/ConfigurationRuleFilter.php
@@ -8,6 +8,7 @@ use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\ValueObject\Configuration;
 use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Rector\VersionBonding\ValueObject\ComposerBoundRuleConfiguration;
 
 /**
@@ -39,6 +40,10 @@ final class ConfigurationRuleFilter
 
         if ($this->configuration->isComposerBased()) {
             return $this->filterComposerBased($rectors);
+        }
+
+        if ($this->configuration->isPhpOnly()) {
+            return $this->filterPhpOnly($rectors);
         }
 
         return $rectors;
@@ -79,6 +84,24 @@ final class ConfigurationRuleFilter
             }
 
             if (in_array($rector::class, $composerBoundRectorClasses, true)) {
+                $activeRectors[] = $rector;
+            }
+        }
+
+        return $activeRectors;
+    }
+
+    /**
+     * Keeps rules bound to a minimal PHP version, e.g. PHP upgrade rules
+     *
+     * @param list<RectorInterface> $rectors
+     * @return list<RectorInterface>
+     */
+    private function filterPhpOnly(array $rectors): array
+    {
+        $activeRectors = [];
+        foreach ($rectors as $rector) {
+            if ($rector instanceof MinPhpVersionInterface) {
                 $activeRectors[] = $rector;
             }
         }

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -296,6 +296,11 @@ final class Option
     public const string COMPOSER_BASED = 'composer-based';
 
     /**
+     * Run only rules bound to a minimal PHP version
+     */
+    public const string PHP = 'php';
+
+    /**
      * @internal To filter files by specific suffix
      */
     public const string ONLY_SUFFIX = 'only-suffix';

--- a/src/Console/ProcessConfigureDecorator.php
+++ b/src/Console/ProcessConfigureDecorator.php
@@ -67,6 +67,13 @@ final class ProcessConfigureDecorator
         );
 
         $command->addOption(
+            Option::PHP,
+            null,
+            InputOption::VALUE_NONE,
+            'Run only PHP rules, e.g. rules bound to a minimal PHP version'
+        );
+
+        $command->addOption(
             Option::ONLY_SUFFIX,
             null,
             InputOption::VALUE_REQUIRED,

--- a/src/ValueObject/Configuration.php
+++ b/src/ValueObject/Configuration.php
@@ -36,12 +36,18 @@ final readonly class Configuration
         private array $levelOverflows = [],
         private bool $showRulesSummary = false,
         private bool $isComposerBased = false,
+        private bool $isPhpOnly = false,
     ) {
     }
 
     public function isComposerBased(): bool
     {
         return $this->isComposerBased;
+    }
+
+    public function isPhpOnly(): bool
+    {
+        return $this->isPhpOnly;
     }
 
     public function isDryRun(): bool

--- a/tests/Configuration/ConfigurationRuleFilterTest.php
+++ b/tests/Configuration/ConfigurationRuleFilterTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Configuration;
+
+use Rector\Configuration\ConfigurationRuleFilter;
+use Rector\DeadCode\Rector\If_\RemoveDeadInstanceOfRector;
+use Rector\Php80\Rector\Class_\StringableForToStringRector;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\ValueObject\Configuration;
+
+final class ConfigurationRuleFilterTest extends AbstractLazyTestCase
+{
+    private ConfigurationRuleFilter $configurationRuleFilter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurationRuleFilter = $this->make(ConfigurationRuleFilter::class);
+    }
+
+    public function testPhpOnlyKeepsMinPhpVersionRules(): void
+    {
+        $stringableForToStringRector = $this->make(StringableForToStringRector::class);
+        $removeDeadInstanceOfRector = $this->make(RemoveDeadInstanceOfRector::class);
+
+        $this->configurationRuleFilter->setConfiguration($this->createConfiguration(true));
+
+        $filteredRectors = $this->configurationRuleFilter->filter(
+            [$stringableForToStringRector, $removeDeadInstanceOfRector]
+        );
+
+        $this->assertSame([$stringableForToStringRector], $filteredRectors);
+    }
+
+    public function testWithoutPhpOnlyKeepsAllRules(): void
+    {
+        $stringableForToStringRector = $this->make(StringableForToStringRector::class);
+        $removeDeadInstanceOfRector = $this->make(RemoveDeadInstanceOfRector::class);
+
+        $this->configurationRuleFilter->setConfiguration($this->createConfiguration(false));
+
+        $filteredRectors = $this->configurationRuleFilter->filter(
+            [$stringableForToStringRector, $removeDeadInstanceOfRector]
+        );
+
+        $this->assertSame([$stringableForToStringRector, $removeDeadInstanceOfRector], $filteredRectors);
+    }
+
+    private function createConfiguration(bool $isPhpOnly): Configuration
+    {
+        return new Configuration(isPhpOnly: $isPhpOnly);
+    }
+}

--- a/tests/Parallel/Command/WorkerCommandLineFactoryTest.php
+++ b/tests/Parallel/Command/WorkerCommandLineFactoryTest.php
@@ -185,6 +185,16 @@ final class WorkerCommandLineFactoryTest extends AbstractLazyTestCase
             ],
             "'" . PHP_BINARY . "' '" . self::DUMMY_MAIN_SCRIPT . "' '" . $cliInputOptionsAsString . "' worker --memory-limit='-1' --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi",
         ];
+
+        yield [
+            [
+                self::COMMAND => 'process',
+                Option::SOURCE => ['src'],
+                '--' . Option::OUTPUT_FORMAT => ConsoleOutputFormatter::NAME,
+                '--' . Option::PHP => true,
+            ],
+            "'" . PHP_BINARY . "' '" . self::DUMMY_MAIN_SCRIPT . "' '" . $cliInputOptionsAsString . "' worker --php --port 2000 --identifier 'identifier' 'src' --output-format 'json' --no-ansi",
+        ];
     }
 
     private function cleanUpEmptyQuoteExpectedCommandOutput(string $result): string


### PR DESCRIPTION
Adds a `--php` option to the `process` command, that runs **only PHP rules** - rules bound to a minimal PHP version, i.e. rules implementing `MinPhpVersionInterface`.

Useful to split a PHP version upgrade from the rest of the rules, without having to maintain a second config:

```bash
vendor/bin/rector process src --php --dry-run
```

## Example

With a config combining PHP sets and other sets:

```php
return RectorConfig::configure()
    ->withPaths([__DIR__ . '/src'])
    ->withPhpSets(php84: true)
    ->withPreparedSets(deadCode: true, codeQuality: true);
```

Running `vendor/bin/rector process src --dry-run` applies everything:

```diff
 class Demo
 {
-    public function run(string $value = null)
+    public function run(?string $value = null)
     {
-        $unused = 1;
-
         return $value;
     }
 }
```

Running `vendor/bin/rector process src --php --dry-run` keeps only the PHP version rules:

```diff
 class Demo
 {
-    public function run(string $value = null)
+    public function run(?string $value = null)
     {
         $unused = 1;
 
         return $value;
     }
 }
```

Downgrade rules are not affected, as they do not implement `MinPhpVersionInterface`.

Like `--only` and `--composer-based`, the option narrows the run, so unused skip reporting is disabled to avoid false positives. It is forwarded to workers in parallel runs.
