### PR TITLE
[Tests] Isolate ApplicationFileProcessorTest cache dir to survive parallel chunk clears

### DIFF
--- a/tests/Application/ApplicationFileProcessor/ApplicationFileProcessorTest.php
+++ b/tests/Application/ApplicationFileProcessor/ApplicationFileProcessorTest.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Application\ApplicationFileProcessor;
 
+use Illuminate\Container\Container;
 use Rector\Application\ApplicationFileProcessor;
+use Rector\Caching\Cache;
+use Rector\Caching\CacheFactory;
 use Rector\Caching\Detector\ChangedFilesDetector;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
 use Rector\ValueObject\Configuration;
@@ -19,6 +24,19 @@ final class ApplicationFileProcessorTest extends AbstractLazyTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        // isolate the cache directory to this test - the default directory is shared across all
+        // parallel test chunks, and FileCacheStorage::clear() deletes the whole directory, so a
+        // sibling chunk can wipe this test's cache between save and load and flip the assertions
+        $rectorConfig = self::getContainer();
+        SimpleParameterProvider::setParameter(
+            Option::CACHE_DIR,
+            sys_get_temp_dir() . '/rector_test_application_file_processor'
+        );
+        $rectorConfig->singleton(
+            Cache::class,
+            static fn (Container $container): Cache => $container->make(CacheFactory::class)->create()
+        );
 
         $this->applicationFileProcessor = $this->make(ApplicationFileProcessor::class);
         $this->changedFilesDetector = $this->make(ChangedFilesDetector::class);


### PR DESCRIPTION
`ApplicationFileProcessorTest` asserts real cache persistence (save then load) against the **shared** cache directory `sys_get_temp_dir() . '/rector_cached_files'`. Under `fastunit -tia`, test chunks run as parallel processes that all share that one directory, and `FileCacheStorage::clear()` deletes the whole directory:

```php
public function clear(): void
{
    FileSystem::delete($this->directory);
}
```

So a sibling chunk can wipe this test's cache entry between the save and the load, making `hasFileChanged()` find nothing and return `true` ("be defensive and assume it's changed"). The three cache-scope tests then fail with `Failed asserting that true is false.` — non-deterministically, depending on chunk timing.

## Fix

Bind a dedicated cache directory for this test only, so no other chunk's `clear()` can touch it:

```diff
     protected function setUp(): void
     {
         parent::setUp();

+        // isolate the cache directory to this test - the default directory is shared across all
+        // parallel test chunks, and FileCacheStorage::clear() deletes the whole directory, so a
+        // sibling chunk can wipe this test's cache between save and load and flip the assertions
+        $rectorConfig = self::getContainer();
+        SimpleParameterProvider::setParameter(
+            Option::CACHE_DIR,
+            sys_get_temp_dir() . '/rector_test_application_file_processor'
+        );
+        $rectorConfig->singleton(
+            Cache::class,
+            static fn (Container $container): Cache => $container->make(CacheFactory::class)->create()
+        );
+
         $this->applicationFileProcessor = $this->make(ApplicationFileProcessor::class);
         $this->changedFilesDetector = $this->make(ChangedFilesDetector::class);
     }
```

The `Cache` singleton is rebound so it is rebuilt from the isolated directory (it is otherwise created once per process from the default directory). Test-only change.
