### PR TITLE
Remove DeprecatedAnnotationToDeprecatedAttributeRector from PHP 8.4 set

### DIFF
--- a/config/set/php84.php
+++ b/config/set/php84.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector;
 use Rector\Php84\Rector\Foreach_\ForeachToArrayAllRector;
 use Rector\Php84\Rector\Foreach_\ForeachToArrayAnyRector;
 use Rector\Php84\Rector\Foreach_\ForeachToArrayFindKeyRector;
@@ -19,7 +18,6 @@ return static function (RectorConfig $rectorConfig): void {
         RoundingModeEnumRector::class,
         AddEscapeArgumentRector::class,
         NewMethodCallWithoutParenthesesRector::class,
-        DeprecatedAnnotationToDeprecatedAttributeRector::class,
         ForeachToArrayFindRector::class,
         ForeachToArrayFindKeyRector::class,
         ForeachToArrayAllRector::class,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -123,6 +123,12 @@ parameters:
             identifier: rector.upgradeDowngradeRegisteredInSet
             path: rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
 
+        # deliberately kept out of the php84 set, as it turns a doc annotation into a runtime deprecation;
+        # it stays available to register directly with withRules()
+        -
+            identifier: rector.upgradeDowngradeRegisteredInSet
+            path: rules/Php84/Rector/Class_/DeprecatedAnnotationToDeprecatedAttributeRector.php
+
         # is nested expr
         -
             message: '#Access to an undefined property PhpParser\\Node\\Expr\:\:\$expr#'


### PR DESCRIPTION
`DeprecatedAnnotationToDeprecatedAttributeRector` changes a doc annotation into a runtime attribute:

```diff
 final class SomeClass
 {
     /**
      * @deprecated 1.0 Use SomeOtherClass instead
      */
+    #[\Deprecated(message: 'Use SomeOtherClass instead', since: '1.0')]
     public function oldMethod()
     {
     }
 }
```

`#[\Deprecated]` makes PHP emit an `E_USER_DEPRECATED` on every call. So a comment that only informed the reader now produces runtime noise, and in projects that convert deprecations to exceptions it breaks the test suite.

That is not what a PHP 8.4 upgrade is usually about, so the rule is removed from the `php84` set. It stays available to register manually, and it stays in the `php-polyfills` set where the opt-in is explicit.