### PR TITLE
[NodeAnalyzer] Treat infinite loop without break as always terminated

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_infinite_while.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_infinite_while.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class AlwaysTerminatedInfiniteWhile
+{
+    public function run($a)
+    {
+        while (true) {
+            if ($a) {
+                return 'A';
+            }
+
+            $a = doSomething();
+        }
+
+        echo 'never executed';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class AlwaysTerminatedInfiniteWhile
+{
+    public function run($a)
+    {
+        while (true) {
+            if ($a) {
+                return 'A';
+            }
+
+            $a = doSomething();
+        }
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_while_true_with_break.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_while_true_with_break.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+class SkipWhileTrueWithBreak
+{
+    public function run($a)
+    {
+        while (true) {
+            if ($a) {
+                break;
+            }
+
+            $a = doSomething();
+        }
+
+        echo 'still reachable after break';
+    }
+}

--- a/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
@@ -6,16 +6,20 @@ namespace Rector\NodeAnalyzer;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Exit_;
 use PhpParser\Node\Expr\Throw_;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Continue_;
+use PhpParser\Node\Stmt\Do_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Finally_;
+use PhpParser\Node\Stmt\For_;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Goto_;
 use PhpParser\Node\Stmt\If_;
@@ -26,6 +30,7 @@ use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\TryCatch;
+use PhpParser\Node\Stmt\While_;
 use PhpParser\NodeVisitor;
 use Rector\PhpDocParser\NodeTraverser\SimpleCallableNodeTraverser;
 use Rector\PhpParser\Node\FileNode;
@@ -65,6 +70,11 @@ final readonly class TerminatedNodeAnalyzer
             return false;
         }
 
+        // an infinite loop with no break never falls through to the next stmt
+        if ($node instanceof While_ || $node instanceof Do_ || $node instanceof For_) {
+            return $this->isTerminatedInfiniteLoop($node);
+        }
+
         if (! in_array($node::class, self::TERMINABLE_NODES_BY_ITS_STMTS, true)) {
             return $this->isTerminatedNode($node, $currentStmt);
         }
@@ -79,6 +89,68 @@ final readonly class TerminatedNodeAnalyzer
 
         /** @var Switch_ $node */
         return $this->isTerminatedInLastStmtsSwitch($node);
+    }
+
+    private function isTerminatedInfiniteLoop(While_|Do_|For_ $loop): bool
+    {
+        if (! $this->isInfiniteLoopCondition($loop)) {
+            return false;
+        }
+
+        // a break/goto escaping the loop makes the following stmt reachable again;
+        // stay conservative and treat any break/goto in the body as escaping
+        return ! $this->hasBreakOrGoto($loop->stmts);
+    }
+
+    private function isInfiniteLoopCondition(While_|Do_|For_ $loop): bool
+    {
+        if ($loop instanceof For_) {
+            // "for (;;)" has no condition and loops forever
+            if ($loop->cond === []) {
+                return true;
+            }
+
+            $lastCond = end($loop->cond);
+            return $lastCond instanceof Expr && $this->isAlwaysTrue($lastCond);
+        }
+
+        return $this->isAlwaysTrue($loop->cond);
+    }
+
+    private function isAlwaysTrue(Expr $expr): bool
+    {
+        if ($expr instanceof ConstFetch) {
+            return $expr->name->toLowerString() === 'true';
+        }
+
+        return $expr instanceof Int_ && $expr->value !== 0;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function hasBreakOrGoto(array $stmts): bool
+    {
+        $hasBreakOrGoto = false;
+
+        $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
+            $stmts,
+            static function (Node $node) use (&$hasBreakOrGoto): ?int {
+                // nested scopes bring their own jump targets
+                if ($node instanceof FunctionLike || $node instanceof ClassLike) {
+                    return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+                }
+
+                if (! $node instanceof Break_ && ! $node instanceof Goto_) {
+                    return null;
+                }
+
+                $hasBreakOrGoto = true;
+                return NodeVisitor::STOP_TRAVERSAL;
+            }
+        );
+
+        return $hasBreakOrGoto;
     }
 
     private function isTerminatedNode(Stmt $previousNode, Stmt $currentStmt): bool


### PR DESCRIPTION
Fixes rectorphp/rector#9852

`TerminatedNodeAnalyzer::isAlwaysTerminated()` did not recognize an infinite loop (`while (true)`, `do {} while (true)`, `for (;;)`) with no `break` as a terminating statement. Anything following such a loop is unreachable, but the analyzer reported the loop as fall-through.

Consequence downstream: `ConsoleExecuteReturnIntRector` appended a redundant `return Command::SUCCESS;` after a `while (true)` body whose exits all `return`, producing an *unreachable statement* that fails PHPStan at level 7+ (reported in the issue). `RemoveUnreachableStatementRector` (the core consumer) also failed to strip such dead code.

Now an infinite loop with no escaping `break`/`goto` is treated as always terminated:

```php
protected function execute(...): int
{
    while (true) {
        if ($this->shouldStop()) {
            return Command::SUCCESS;
        }
        $this->tick();
    }
    // was appended before, now correctly omitted:
    // return Command::SUCCESS; ← unreachable
}
```

Behavior with `RemoveUnreachableStatementRector`:

```diff
 while (true) {
     if ($a) {
         return 'A';
     }
     $a = doSomething();
 }
-echo 'never executed';
```

Conservative on purpose: a loop containing any `break`/`goto` (which may exit it) is left as non-terminating, so no code that could still be reached is dropped. Only literal always-true conditions (`true`, non-zero int literal, empty `for(;;)`) qualify — dynamic conditions like `while ($x)` are untouched.

Fixtures: `always_terminated_infinite_while.php.inc` (removed dead code) and `skip_while_true_with_break.php.inc` (kept, has a break).
