### PR TITLE
[ci] Bump actions/checkout to v5, to run on Node.js 24

### DIFF
--- a/.github/workflows/build_scoped_rector.yaml
+++ b/.github/workflows/build_scoped_rector.yaml
@@ -33,7 +33,7 @@ jobs:
                 run: sleep 20
 
             -
-                uses: actions/checkout@v4
+                uses: actions/checkout@v5
                 with:
                     fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
 
             # 6. clone remote repository, so we can push it
             -
-                uses: "actions/checkout@v4"
+                uses: "actions/checkout@v5"
                 with:
                     repository: rectorphp/rector
                     path: remote-repository

--- a/.github/workflows/claude_issue_fixer.yaml
+++ b/.github/workflows/claude_issue_fixer.yaml
@@ -21,7 +21,7 @@ jobs:
         steps:
             # 1. Checkout
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -86,7 +86,7 @@ jobs:
         timeout-minutes: 10
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
 
             # see https://github.com/shivammathur/setup-php
             -

--- a/.github/workflows/code_analysis_no_dev.yaml
+++ b/.github/workflows/code_analysis_no_dev.yaml
@@ -13,7 +13,7 @@ jobs:
         timeout-minutes: 10
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
             # see https://github.com/shivammathur/setup-php
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,7 +49,7 @@ jobs:
         name: End to end test - ${{ matrix.directory }}
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/e2e_command_with_option.yaml
+++ b/.github/workflows/e2e_command_with_option.yaml
@@ -21,7 +21,7 @@ jobs:
         timeout-minutes: 10
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
 
             # see https://github.com/shivammathur/setup-php
             -

--- a/.github/workflows/e2e_with_cache.yaml
+++ b/.github/workflows/e2e_with_cache.yaml
@@ -30,7 +30,7 @@ jobs:
         name: End to end test - ${{ matrix.directory }}
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/e2e_with_no_diffs.yaml
+++ b/.github/workflows/e2e_with_no_diffs.yaml
@@ -30,7 +30,7 @@ jobs:
         name: End to end test - ${{ matrix.directory }}
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/packages_tests.yaml
+++ b/.github/workflows/packages_tests.yaml
@@ -37,7 +37,7 @@ jobs:
         steps:
             # see https://github.com/actions/checkout#usage
             -
-                uses: "actions/checkout@v4"
+                uses: "actions/checkout@v5"
                 with:
                     repository: ${{ matrix.repository_name }}
                     ref: "main"

--- a/.github/workflows/phpstan_printer_test.yaml
+++ b/.github/workflows/phpstan_printer_test.yaml
@@ -25,7 +25,7 @@ jobs:
 
         name: PHP ${{ matrix.php-versions }} tests (${{ matrix.os }})
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
 
             -
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpunit_and_phpstan_autoload_compat_test.yaml
+++ b/.github/workflows/phpunit_and_phpstan_autoload_compat_test.yaml
@@ -38,7 +38,7 @@ jobs:
                 working-directory: compat-tests
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
 
             -
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -14,7 +14,7 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == 'rectorphp/rector-src'
         steps:
             -
-                uses: actions/checkout@v4
+                uses: actions/checkout@v5
                 with:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/remove_unused_deps.yaml
+++ b/.github/workflows/remove_unused_deps.yaml
@@ -14,7 +14,7 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == 'rectorphp/rector-src'
         steps:
             -
-                uses: actions/checkout@v4
+                uses: actions/checkout@v5
                 with:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
 
         name: PHP ${{ matrix.php-versions }} tests (${{ matrix.os }})
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
 
             -
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -13,7 +13,7 @@ jobs:
         runs-on: "ubuntu-latest"
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
 
 

--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -33,7 +33,7 @@ jobs:
 
         steps:
             -
-                uses: actions/checkout@v4
+                uses: actions/checkout@v5
                 with:
                     token: ${{ secrets.ACCESS_TOKEN }}
 


### PR DESCRIPTION
Every job currently reports:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

`actions/checkout@v5` targets Node.js 24 natively, which clears the warning.

```diff
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
```

Applied to all 16 workflow files (17 usages). No other change; every workflow still parses as valid YAML.

The remaining actions were not flagged by the runner and are left alone.