### PR TITLE
[ci] Bump outdated GitHub actions to current majors

### DIFF
--- a/.github/workflows/claude_issue_fixer.yaml
+++ b/.github/workflows/claude_issue_fixer.yaml
@@ -38,7 +38,7 @@ jobs:
                   coverage: none
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@v4
 
             # 4. Pick a random open issue from rectorphp/rector (skip any already covered by a PR)
             - name: Pick a fixable issue

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -35,7 +35,7 @@ jobs:
 
             -
                 # commit only to core contributors who have repository access
-                uses: stefanzweifel/git-auto-commit-action@v5
+                uses: stefanzweifel/git-auto-commit-action@v7
                 with:
                     commit_message: '[ci-review] Rector Rectify'
                     commit_author: 'GitHub Action <actions@github.com>'

--- a/.github/workflows/remove_unused_deps.yaml
+++ b/.github/workflows/remove_unused_deps.yaml
@@ -32,7 +32,7 @@ jobs:
 
             -
                 # commit only to core contributors who have repository access
-                uses: stefanzweifel/git-auto-commit-action@v5
+                uses: stefanzweifel/git-auto-commit-action@v7
                 with:
                     commit_message: '[ci-review] Remove unused dependencies'
                     commit_author: 'GitHub Action <actions@github.com>'

--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -51,7 +51,7 @@ jobs:
             # see https://github.com/peter-evans/create-pull-request
             -
                 name: Create pull-request
-                uses: peter-evans/create-pull-request@v6
+                uses: peter-evans/create-pull-request@v8
                 id: cpr
                 with:
                     token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
Follow-up to #8335. Three actions were still on older majors, all now on the current one.

| action | before | after |
|---|---|---|
| `ramsey/composer-install` | `v3` | `v4` |
| `stefanzweifel/git-auto-commit-action` | `v5` | `v7` |
| `peter-evans/create-pull-request` | `v6` | `v8` |

`ramsey/composer-install@v4` was already used in every other workflow; `claude_issue_fixer.yaml` was the last `v3` holdout.

## Why the majors are safe here

**`git-auto-commit-action` v5 -> v7.** `v6` removed `create_branch`, `skip_checkout` and `skip_fetch`, and `v7` restored them; none of them are used here. Only `commit_message`, `commit_author` and `commit_user_email` are, and all three are unchanged. The `branch` input keeps the same default in both versions:

```yaml
# v5 and v7 alike
branch:
    default: ${{ github.head_ref }}
```

That matters because `rector.yaml` and `remove_unused_deps.yaml` run on `pull_request` with a plain `actions/checkout`, so the repository is in detached HEAD. `v7` notices this, but only logs a warning and carries on:

```bash
_check_if_repository_is_in_detached_state() {
    if [ -z "$(git symbolic-ref HEAD)" ]
    then
        _log "warning" "Repository is in a detached HEAD state. git-auto-commit will likely handle this automatically. [...]";
```

So `[ci-review] Rector Rectify` keeps working as before.

**`create-pull-request` v6 -> v8.** The `v7` behaviour changes do not touch this usage:

- `git-token` renamed to `branch-token` — this workflow passes `token`, not `git-token`
- `pull-request-operation` now returns `none` instead of empty — the condition here is `== 'created'`
- the deprecated `PULL_REQUEST_NUMBER` env output was removed — this workflow already reads the `pull-request-number` output

`v8` only raises the self-hosted runner requirement to v2.327.1 for Node 24; these jobs run on `ubuntu-latest`.

Every workflow still parses as valid YAML.

Left alone, since they were not flagged and are not in the Node 20 group: `dessant/lock-threads@v5`, `actions/stale@v10`, `crate-ci/typos@v1.46.0`.