### PR TITLE
[ci] Bump lock-threads, stale and typos actions to current versions

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: dessant/lock-threads@v5
+            - uses: dessant/lock-threads@v6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,7 +11,7 @@ jobs:
         if: github.repository == 'rectorphp/rector-src'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/stale@v10
+            - uses: actions/stale@v11
               with:
                   days-before-stale: 60
                   days-before-close: 90

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -18,7 +18,7 @@ jobs:
 
 
             - name: "Check for typos"
-              uses: "crate-ci/typos@v1.46.0"
+              uses: "crate-ci/typos@v1.49.0"
               with:
                   config: .github/typos.toml
                   files: "README.md src config rules tests rules-tests templates"


### PR DESCRIPTION
Follow-up to #8335 and #8336, covering the last three actions still on an older version.

| action | before | after |
|---|---|---|
| `dessant/lock-threads` | `v5` | `v6` |
| `actions/stale` | `v10` | `v11` |
| `crate-ci/typos` | `v1.46.0` | `v1.49.0` |

## Why these are safe

**`lock-threads` v5 -> v6.** The changelog lists exactly one breaking change:

> ⚠ BREAKING CHANGES
> * the action now requires Node.js 24

No inputs changed, so `github-token`, `pr-inactive-days`, `pr-comment` and `exclude-any-pr-labels` all still apply.

**`stale` v10 -> v11.** An ESM migration plus a `brace-expansion` security bump; no breaking changes and no input changes. The Node 24 jump already happened in `v10`, which this repo is on.

**`typos` v1.46.0 -> v1.49.0.** A `typos` bump can fail CI on its own, because new dictionary entries can flag words that used to pass. Ran `v1.49.0` locally over the exact file list the workflow checks:

```
$ typos --config .github/typos.toml README.md src config rules tests rules-tests templates
$ echo $?
0
```

No new findings.

After this, every action in `.github/workflows` is on its current major.