### PR TITLE
[dx] Include skipped class name in non-Rector-rule warning message

### DIFF
--- a/src/Reporting/MissConfigurationReporter.php
+++ b/src/Reporting/MissConfigurationReporter.php
@@ -84,13 +84,13 @@ final readonly class MissConfigurationReporter
         }
 
         $this->symfonyStyle->warning(sprintf(
-            '%s not a Rector rule, so %s never be skipped. Only classes that implement "%s" can be used in "->withSkip()"',
-            count($skippedNonRectorClasses) > 1 ? 'These skipped classes are' : 'This skipped class is',
+            '%s "%s" %s not a Rector rule, so %s never be skipped. Only classes that implement "%s" can be used in "->withSkip()"',
+            count($skippedNonRectorClasses) > 1 ? 'These skipped classes' : 'This skipped class',
+            implode('", "', $skippedNonRectorClasses),
+            count($skippedNonRectorClasses) > 1 ? 'are' : 'is',
             count($skippedNonRectorClasses) > 1 ? 'they can' : 'it can',
             RectorInterface::class
         ));
-
-        $this->symfonyStyle->listing($skippedNonRectorClasses);
     }
 
     /**


### PR DESCRIPTION
The warning for `->withSkip()` classes that are not Rector rules printed the class names in a separate listing block below the message. The message itself had no reference to the broken value.

Now the class name is part of the message:

```diff
-This skipped class is not a Rector rule, so it can never be skipped. Only classes that
-implement "Rector\Contract\Rector\RectorInterface" can be used in "->withSkip()"
-
- * App\Service\SomeService
+This skipped class "App\Service\SomeService" is not a Rector rule, so it can never be
+skipped. Only classes that implement "Rector\Contract\Rector\RectorInterface" can be
+used in "->withSkip()"
```

The now redundant `listing()` call is removed.