### PR TITLE
[CI] Move Windows tests to nightly cron

### DIFF
--- a/.github/workflows/tests_windows.yaml
+++ b/.github/workflows/tests_windows.yaml
@@ -1,10 +1,10 @@
-name: Tests
+name: Tests (Windows)
 
 on:
-    pull_request: null
-    push:
-     branches:
-        - main
+    schedule:
+        # every 3 hours
+        - cron: '0 */3 * * *'
+    workflow_dispatch: null
 
 
 
@@ -17,13 +17,12 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest]
                 php-versions: ['8.4', '8.5']
 
-        runs-on: ${{ matrix.os }}
+        runs-on: windows-latest
         timeout-minutes: 4
 
-        name: PHP ${{ matrix.php-versions }} tests (${{ matrix.os }})
+        name: PHP ${{ matrix.php-versions }} tests (windows-latest)
         steps:
             -   uses: actions/checkout@v5
 


### PR DESCRIPTION
## Why

Windows runners on every PR/push made CI feedback slow. Windows jobs are much slower than Ubuntu and blocked fast iteration.

## What

- Drop `windows-latest` from `tests.yaml` matrix (Ubuntu-only on PR/push now).
- New `tests_windows.yaml` runs Windows tests on a schedule: cron `0 */3 * * *` (every 3 hours), plus manual `workflow_dispatch`.

Same PHP matrix (`8.4`, `8.5`) and same phpunit run, just moved off the PR hot path.