### PR TITLE
[dx] Warn on skipped classes that are not Rector rules

### DIFF
--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -241,6 +241,11 @@ final class Option
     public const string SKIPPED_RECTOR_RULES = 'skipped_rector_rules';
 
     /**
+     * @internal For reporting skipped classes that are not Rector rules
+     */
+    public const string SKIPPED_NON_RECTOR_CLASSES = 'skipped_non_rector_classes';
+
+    /**
      * @internal For reporting deprecated cache meta extensions
      */
     public const string CACHE_META_EXTENSIONS = 'cache_meta_extensions';

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -189,6 +189,7 @@ EOF
         $this->deprecatedRulesReporter->reportDeprecatedAttributesSetsArgs();
 
         $this->missConfigurationReporter->reportSkippedNeverRegisteredRules();
+        $this->missConfigurationReporter->reportSkippedNonRectorClasses();
         $this->missConfigurationReporter->reportUnusedSkips($processResult);
 
         return $this->resolveReturnCode($processResult, $configuration);

--- a/src/Reporting/MissConfigurationReporter.php
+++ b/src/Reporting/MissConfigurationReporter.php
@@ -7,6 +7,7 @@ namespace Rector\Reporting;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Configuration\VendorMissAnalyseGuard;
+use Rector\Contract\Rector\RectorInterface;
 use Rector\PostRector\Contract\Rector\PostRectorInterface;
 use Rector\ValueObject\ProcessResult;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -70,6 +71,26 @@ final readonly class MissConfigurationReporter
         ));
 
         $this->symfonyStyle->listing($neverRegisteredSkippedRules);
+    }
+
+    public function reportSkippedNonRectorClasses(): void
+    {
+        $skippedNonRectorClasses = SimpleParameterProvider::provideArrayParameter(
+            Option::SKIPPED_NON_RECTOR_CLASSES
+        );
+
+        if ($skippedNonRectorClasses === []) {
+            return;
+        }
+
+        $this->symfonyStyle->warning(sprintf(
+            '%s not a Rector rule, so %s never be skipped. Only classes that implement "%s" can be used in "->withSkip()"',
+            count($skippedNonRectorClasses) > 1 ? 'These skipped classes are' : 'This skipped class is',
+            count($skippedNonRectorClasses) > 1 ? 'they can' : 'it can',
+            RectorInterface::class
+        ));
+
+        $this->symfonyStyle->listing($skippedNonRectorClasses);
     }
 
     /**

--- a/src/Validation/RectorConfigValidator.php
+++ b/src/Validation/RectorConfigValidator.php
@@ -6,7 +6,9 @@ namespace Rector\Validation;
 
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Contract\Rector\RectorInterface;
 use Rector\Exception\ShouldNotHappenException;
+use Rector\PostRector\Contract\Rector\PostRectorInterface;
 
 final class RectorConfigValidator
 {
@@ -33,8 +35,14 @@ final class RectorConfigValidator
     {
         $nonExistingRules = [];
         $skippedRectorRules = [];
+        $skippedNonRectorClasses = [];
 
         foreach ($skip as $key => $value) {
+            if (is_string($key) && self::isNonRectorClass($key)) {
+                $skippedNonRectorClasses[] = $key;
+                continue;
+            }
+
             if (self::isRectorClassValue($key)) {
                 if (class_exists($key)) {
                     $skippedRectorRules[] = $key;
@@ -58,6 +66,7 @@ final class RectorConfigValidator
         }
 
         SimpleParameterProvider::addParameter(Option::SKIPPED_RECTOR_RULES, $skippedRectorRules);
+        SimpleParameterProvider::addParameter(Option::SKIPPED_NON_RECTOR_CLASSES, $skippedNonRectorClasses);
 
         if ($nonExistingRules === []) {
             return;
@@ -71,6 +80,23 @@ final class RectorConfigValidator
         throw new ShouldNotHappenException(
             'These rules from "$rectorConfig->skip()" do not exist - remove them or fix their names:' . PHP_EOL . $nonExistingRulesString
         );
+    }
+
+    /**
+     * Only Rector rules are matched against skipped classes, so any other class can never be skipped
+     */
+    private static function isNonRectorClass(string $key): bool
+    {
+        // interfaces are allowed, as they can mark a group of Rector rules
+        if (! class_exists($key)) {
+            return false;
+        }
+
+        if (is_a($key, RectorInterface::class, true)) {
+            return false;
+        }
+
+        return ! is_a($key, PostRectorInterface::class, true);
     }
 
     private static function isRectorClassValue(mixed $value): bool

--- a/tests/Reporting/MissConfigurationReporterTest.php
+++ b/tests/Reporting/MissConfigurationReporterTest.php
@@ -7,12 +7,15 @@ namespace Rector\Tests\Reporting;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Configuration\VendorMissAnalyseGuard;
+use Rector\Php85\Rector\FuncCall\OrdSingleByteRector;
+use Rector\PostRector\Rector\NameImportingPostRector;
 use Rector\Reporting\MissConfigurationReporter;
 use Rector\Reporting\UnusedSkipResolver;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use Rector\Tests\Skipper\Skipper\Fixture\Element\FifthElement;
 use Rector\Tests\Skipper\Skipper\Fixture\Element\ThreeMan;
 use Rector\Tests\Skipper\Skipper\Source\AnotherClassToSkip;
+use Rector\Validation\RectorConfigValidator;
 use Rector\ValueObject\ProcessResult;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -59,6 +62,38 @@ final class MissConfigurationReporterTest extends AbstractLazyTestCase
     {
         SimpleParameterProvider::setParameter(Option::SKIP, []);
         SimpleParameterProvider::setParameter(Option::REPORT_UNUSED_SKIPS, false);
+        SimpleParameterProvider::setParameter(Option::SKIPPED_NON_RECTOR_CLASSES, []);
+    }
+
+    public function testReportsSkippedNonRectorClass(): void
+    {
+        RectorConfigValidator::ensureRectorRulesExist([
+            // not a Rector rule, can never be skipped
+            AnotherClassToSkip::class => ['some/path'],
+            // Rector rule, must not be reported
+            OrdSingleByteRector::class => ['some/path'],
+            // post rector rule, must not be reported
+            NameImportingPostRector::class => ['some/path'],
+        ]);
+
+        $this->missConfigurationReporter->reportSkippedNonRectorClasses();
+
+        $output = $this->bufferedOutput->fetch();
+
+        $this->assertStringContainsString('AnotherClassToSkip', $output);
+        $this->assertStringNotContainsString('OrdSingleByteRector', $output);
+        $this->assertStringNotContainsString('NameImportingPostRector', $output);
+    }
+
+    public function testReportsNothingOnRectorClassesOnly(): void
+    {
+        RectorConfigValidator::ensureRectorRulesExist([
+            OrdSingleByteRector::class => ['some/path'],
+        ]);
+
+        $this->missConfigurationReporter->reportSkippedNonRectorClasses();
+
+        $this->assertSame('', $this->bufferedOutput->fetch());
     }
 
     public function testReportsOnlyTrackableUnusedSkips(): void


### PR DESCRIPTION
Skipping a class in `->withSkip()` only has an effect if that class is a Rector rule - skipped classes are matched against Rector rules only. Any other class silently does nothing, e.g. a typo'd or moved rule name, or a service class picked by mistake.

Now such a class is reported after the run:

```php
return RectorConfig::configure()
    ->withSkip([
        // not a Rector rule
        App\Service\SomeService::class => [__DIR__ . '/src/SomeFile.php'],
    ]);
```

```
 [WARNING] This skipped class is not a Rector rule, so it can never be skipped.
           Only classes that implement "Rector\Contract\Rector\RectorInterface"
           can be used in "->withSkip()"

 * App\Service\SomeService
```

Interfaces are allowed, as they can mark a group of rules. `PostRectorInterface` rules are allowed too.
