### PR TITLE
[Testing] Isolate ApplicationFileProcessorTest cache dir to fix parallel flake

### DIFF
--- a/tests/Application/ApplicationFileProcessor/ApplicationFileProcessorTest.php
+++ b/tests/Application/ApplicationFileProcessor/ApplicationFileProcessorTest.php
@@ -20,6 +20,11 @@ final class ApplicationFileProcessorTest extends AbstractLazyTestCase
     {
         parent::setUp();
 
+        // reset the container to boot an isolated cache dir, so parallel test processes cannot
+        // wipe the shared default cache mid-run and flip the caching assertions below
+        self::$rectorConfig = null;
+        $this->bootFromConfigFiles([__DIR__ . '/config.php']);
+
         $this->applicationFileProcessor = $this->make(ApplicationFileProcessor::class);
         $this->changedFilesDetector = $this->make(ChangedFilesDetector::class);
     }

--- a/tests/Application/ApplicationFileProcessor/config.php
+++ b/tests/Application/ApplicationFileProcessor/config.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    // isolated cache dir, so parallel test processes cannot wipe the shared default cache
+    // mid-run and flip the caching assertions of this test
+    $rectorConfig->cacheDirectory(sys_get_temp_dir() . '/_rector_application_file_processor_test');
+};


### PR DESCRIPTION
## Problem

`ApplicationFileProcessorTest` asserts that files are cached as unchanged on disk, using the **shared default** cache dir `sys_get_temp_dir()/rector_cached_files`. `Cache` is a process-wide singleton and that dir is shared across every parallel `fastunit -tia` chunk process.

Other tests wipe that whole dir mid-run:
- `ChangedFilesDetector::clear()` in teardown (`rm -rf` the dir),
- config-change invalidation in the many rule tests.

When a parallel process wipes the dir between this test's `processFiles()` and its assertion, `hasFileChanged()` defensively returns `true`, so the `assertFalse(...)` calls flip:

```
Failed asserting that true is false.
```

It is a latent flake. It surfaced in #8358 because that PR touches the central `ConfigurationRuleFilter`, so TIA marked this test impacted and co-scheduled it with cache-wiping tests. `main` was green only by scheduling luck.

## Fix

Isolate this test's cache dir, mirroring the existing `_rector_cached_files_test` pattern used by the caching tests. The container is reset in `setUp()` (same pattern as `SkipperRectorRuleTest`) so the isolated dir is applied before the `Cache` singleton is built.

## Proof

Background loop wiping the default dir while running the test 8x:

| version | result under wipe race |
| --- | --- |
| before | pass=3 fail=5 |
| after | pass=8 fail=0 |