### PR TITLE
[CI] Drop Windows from PHPUnit benchmark

### DIFF
--- a/.github/workflows/benchmark_phpunit.yaml
+++ b/.github/workflows/benchmark_phpunit.yaml
@@ -1,7 +1,7 @@
 name: Benchmark PHPUnit
 
 # A/B wall-time benchmark: serial phpunit vs the Go parallel runner.
-# Scheduled only (not on pull requests); runs every 2 hours on ubuntu + windows.
+# Scheduled only (not on pull requests); runs every 2 hours on ubuntu.
 # Reminder: cron fires only from the default branch, so this starts running
 # once the file is on `main`.
 on:
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest]
+                os: [ubuntu-latest]
                 php-versions: ['8.4', '8.5']
 
         runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Drop `windows-latest` from the PHPUnit A/B benchmark matrix (`benchmark_phpunit.yaml`). Benchmark now runs on `ubuntu-latest` only.

Windows CI test coverage is unchanged — it stays in `tests_windows.yaml`.

```diff
 matrix:
-    os: [ubuntu-latest, windows-latest]
+    os: [ubuntu-latest]
     php-versions: ['8.4', '8.5']
```