### PR TITLE
Group fixture checks into single Code Analysis job

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -64,16 +64,11 @@ jobs:
                         run: vendor/bin/swiss-knife finalize-classes src tests rules --dry-run --skip-file="src/PhpParser/Node/FileNode.php"
 
                     -
-                        name: 'Check before/after test fixture on no-changes'
-                        run: php scripts/check-before-after-same-fixtures.php
-
-                    -
-                        name: 'Check fixture classes are different to nodes'
-                        run: php scripts/avoid-short-node-names-in-fixtures.php
-
-                    -
-                        name: 'Check no "*.php" files in rules Fixture directory'
-                        run: php scripts/no-php-file-in-fixtures.php
+                        name: 'Fixture Checks'
+                        run: |
+                            php scripts/check-before-after-same-fixtures.php
+                            php scripts/avoid-short-node-names-in-fixtures.php
+                            php scripts/no-php-file-in-fixtures.php
 
                     -
                         name: "PHP Linter"


### PR DESCRIPTION
Merge 3 separate fixture-related matrix entries in `code_analysis.yaml` into one **Fixture Checks** job. Fewer separate GitHub checks, same coverage.

Before — 3 checks:

- `Check before/after test fixture on no-changes`
- `Check fixture classes are different to nodes`
- `Check no "*.php" files in rules Fixture directory`

After — 1 check `Fixture Checks`:

```yaml
-
    name: 'Fixture Checks'
    run: |
        php scripts/check-before-after-same-fixtures.php
        php scripts/avoid-short-node-names-in-fixtures.php
        php scripts/no-php-file-in-fixtures.php
```

Note: if branch protection lists the old 3 check names as required, update required checks to `Fixture Checks`.