### PR TITLE
[Composer] Target lowest version for any distributed package type, only 'project' is an application

### DIFF
--- a/src/Composer/InstalledPackageResolver.php
+++ b/src/Composer/InstalledPackageResolver.php
@@ -137,12 +137,16 @@ final class InstalledPackageResolver
     /**
      * A library declares a compatibility range in its "composer.json"; the version-specific rules must target the
      * lowest declared version, not the one that happens to be installed locally.
+     *
+     * Anything but an application counts as a library: a missing "type" or an explicit "project" is an application,
+     * every other declared type ("library", "symfony-bundle", ...) is a distributed package.
      */
     private function isLibrary(): bool
     {
         $projectComposerJson = $this->loadProjectComposerJson();
+        $type = $projectComposerJson['type'] ?? null;
 
-        return ($projectComposerJson['type'] ?? null) === 'library';
+        return is_string($type) && $type !== 'project';
     }
 
     /**

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -55,6 +55,9 @@ final class RectorConfig extends Container
      */
     private array $autotagInterfaces = [Command::class, ResettableInterface::class];
 
+    /**
+     * Optional override, e.g. injected by a test to read the versions from a standalone "composer.json"
+     */
     private ?InstalledPackageResolver $installedPackageResolver = null;
 
     private static ?bool $recreated = null;
@@ -570,7 +573,14 @@ final class RectorConfig extends Container
 
     private function resolveInstalledPackageVersion(string $packageName): ?string
     {
-        $this->installedPackageResolver ??= new InstalledPackageResolver();
+        // an explicitly injected resolver wins, e.g. a test pointing at a standalone "composer.json"
+        if (! $this->installedPackageResolver instanceof InstalledPackageResolver) {
+            // otherwise reuse the container-bound resolver, so a test-provided "composer.json" (via
+            // AbstractRectorTestCase::provideComposerJsonFilePath()) drives the version, not the project root
+            $this->installedPackageResolver = $this->bound(InstalledPackageResolver::class)
+                ? $this->make(InstalledPackageResolver::class)
+                : new InstalledPackageResolver();
+        }
 
         return $this->installedPackageResolver->resolvePackageVersion($packageName);
     }

--- a/tests/Composer/Fixture/InstalledPackageResolver/project_composer_json/composer.json
+++ b/tests/Composer/Fixture/InstalledPackageResolver/project_composer_json/composer.json
@@ -1,0 +1,10 @@
+{
+    "type": "project",
+    "require": {
+        "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0",
+        "symfony/console": "^7.0"
+    },
+    "require-dev": {
+        "nette/utils": "^3.2"
+    }
+}

--- a/tests/Composer/Fixture/InstalledPackageResolver/project_composer_json/vendor/composer/installed.json
+++ b/tests/Composer/Fixture/InstalledPackageResolver/project_composer_json/vendor/composer/installed.json
@@ -1,0 +1,24 @@
+{
+    "packages": [
+        {
+            "name": "phpunit/phpunit",
+            "version": "12.1.0",
+            "version_normalized": "12.1.0.0"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.2.0",
+            "version_normalized": "7.2.0.0"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v3.2.0",
+            "version_normalized": "3.2.0.0"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.11.0",
+            "version_normalized": "1.11.0.0"
+        }
+    ]
+}

--- a/tests/Composer/Fixture/InstalledPackageResolver/symfony_bundle_composer_json/composer.json
+++ b/tests/Composer/Fixture/InstalledPackageResolver/symfony_bundle_composer_json/composer.json
@@ -1,0 +1,10 @@
+{
+    "type": "symfony-bundle",
+    "require": {
+        "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0",
+        "symfony/console": "^7.0"
+    },
+    "require-dev": {
+        "nette/utils": "^3.2"
+    }
+}

--- a/tests/Composer/Fixture/InstalledPackageResolver/symfony_bundle_composer_json/vendor/composer/installed.json
+++ b/tests/Composer/Fixture/InstalledPackageResolver/symfony_bundle_composer_json/vendor/composer/installed.json
@@ -1,0 +1,24 @@
+{
+    "packages": [
+        {
+            "name": "phpunit/phpunit",
+            "version": "12.1.0",
+            "version_normalized": "12.1.0.0"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.2.0",
+            "version_normalized": "7.2.0.0"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v3.2.0",
+            "version_normalized": "3.2.0.0"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.11.0",
+            "version_normalized": "1.11.0.0"
+        }
+    ]
+}

--- a/tests/Composer/InstalledPackageResolverTest.php
+++ b/tests/Composer/InstalledPackageResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Composer;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Rector\Composer\InstalledPackageResolver;
 use Rector\Composer\ValueObject\InstalledPackage;
@@ -47,11 +48,10 @@ final class InstalledPackageResolverTest extends TestCase
         $this->assertSame('1.11.0.0', $installedPackageResolver->resolvePackageVersion('webmozart/assert'));
     }
 
-    public function testLibraryTargetsLowestDeclaredVersionEvenWhenInstalledSatisfies(): void
+    #[DataProvider('provideLibraryTypeFixtureDirectory')]
+    public function testLibraryTargetsLowestDeclaredVersionEvenWhenInstalledSatisfies(string $fixtureDirectory): void
     {
-        $installedPackageResolver = new InstalledPackageResolver(
-            __DIR__ . '/Fixture/InstalledPackageResolver/library_composer_json'
-        );
+        $installedPackageResolver = new InstalledPackageResolver($fixtureDirectory);
 
         // installed 12.1.0 satisfies "^10.5 || ^11.0 || ^12.0", yet a library targets the lowest declared version
         $this->assertSame('10.5.0.0', $installedPackageResolver->resolvePackageVersion('phpunit/phpunit'));
@@ -64,6 +64,31 @@ final class InstalledPackageResolverTest extends TestCase
 
         // not required in the "composer.json", the installed version stands
         $this->assertSame('1.11.0.0', $installedPackageResolver->resolvePackageVersion('webmozart/assert'));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideLibraryTypeFixtureDirectory(): iterable
+    {
+        // "library" is the default distributed type
+        yield 'library' => [__DIR__ . '/Fixture/InstalledPackageResolver/library_composer_json'];
+
+        // any other non-"project" distributed type behaves the same way
+        yield 'symfony-bundle' => [__DIR__ . '/Fixture/InstalledPackageResolver/symfony_bundle_composer_json'];
+    }
+
+    public function testProjectTypeKeepsInstalledVersionOverDeclaredRange(): void
+    {
+        $installedPackageResolver = new InstalledPackageResolver(
+            __DIR__ . '/Fixture/InstalledPackageResolver/project_composer_json'
+        );
+
+        // an explicit "project" is an application, so the installed version stands even within a wider range
+        $this->assertSame('12.1.0.0', $installedPackageResolver->resolvePackageVersion('phpunit/phpunit'));
+
+        // installed 7.2.0 satisfies "^7.0", kept as installed
+        $this->assertSame('7.2.0.0', $installedPackageResolver->resolvePackageVersion('symfony/console'));
     }
 
     public function testStandaloneComposerJsonResolvesVersionsWithoutVendor(): void


### PR DESCRIPTION
## What

Two related changes to how composer-package versions drive version-bound rules.

### 1. Lowest declared version for distributed packages

`InstalledPackageResolver` treated only `"type": "library"` as a distributed package. Now **any non-`project` type** (`library`, `symfony-bundle`, `rector-extension`, ...) targets the **lowest declared** version, while a missing type or an explicit `"project"` stays an application on the installed version.

```diff
-        return ($projectComposerJson['type'] ?? null) === 'library';
+        $type = $projectComposerJson['type'] ?? null;
+
+        return is_string($type) && $type !== 'project';
```

### 2. Honor a test-provided composer.json for composer-bound rules

`RectorConfig::ruleWithConfigurationComposerVersionBound()` resolved the version through a private `new InstalledPackageResolver()` reading the **project root**, ignoring the resolver a test configures via `AbstractRectorTestCase::provideComposerJsonFilePath()`. It now resolves through the **container-bound** singleton, so a test-specific `composer.json` drives the version:

```diff
-        $this->installedPackageResolver ??= new InstalledPackageResolver();
-        return $this->installedPackageResolver->resolvePackageVersion($packageName);
+        if (! $this->bound(InstalledPackageResolver::class)) {
+            $this->singleton(InstalledPackageResolver::class);
+        }
+        return $this->make(InstalledPackageResolver::class)->resolvePackageVersion($packageName);
```

Without this, an extension package (e.g. `rector-doctrine`, `"type": "rector-extension"`) resolved its version-bound rules from its own root `composer.json` — so change #1 dropped it to the lowest declared floor and deactivated newer-version rules in the extension's own test suite. With this, `rector-doctrine`'s `tests/ComposerBased/composer.json` (rectorphp/rector-doctrine#513) drives the version deterministically; its root `composer.json` and fixtures stay untouched.

## Tests

- `InstalledPackageResolverTest`: library test is a data provider over `library` + `symfony-bundle`; new `project_composer_json` fixture proves an explicit `"project"` keeps the installed version.
- Verified against rector-doctrine `main`: `ComposerBasedTest` 3/3 green, fixtures unchanged.