### PR TITLE
[TypeDeclarationDocblocks] Skip ClassMethodArrayDocblockParamFromLocalCallsRector on methods overriding parent/interface

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_interface_wider_param.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_interface_wider_param.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+use Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Source\SomeSearchInterface;
+
+final class SkipInterfaceWiderParam implements SomeSearchInterface
+{
+    public function findOneMatching(array $criteria): ?object
+    {
+        return null;
+    }
+
+    public function go(string $id): ?object
+    {
+        return $this->findOneMatching(['id' => $id]);
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Source/SomeSearchInterface.php
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Source/SomeSearchInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Source;
+
+interface SomeSearchInterface
+{
+    /**
+     * @param array{alias?: string, id?: string} $criteria
+     */
+    public function findOneMatching(array $criteria): ?object;
+}

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
@@ -11,6 +11,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\NodeManipulator\ClassMethodManipulator;
 use Rector\PhpParser\NodeFinder\LocalMethodCallFinder;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\NodeAnalyzer\CallTypesResolver;
@@ -29,7 +30,8 @@ final class ClassMethodArrayDocblockParamFromLocalCallsRector extends AbstractRe
         private readonly CallTypesResolver $callTypesResolver,
         private readonly LocalMethodCallFinder $localMethodCallFinder,
         private readonly UsefulArrayTagNodeAnalyzer $usefulArrayTagNodeAnalyzer,
-        private readonly NodeDocblockTypeDecorator $nodeDocblockTypeDecorator
+        private readonly NodeDocblockTypeDecorator $nodeDocblockTypeDecorator,
+        private readonly ClassMethodManipulator $classMethodManipulator
     ) {
     }
 
@@ -86,6 +88,11 @@ CODE_SAMPLE
 
         foreach ($node->getMethods() as $classMethod) {
             if ($classMethod->getParams() === []) {
+                continue;
+            }
+
+            // parent/interface method may declare a wider @param contract; local calls are narrower, so skip to keep LSP
+            if ($this->classMethodManipulator->hasParentMethodOrInterfaceMethod($node, $this->getName($classMethod))) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes rectorphp/rector#9835

`ClassMethodArrayDocblockParamFromLocalCallsRector` added a `@param` docblock inferred from **local** calls, even when the method overrides a parent/interface method whose contract is **wider**. This narrowed the type below the parent contract and broke LSP.

## Before

Interface declares a wide array shape:

```php
interface SomeSearchInterface
{
    /** @param array{alias?: string, id?: string} \$criteria */
    public function findOneMatching(array \$criteria): ?object;
}
```

Implementation only calls it locally with `['id' => ...]`, so the rule wrongly narrowed the docblock:

```diff
 final class SomeSearch implements SomeSearchInterface
 {
+    /**
+     * @param array<string, string> \$criteria
+     */
     public function findOneMatching(array \$criteria): ?object
     {
         return null;
     }
 }
```

## After

The rule now skips a method when a parent class or interface already declares it (`ClassMethodManipulator::hasParentMethodOrInterfaceMethod()`), keeping the wider contract intact.