### PR TITLE
Resolve the composer-based set of extension packages in withComposerBased()

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -63,6 +63,17 @@ final class RectorConfigBuilder
     ];
 
     /**
+     * The composer-based set of the extensions that rector-src does not require, so their set list class cannot be
+     * imported here. Resolved at run-time; an extension that ships no such set falls back to its set group.
+     *
+     * @var array<SetGroup::*, string>
+     */
+    private const array EXTENSION_COMPOSER_BASED_SET_LISTS = [
+        SetGroup::LARAVEL => 'RectorLaravel\\Set\\LaravelSetList::COMPOSER_BASED',
+        SetGroup::DRUPAL => 'DrupalRector\\Set\\DrupalSetList::COMPOSER_BASED',
+    ];
+
+    /**
      * @var string[]
      */
     private array $paths = [];
@@ -741,10 +752,24 @@ final class RectorConfigBuilder
             SetGroup::DRUPAL => $drupal,
         ];
 
-        foreach ($setMap as $setPath => $isEnabled) {
-            if ($isEnabled) {
-                $this->setGroups[] = $setPath;
+        foreach ($setMap as $setGroup => $isEnabled) {
+            if (! $isEnabled) {
+                continue;
             }
+
+            $setListConstant = self::EXTENSION_COMPOSER_BASED_SET_LISTS[$setGroup];
+            if (defined($setListConstant)) {
+                $setFilePath = constant($setListConstant);
+                Assert::string($setFilePath);
+
+                // single set, as every rule inside is bound to the installed package version on its own
+                $this->sets[] = $setFilePath;
+                continue;
+            }
+
+            // @deprecated fallback for extensions that still describe their sets as objects,
+            // instead of bonding the rules themselves
+            $this->setGroups[] = $setGroup;
         }
 
         if ($phpunit) {

--- a/tests/Configuration/ExtensionComposerBasedSetTest.php
+++ b/tests/Configuration/ExtensionComposerBasedSetTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Configuration;
+
+use PHPUnit\Framework\TestCase;
+use Rector\Configuration\RectorConfigBuilder;
+use Rector\Set\Enum\SetGroup;
+use ReflectionClass;
+
+final class ExtensionComposerBasedSetTest extends TestCase
+{
+    /**
+     * Both toggles of withComposerBased() that point at an extension package must have a set list mapped,
+     * otherwise the lookup hits an undefined array key.
+     */
+    public function testEverySetGroupToggleHasASetListMapped(): void
+    {
+        $extensionSetLists = $this->provideExtensionComposerBasedSetLists();
+
+        self::assertArrayHasKey(SetGroup::LARAVEL, $extensionSetLists);
+        self::assertArrayHasKey(SetGroup::DRUPAL, $extensionSetLists);
+
+        foreach ($extensionSetLists as $setListConstant) {
+            self::assertMatchesRegularExpression('#^\w+(\\\\\w+)+::\w+$#', $setListConstant);
+        }
+    }
+
+    /**
+     * The extension packages are not required by rector-src, so their constant is undefined here and the
+     * deprecated set group has to keep working.
+     */
+    public function testFallsBackToTheSetGroupWhenTheExtensionIsNotInstalled(): void
+    {
+        foreach ($this->provideExtensionComposerBasedSetLists() as $setListConstant) {
+            self::assertFalse(defined($setListConstant), $setListConstant);
+        }
+
+        $rectorConfigBuilder = new RectorConfigBuilder()
+            ->withComposerBased(laravel: true, drupal: true);
+
+        self::assertSame([SetGroup::LARAVEL, SetGroup::DRUPAL], $this->readPrivateArray($rectorConfigBuilder, 'setGroups'));
+        self::assertSame([], $this->readPrivateArray($rectorConfigBuilder, 'sets'));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function provideExtensionComposerBasedSetLists(): array
+    {
+        $extensionSetLists = new ReflectionClass(RectorConfigBuilder::class)
+            ->getConstant('EXTENSION_COMPOSER_BASED_SET_LISTS');
+
+        self::assertIsArray($extensionSetLists);
+
+        return $extensionSetLists;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    private function readPrivateArray(RectorConfigBuilder $rectorConfigBuilder, string $propertyName): array
+    {
+        $value = new ReflectionClass($rectorConfigBuilder)
+            ->getProperty($propertyName)
+            ->getValue($rectorConfigBuilder);
+
+        self::assertIsArray($value);
+
+        return $value;
+    }
+}


### PR DESCRIPTION
`withComposerBased(phpunit: true)`, `doctrine:`, `twig:` and `symfony:` load a single set in which every rule is bound to the installed package version on its own — the pattern `ComposerPackageConstraintInterface` deprecated `SetProviderInterface` and `ComposerTriggeredSet` in favour of.

The `laravel:` and `drupal:` toggles could not follow, because rector-src does not require those packages and so cannot import their set list class. They stayed on the deprecated set-group path, which means an extension that *has* migrated to a composer-based set has no way to be picked up by the very toggle meant to load it.

This resolves the extension's set list constant by name, so no dependency is needed:

```php
private const array EXTENSION_COMPOSER_BASED_SET_LISTS = [
    SetGroup::LARAVEL => 'RectorLaravel\Set\LaravelSetList::COMPOSER_BASED',
    SetGroup::DRUPAL => 'DrupalRector\Set\DrupalSetList::COMPOSER_BASED',
];
```

```diff
-        foreach ($setMap as $setPath => $isEnabled) {
-            if ($isEnabled) {
-                $this->setGroups[] = $setPath;
+        foreach ($setMap as $setGroup => $isEnabled) {
+            if (! $isEnabled) {
+                continue;
             }
+
+            $setListConstant = self::EXTENSION_COMPOSER_BASED_SET_LISTS[$setGroup];
+            if (defined($setListConstant)) {
+                $setFilePath = constant($setListConstant);
+                Assert::string($setFilePath);
+
+                // single set, as every rule inside is bound to the installed package version on its own
+                $this->sets[] = $setFilePath;
+                continue;
+            }
+
+            // @deprecated fallback for extensions that still describe their sets as objects,
+            // instead of bonding the rules themselves
+            $this->setGroups[] = $setGroup;
         }
```

Constant defined → the set is loaded, exactly like the bundled packages'. Constant absent — extension not installed, or not migrated yet — → the set group is registered as before, so nothing changes for it. `defined()` autoloads the class and returns `false` rather than throwing when it does not exist.

`palantirnet/drupal-rector` has `DrupalSetList::COMPOSER_BASED` ready on a branch: a single generated set registering every rule with the exact `drupal/core` version its deprecation was introduced in, configurable ones through `ruleWithConfigurationComposerVersionBound()`. With this change `withComposerBased(drupal: true)` picks it up as soon as both are released, and `rector composer-based` reports the constraints.