### PR TITLE
[Composer] Target lowest declared version for libraries in composer-based sets

### DIFF
--- a/src/Composer/InstalledPackageResolver.php
+++ b/src/Composer/InstalledPackageResolver.php
@@ -108,6 +108,7 @@ final class InstalledPackageResolver
     private function createInstalledPackages(array $packages): array
     {
         $packageConstraints = $this->resolvePackageConstraints();
+        $isLibrary = $this->isLibrary();
         $installedPackages = [];
 
         foreach ($packages as $package) {
@@ -116,15 +117,32 @@ final class InstalledPackageResolver
 
             $constraint = $packageConstraints[$name] ?? null;
             if (is_string($constraint)) {
-                // the "installed.json" can be outdated, e.g. after a branch switch;
-                // in such case the "composer.json" constraint has a priority
-                $version = $this->matchConstraintVersion($version, $constraint) ?? $version;
+                if ($isLibrary) {
+                    // a library must stay compatible with the lowest version it declares,
+                    // regardless of which one happens to be installed locally
+                    $version = $this->resolveConstraintLowestVersion($constraint) ?? $version;
+                } else {
+                    // the "installed.json" can be outdated, e.g. after a branch switch;
+                    // in such case the "composer.json" constraint has a priority
+                    $version = $this->matchConstraintVersion($version, $constraint) ?? $version;
+                }
             }
 
             $installedPackages[$name] = new InstalledPackage($name, $version);
         }
 
         return $installedPackages;
+    }
+
+    /**
+     * A library declares a compatibility range in its "composer.json"; the version-specific rules must target the
+     * lowest declared version, not the one that happens to be installed locally.
+     */
+    private function isLibrary(): bool
+    {
+        $projectComposerJson = $this->loadProjectComposerJson();
+
+        return ($projectComposerJson['type'] ?? null) === 'library';
     }
 
     /**

--- a/tests/Composer/Fixture/InstalledPackageResolver/library_composer_json/composer.json
+++ b/tests/Composer/Fixture/InstalledPackageResolver/library_composer_json/composer.json
@@ -1,0 +1,10 @@
+{
+    "type": "library",
+    "require": {
+        "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0",
+        "symfony/console": "^7.0"
+    },
+    "require-dev": {
+        "nette/utils": "^3.2"
+    }
+}

--- a/tests/Composer/Fixture/InstalledPackageResolver/library_composer_json/vendor/composer/installed.json
+++ b/tests/Composer/Fixture/InstalledPackageResolver/library_composer_json/vendor/composer/installed.json
@@ -1,0 +1,24 @@
+{
+    "packages": [
+        {
+            "name": "phpunit/phpunit",
+            "version": "12.1.0",
+            "version_normalized": "12.1.0.0"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.2.0",
+            "version_normalized": "7.2.0.0"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v3.2.0",
+            "version_normalized": "3.2.0.0"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.11.0",
+            "version_normalized": "1.11.0.0"
+        }
+    ]
+}

--- a/tests/Composer/InstalledPackageResolverTest.php
+++ b/tests/Composer/InstalledPackageResolverTest.php
@@ -47,6 +47,25 @@ final class InstalledPackageResolverTest extends TestCase
         $this->assertSame('1.11.0.0', $installedPackageResolver->resolvePackageVersion('webmozart/assert'));
     }
 
+    public function testLibraryTargetsLowestDeclaredVersionEvenWhenInstalledSatisfies(): void
+    {
+        $installedPackageResolver = new InstalledPackageResolver(
+            __DIR__ . '/Fixture/InstalledPackageResolver/library_composer_json'
+        );
+
+        // installed 12.1.0 satisfies "^10.5 || ^11.0 || ^12.0", yet a library targets the lowest declared version
+        $this->assertSame('10.5.0.0', $installedPackageResolver->resolvePackageVersion('phpunit/phpunit'));
+
+        // installed 7.2.0 satisfies "^7.0", still lowered to the declared floor
+        $this->assertSame('7.0.0.0', $installedPackageResolver->resolvePackageVersion('symfony/console'));
+
+        // require-dev is respected as well
+        $this->assertSame('3.2.0.0', $installedPackageResolver->resolvePackageVersion('nette/utils'));
+
+        // not required in the "composer.json", the installed version stands
+        $this->assertSame('1.11.0.0', $installedPackageResolver->resolvePackageVersion('webmozart/assert'));
+    }
+
     public function testStandaloneComposerJsonResolvesVersionsWithoutVendor(): void
     {
         $installedPackageResolver = new InstalledPackageResolver(


### PR DESCRIPTION
Fixes deterministic version targeting for **libraries** in composer-based sets. Refs rectorphp/rector#9858.

## Problem

`withComposerBased()` rules gate on the **locally installed** package version (`vendor/composer/installed.json`). That is right for applications, wrong for libraries.

A library declares a compatibility range in `composer.json`:

```json
{
    "type": "library",
    "require": {
        "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0"
    }
}
```

With PHPUnit 12 installed locally, Rector emitted 12-only code and silently broke the declared support for 10.5. Output changed between `composer install`, `composer update`, and `composer update --prefer-lowest` for identical source.
