### PR TITLE
[Php74] Add IfToNullCoalescingAssignRector to convert if null-guard to ??=

### DIFF
--- a/config/set/php74.php
+++ b/config/set/php74.php
@@ -13,6 +13,7 @@ use Rector\Php74\Rector\FuncCall\HebrevcToNl2brHebrevRector;
 use Rector\Php74\Rector\FuncCall\MbStrrposEncodingArgumentPositionRector;
 use Rector\Php74\Rector\FuncCall\MoneyFormatToNumberFormatRector;
 use Rector\Php74\Rector\FuncCall\RestoreIncludePathToIniRestoreRector;
+use Rector\Php74\Rector\If_\IfToNullCoalescingAssignRector;
 use Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector;
 use Rector\Php74\Rector\StaticCall\ExportToReflectionFunctionRector;
 use Rector\Php74\Rector\Ternary\ParenthesizeNestedTernaryRector;
@@ -34,6 +35,7 @@ return static function (RectorConfig $rectorConfig): void {
         ExportToReflectionFunctionRector::class,
         MbStrrposEncodingArgumentPositionRector::class,
         NullCoalescingOperatorRector::class,
+        IfToNullCoalescingAssignRector::class,
         ClosureToArrowFunctionRector::class,
         RestoreDefaultNullToNullableTypePropertyRector::class,
         CurlyToSquareBracketArrayStringRector::class,

--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/is_null_property.php.inc
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/is_null_property.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+class IsNullProperty
+{
+    private $instance;
+
+    public function get()
+    {
+        if (is_null($this->instance)) {
+            $this->instance = new self();
+        }
+
+        return $this->instance;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+class IsNullProperty
+{
+    private $instance;
+
+    public function get()
+    {
+        $this->instance ??= new self();
+
+        return $this->instance;
+    }
+}
+
+?>

--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/isset_array.php.inc
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/isset_array.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+$array = [];
+if (! isset($array['user_id'])) {
+    $array['user_id'] = 'value';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+$array = [];
+$array['user_id'] ??= 'value';
+
+?>

--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/null_identical_variable.php.inc
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/null_identical_variable.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+function nullIdenticalVariable($value)
+{
+    if (null === $value) {
+        $value = 'default';
+    }
+}
+
+function variableIdenticalNull($value)
+{
+    if ($value === null) {
+        $value = 'default';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+function nullIdenticalVariable($value)
+{
+    $value ??= 'default';
+}
+
+function variableIdenticalNull($value)
+{
+    $value ??= 'default';
+}
+
+?>

--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/skip_different_target.php.inc
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/skip_different_target.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+function skipDifferentTarget($value, $other)
+{
+    if (null === $value) {
+        $other = 'default';
+    }
+}

--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/skip_else.php.inc
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/skip_else.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+function skipElse($value)
+{
+    if (null === $value) {
+        $value = 'default';
+    } else {
+        $value = 'other';
+    }
+}

--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/skip_multiple_isset_vars.php.inc
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/skip_multiple_isset_vars.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+function skipMultipleIssetVars($first, $second)
+{
+    if (! isset($first, $second)) {
+        $first = 'default';
+    }
+}

--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/skip_multiple_stmts.php.inc
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/skip_multiple_stmts.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+function skipMultipleStmts($value)
+{
+    if (null === $value) {
+        $value = 'default';
+        echo $value;
+    }
+}

--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/skip_self_reference.php.inc
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/skip_self_reference.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+function skipSelfReference($value)
+{
+    if (null === $value) {
+        $value = $value . 'suffix';
+    }
+}

--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/IfToNullCoalescingAssignRectorTest.php
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/IfToNullCoalescingAssignRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class IfToNullCoalescingAssignRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/config/configured_rule.php
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php74\Rector\If_\IfToNullCoalescingAssignRector;
+
+return RectorConfig::configure()
+    ->withRules([IfToNullCoalescingAssignRector::class]);

--- a/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php
+++ b/rules/DeadCode/Rector/ConstFetch/RemovePhpVersionIdCheckRector.php
@@ -84,12 +84,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): null|array|int
     {
-        /**
-         * $this->phpVersionProvider->provide() fallback is here as $currentFileProvider must be accessed after initialization
-         */
-        if ($this->phpVersion === null) {
-            $this->phpVersion = $this->phpVersionProvider->provide();
-        }
+        $this->phpVersion ??= $this->phpVersionProvider->provide();
 
         if (! $node->cond instanceof BinaryOp) {
             return null;

--- a/rules/Naming/Guard/PropertyConflictingNameGuard/MatchPropertyTypeConflictingNameGuard.php
+++ b/rules/Naming/Guard/PropertyConflictingNameGuard/MatchPropertyTypeConflictingNameGuard.php
@@ -33,10 +33,7 @@ final readonly class MatchPropertyTypeConflictingNameGuard
         $expectedNames = [];
         foreach ($classLike->getProperties() as $property) {
             $expectedName = $this->matchPropertyTypeExpectedNameResolver->resolve($property, $classLike);
-            if ($expectedName === null) {
-                // fallback to existing name
-                $expectedName = $this->nodeNameResolver->getName($property);
-            }
+            $expectedName ??= $this->nodeNameResolver->getName($property);
 
             $expectedNames[] = $expectedName;
         }

--- a/rules/Php74/Rector/If_/IfToNullCoalescingAssignRector.php
+++ b/rules/Php74/Rector/If_/IfToNullCoalescingAssignRector.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php74\Rector\If_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp\Coalesce as AssignCoalesce;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Isset_;
+use PhpParser\Node\Stmt\Else_;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\If_;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\IfToNullCoalescingAssignRectorTest
+ */
+final class IfToNullCoalescingAssignRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change `if` null guard with single assign to null coalescing assign `??=`', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+if (! isset($array['user_id'])) {
+    $array['user_id'] = 'value';
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+$array['user_id'] ??= 'value';
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [If_::class];
+    }
+
+    /**
+     * @param If_ $node
+     */
+    public function refactor(Node $node): ?Expression
+    {
+        if ($node->else instanceof Else_) {
+            return null;
+        }
+
+        if ($node->elseifs !== []) {
+            return null;
+        }
+
+        if (count($node->stmts) !== 1) {
+            return null;
+        }
+
+        $onlyStmt = $node->stmts[0];
+        if (! $onlyStmt instanceof Expression) {
+            return null;
+        }
+
+        $assign = $onlyStmt->expr;
+        if (! $assign instanceof Assign) {
+            return null;
+        }
+
+        $testedExpr = $this->matchNullGuardedExpr($node->cond);
+        if (! $testedExpr instanceof Expr) {
+            return null;
+        }
+
+        if (! $this->nodeComparator->areNodesEqual($assign->var, $testedExpr)) {
+            return null;
+        }
+
+        // the assigned value must not reference the target, e.g. $x = $x + 1
+        $selfReference = $this->betterNodeFinder->findFirst(
+            $assign->expr,
+            fn (Node $subNode): bool => $this->nodeComparator->areNodesEqual($subNode, $assign->var)
+        );
+        if ($selfReference instanceof Node) {
+            return null;
+        }
+
+        return new Expression(new AssignCoalesce($assign->var, $assign->expr));
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::NULL_COALESCE_ASSIGN;
+    }
+
+    private function matchNullGuardedExpr(Expr $expr): ?Expr
+    {
+        // ! isset($value)
+        if ($expr instanceof BooleanNot && $expr->expr instanceof Isset_) {
+            if (count($expr->expr->vars) !== 1) {
+                return null;
+            }
+
+            return $expr->expr->vars[0];
+        }
+
+        // is_null($value)
+        if ($expr instanceof FuncCall && $this->isName($expr, 'is_null')) {
+            if ($expr->isFirstClassCallable()) {
+                return null;
+            }
+
+            if (count($expr->getArgs()) !== 1) {
+                return null;
+            }
+
+            return $expr->getArgs()[0]
+                ->value;
+        }
+
+        // null === $value or $value === null
+        if ($expr instanceof Identical) {
+            if ($this->valueResolver->isNull($expr->left)) {
+                return $expr->right;
+            }
+
+            if ($this->valueResolver->isNull($expr->right)) {
+                return $expr->left;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/BetterPhpDocParser/PhpDocParser/ClassAnnotationMatcher.php
+++ b/src/BetterPhpDocParser/PhpDocParser/ClassAnnotationMatcher.php
@@ -46,9 +46,7 @@ final class ClassAnnotationMatcher
         $uses = $this->useImportsResolver->resolve();
         $fullyQualifiedClass = $this->resolveFullyQualifiedClass($uses, $node, $tag);
 
-        if ($fullyQualifiedClass === null) {
-            $fullyQualifiedClass = $tag;
-        }
+        $fullyQualifiedClass ??= $tag;
 
         $this->fullyQualifiedNameByHash[$uniqueId] = $fullyQualifiedClass;
 

--- a/src/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
+++ b/src/BetterPhpDocParser/Printer/PhpDocInfoPrinter.php
@@ -256,9 +256,7 @@ final class PhpDocInfoPrinter
             ->getPhpDocNode()
             ->getAttribute(PhpDocAttributeKey::LAST_PHP_DOC_TOKEN_POSITION);
 
-        if ($lastTokenPosition === null) {
-            $lastTokenPosition = $this->currentTokenPosition;
-        }
+        $lastTokenPosition ??= $this->currentTokenPosition;
 
         if ($lastTokenPosition === 0) {
             return $output . "\n */";

--- a/src/Console/Style/SymfonyStyleFactory.php
+++ b/src/Console/Style/SymfonyStyleFactory.php
@@ -22,10 +22,7 @@ final readonly class SymfonyStyleFactory
      */
     public function create(): RectorStyle
     {
-        // to prevent missing argv indexes
-        if (! isset($_SERVER['argv'])) {
-            $_SERVER['argv'] = [];
-        }
+        $_SERVER['argv'] ??= [];
 
         $argvInput = new ArgvInput();
         $consoleOutput = new ConsoleOutput();

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -90,9 +90,7 @@ final class BetterStandardPrinter extends Standard
     public function print(Node|array|null $node): string
     {
 
-        if ($node === null) {
-            $node = [];
-        }
+        $node ??= [];
 
         if (! is_array($node)) {
             $node = [$node];

--- a/src/ValueObject/ProcessResult.php
+++ b/src/ValueObject/ProcessResult.php
@@ -100,9 +100,7 @@ final class ProcessResult
 
         foreach ($this->fileDiffs as $fileDiff) {
             foreach ($fileDiff->getRectorClasses() as $rectorClass) {
-                if (! isset($ruleCounts[$rectorClass])) {
-                    $ruleCounts[$rectorClass] = 0;
-                }
+                $ruleCounts[$rectorClass] ??= 0;
 
                 ++$ruleCounts[$rectorClass];
             }


### PR DESCRIPTION
Closes rectorphp/rector#9843

Adds `IfToNullCoalescingAssignRector` (Php74 set). It converts an `if` null-guard around a single self-assignment into the `??=` null coalescing assignment operator.

Three guard shapes are recognized:

```diff
-if (! isset($array['user_id'])) {
-    $array['user_id'] = 'value';
-}
+$array['user_id'] ??= 'value';
```

```diff
-if (null === $value) {
-    $value = 'default';
-}
+$value ??= 'default';
```

```diff
-if (is_null($this->instance)) {
-    $this->instance = new self();
-}
+$this->instance ??= new self();
```

### Safety guards (rule bails out otherwise)

- No `else` / `elseif` branch.
- Exactly one statement in the `if` body, and it is a plain assignment.
- The assigned target matches the tested expression.
- The assigned value does not reference the target (skips `$x = $x . 'suffix'`).
- `isset()` with more than one variable is skipped.

Both operand orders of the identical check (`null === $x` and `$x === null`) are handled.

The rule dogfoods on rector-src itself (8 files simplified in this PR).
