### PR TITLE
[VersionBonding] Allow a rule to require multiple composer package constraints at once

### DIFF
--- a/src/Console/Command/ComposerBasedCommand.php
+++ b/src/Console/Command/ComposerBasedCommand.php
@@ -103,19 +103,25 @@ final class ComposerBasedCommand extends Command
             }
 
             $composerPackageConstraint = $rector->provideComposerPackageConstraint();
-            $packageName = $composerPackageConstraint->getPackageName();
-            $constraint = $composerPackageConstraint->getConstraint();
+            $composerPackageConstraints = is_array($composerPackageConstraint)
+                ? $composerPackageConstraint
+                : [$composerPackageConstraint];
 
-            $installedVersion = $this->installedPackageResolver->resolvePackageVersion($packageName);
-            $isActive = $installedVersion !== null && Semver::satisfies($installedVersion, $constraint);
+            foreach ($composerPackageConstraints as $composerPackageConstraint) {
+                $packageName = $composerPackageConstraint->getPackageName();
+                $constraint = $composerPackageConstraint->getConstraint();
 
-            $tableRows[] = [
-                $this->printShortClassName($rector::class),
-                $packageName,
-                $constraint,
-                $installedVersion ?? '-',
-                $isActive ? 'yes' : 'no',
-            ];
+                $installedVersion = $this->installedPackageResolver->resolvePackageVersion($packageName);
+                $isActive = $installedVersion !== null && Semver::satisfies($installedVersion, $constraint);
+
+                $tableRows[] = [
+                    $this->printShortClassName($rector::class),
+                    $packageName,
+                    $constraint,
+                    $installedVersion ?? '-',
+                    $isActive ? 'yes' : 'no',
+                ];
+            }
         }
 
         // sort by package name first, then by rule class

--- a/src/VersionBonding/ComposerPackageConstraintFilter.php
+++ b/src/VersionBonding/ComposerPackageConstraintFilter.php
@@ -43,14 +43,25 @@ final readonly class ComposerPackageConstraintFilter
     private function satisfiesComposerPackageConstraint(ComposerPackageConstraintInterface $rector): bool
     {
         $composerPackageConstraint = $rector->provideComposerPackageConstraint();
-        $packageVersion = $this->installedPackageResolver->resolvePackageVersion(
-            $composerPackageConstraint->getPackageName(),
-        );
+        $composerPackageConstraints = is_array($composerPackageConstraint)
+            ? $composerPackageConstraint
+            : [$composerPackageConstraint];
 
-        if ($packageVersion === null) {
-            return false;
+        // every constraint must be satisfied, so the rule fits every required package at once
+        foreach ($composerPackageConstraints as $composerPackageConstraint) {
+            $packageVersion = $this->installedPackageResolver->resolvePackageVersion(
+                $composerPackageConstraint->getPackageName(),
+            );
+
+            if ($packageVersion === null) {
+                return false;
+            }
+
+            if (! Semver::satisfies($packageVersion, $composerPackageConstraint->getConstraint())) {
+                return false;
+            }
         }
 
-        return Semver::satisfies($packageVersion, $composerPackageConstraint->getConstraint());
+        return true;
     }
 }

--- a/src/VersionBonding/Contract/ComposerPackageConstraintInterface.php
+++ b/src/VersionBonding/Contract/ComposerPackageConstraintInterface.php
@@ -15,5 +15,11 @@ use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
  */
 interface ComposerPackageConstraintInterface
 {
-    public function provideComposerPackageConstraint(): ComposerPackageConstraint;
+    /**
+     * Return a single constraint, or a list of constraints that must all be satisfied at once,
+     * e.g. an attribute that only works when both a library and its framework integration are new enough.
+     *
+     * @return ComposerPackageConstraint|list<ComposerPackageConstraint>
+     */
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint|array;
 }

--- a/tests/VersionBonding/ComposerPackageConstraintFilterTest.php
+++ b/tests/VersionBonding/ComposerPackageConstraintFilterTest.php
@@ -7,8 +7,10 @@ namespace Rector\Tests\VersionBonding;
 use PHPUnit\Framework\TestCase;
 use Rector\Composer\InstalledPackageResolver;
 use Rector\Tests\VersionBonding\Fixture\ComposerPackageConstraintRector;
+use Rector\Tests\VersionBonding\Fixture\ComposerPackageConstraintsRector;
 use Rector\Tests\VersionBonding\Fixture\NoInterfaceRector;
 use Rector\VersionBonding\ComposerPackageConstraintFilter;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 
 final class ComposerPackageConstraintFilterTest extends TestCase
 {
@@ -68,6 +70,40 @@ final class ComposerPackageConstraintFilterTest extends TestCase
     {
         $composerPackageConstraintRector = new ComposerPackageConstraintRector('nikic/php-parser', '<1.0.0');
         $filtered = $this->composerPackageConstraintFilter->filter([$composerPackageConstraintRector]);
+
+        $this->assertCount(0, $filtered);
+    }
+
+    public function testRectorWithAllConstraintsSatisfiedIsIncluded(): void
+    {
+        $composerPackageConstraintsRector = new ComposerPackageConstraintsRector(
+            new ComposerPackageConstraint('nikic/php-parser', '>=4.0.0'),
+            new ComposerPackageConstraint('phpstan/phpstan', '>=1.0.0'),
+        );
+        $filtered = $this->composerPackageConstraintFilter->filter([$composerPackageConstraintsRector]);
+
+        $this->assertCount(1, $filtered);
+        $this->assertSame($composerPackageConstraintsRector, $filtered[0]);
+    }
+
+    public function testRectorWithOneUnsatisfiedConstraintIsExcluded(): void
+    {
+        $composerPackageConstraintsRector = new ComposerPackageConstraintsRector(
+            new ComposerPackageConstraint('nikic/php-parser', '>=4.0.0'),
+            new ComposerPackageConstraint('nikic/php-parser', '>=999.0.0'),
+        );
+        $filtered = $this->composerPackageConstraintFilter->filter([$composerPackageConstraintsRector]);
+
+        $this->assertCount(0, $filtered);
+    }
+
+    public function testRectorWithOneMissingPackageIsExcluded(): void
+    {
+        $composerPackageConstraintsRector = new ComposerPackageConstraintsRector(
+            new ComposerPackageConstraint('nikic/php-parser', '>=4.0.0'),
+            new ComposerPackageConstraint('non-existent/package', '>=1.0.0'),
+        );
+        $filtered = $this->composerPackageConstraintFilter->filter([$composerPackageConstraintsRector]);
 
         $this->assertCount(0, $filtered);
     }

--- a/tests/VersionBonding/Fixture/ComposerPackageConstraintsRector.php
+++ b/tests/VersionBonding/Fixture/ComposerPackageConstraintsRector.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\VersionBonding\Fixture;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ComposerPackageConstraintsRector extends AbstractRector implements ComposerPackageConstraintInterface
+{
+    /**
+     * @var ComposerPackageConstraint[]
+     */
+    private array $composerPackageConstraints;
+
+    public function __construct(ComposerPackageConstraint ...$composerPackageConstraints)
+    {
+        $this->composerPackageConstraints = $composerPackageConstraints;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Test rector with multiple composer package constraints', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return null;
+    }
+
+    /**
+     * @return list<ComposerPackageConstraint>
+     */
+    public function provideComposerPackageConstraint(): array
+    {
+        return array_values($this->composerPackageConstraints);
+    }
+}


### PR DESCRIPTION
Enables a version-bonded rule to declare **more than one** composer package constraint, all of which must be satisfied for the rule to run.

## Why

Some rules only make sense when *two* packages are new enough at the same time. Example from [rectorphp/rector#9856](https://github.com/rectorphp/rector/issues/9856): the `#[AsTwigFilter]` / `#[AsTwigFunction]` / `#[AsTwigTest]` attributes exist in `twig/twig` 3.21, but Symfony only autoregisters extension-less classes built from them in `symfony/twig-bridge` 7.3. A rule gated on twig alone fires on Symfony 6.4, strips `TwigExtension`, and silently loses every filter/function.

Until now `provideComposerPackageConstraint()` could return a single constraint only.

## What

`ComposerPackageConstraintInterface::provideComposerPackageConstraint()` may now return either a single `ComposerPackageConstraint` (unchanged) or a `list<ComposerPackageConstraint>`. The return type widened to `ComposerPackageConstraint|array`, so every existing implementer stays valid by covariance — no rule needs to change.

The filter requires **all** constraints to be satisfied; a single miss (or missing package) skips the rule:

```php
public function provideComposerPackageConstraint(): array
{
    return [
        new ComposerPackageConstraint('twig/twig', '>=3.21'),
        new ComposerPackageConstraint('symfony/twig-bridge', '>=7.3'),
    ];
}
```

`bin/rector composer-based` (the debug table) now prints one row per constraint.

The matching rule fix lives in a follow-up rector-symfony PR that depends on this one.
