### PR TITLE
Remove abandoned symplify/phpstan-extensions in favor of symplify/phpstan-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
         "rector/swiss-knife": "^2.4.1",
         "shipmonk/composer-dependency-analyser": "^1.8",
         "symplify/easy-coding-standard": "^13.2.13",
-        "symplify/phpstan-extensions": "^12.0.2",
         "symplify/phpstan-rules": "^14.12",
         "symplify/vendor-patches": "^11.5",
         "tomasvotruba/class-leak": "^2.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,6 +23,10 @@ services:
 parameters:
     level: 8
 
+    # getcwd()/dirname()/realpath() always return string, as previously provided by abandoned symplify/phpstan-extensions
+    symplify:
+        pathStrings: true
+
     reportUnmatchedIgnoredErrors: false
 
     errorFormat: symplify


### PR DESCRIPTION
`symplify/phpstan-extensions` is abandoned as shown in composer install/update:

```bash
Package symplify/easy-parallel is abandoned, you should avoid using it. Use local parallel configuration instead.
```

and on https://packagist.org/packages/symplify/phpstan-extensions

The `symplify/phpstan-rules` already in `composer.json`, so this PR remove it and add set `pathStrings` to be `true` for `symplify` parameters for `getcwd()`, `dirname()`, and `realpath()` usage.