### PR TITLE
[Configuration] Skip deprecated rules from active set, warn only instead of crashing

### DIFF
--- a/src/Configuration/ConfigurationRuleFilter.php
+++ b/src/Configuration/ConfigurationRuleFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Configuration;
 
+use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\ValueObject\Configuration;
@@ -30,6 +31,12 @@ final class ConfigurationRuleFilter
      */
     public function filter(array $rectors): array
     {
+        // deprecated rules only warn via DeprecatedRulesReporter; they must never run, as their
+        // refactor() throws to signal the deprecation - keep them out of the active set
+        $rectors = array_values(
+            array_filter($rectors, static fn (RectorInterface $rector): bool => ! $rector instanceof DeprecatedInterface)
+        );
+
         if (! $this->configuration instanceof Configuration) {
             return $rectors;
         }

--- a/tests/Configuration/ConfigurationRuleFilterTest.php
+++ b/tests/Configuration/ConfigurationRuleFilterTest.php
@@ -8,6 +8,7 @@ use Rector\Configuration\ConfigurationRuleFilter;
 use Rector\DeadCode\Rector\If_\RemoveDeadInstanceOfRector;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\Transform\Rector\Class_\AddInterfaceByTraitRector;
 use Rector\ValueObject\Configuration;
 
 final class ConfigurationRuleFilterTest extends AbstractLazyTestCase
@@ -47,6 +48,20 @@ final class ConfigurationRuleFilterTest extends AbstractLazyTestCase
         );
 
         $this->assertSame([$stringableForToStringRector, $removeDeadInstanceOfRector], $filteredRectors);
+    }
+
+    public function testFiltersOutDeprecatedRules(): void
+    {
+        $removeDeadInstanceOfRector = $this->make(RemoveDeadInstanceOfRector::class);
+        $addInterfaceByTraitRector = $this->make(AddInterfaceByTraitRector::class);
+
+        $this->configurationRuleFilter->setConfiguration($this->createConfiguration(false));
+
+        $filteredRectors = $this->configurationRuleFilter->filter(
+            [$removeDeadInstanceOfRector, $addInterfaceByTraitRector]
+        );
+
+        $this->assertSame([$removeDeadInstanceOfRector], $filteredRectors);
     }
 
     private function createConfiguration(bool $isPhpOnly): Configuration

--- a/tests/Configuration/ConfigurationRuleFilterTest.php
+++ b/tests/Configuration/ConfigurationRuleFilterTest.php
@@ -8,7 +8,7 @@ use Rector\Configuration\ConfigurationRuleFilter;
 use Rector\DeadCode\Rector\If_\RemoveDeadInstanceOfRector;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
-use Rector\Transform\Rector\Class_\AddInterfaceByTraitRector;
+use Rector\Tests\Configuration\Source\DeprecatedRectorStub;
 use Rector\ValueObject\Configuration;
 
 final class ConfigurationRuleFilterTest extends AbstractLazyTestCase
@@ -53,12 +53,12 @@ final class ConfigurationRuleFilterTest extends AbstractLazyTestCase
     public function testFiltersOutDeprecatedRules(): void
     {
         $removeDeadInstanceOfRector = $this->make(RemoveDeadInstanceOfRector::class);
-        $addInterfaceByTraitRector = $this->make(AddInterfaceByTraitRector::class);
+        $deprecatedRectorStub = $this->make(DeprecatedRectorStub::class);
 
         $this->configurationRuleFilter->setConfiguration($this->createConfiguration(false));
 
         $filteredRectors = $this->configurationRuleFilter->filter(
-            [$removeDeadInstanceOfRector, $addInterfaceByTraitRector]
+            [$removeDeadInstanceOfRector, $deprecatedRectorStub]
         );
 
         $this->assertSame([$removeDeadInstanceOfRector], $filteredRectors);

--- a/tests/Configuration/Source/DeprecatedRectorStub.php
+++ b/tests/Configuration/Source/DeprecatedRectorStub.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Configuration\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class DeprecatedRectorStub extends AbstractRector implements DeprecatedInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Deprecated stub rule for tests', [new CodeSample('before', 'after')]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9859

A registered deprecated rule crashed Rector with exit code 1 instead of only warning.

`DeprecatedRulesReporter` printed the deprecation as a warning, but the rule was still registered and run. Every deprecated rule has a gutted `refactor()` that throws, so as soon as it matched a node the run crashed.

Fix: `ConfigurationRuleFilter` now drops deprecated rules from the active set. They still warn, but never run.

Before: warning + `[ERROR]` -> exit code 1
After: warning only -> exit code 0