### PR TITLE
[DeadCode] Fix offset access + drop phpstan ignore in RemoveParentDelegatingConstructorRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -194,12 +194,6 @@ parameters:
             identifier: offsetAccess.nonArray
             path: src/PhpParser/NodeTraverser/RectorNodeTraverser.php
 
-        # known non-empty class method
-        -
-            identifier: offsetAccess.notFound
-            message: '#Offset 0 might not exist on array<PhpParser\\Node\\Stmt>\|null#'
-            path: rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
-
         -
             identifier: offsetAccess.notFound
             message: '#Offset float\|int\|string might not exist on string#'

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
@@ -209,7 +209,10 @@ CODE_SAMPLE
 
     private function isParameterAndArgCountAndOrderIdentical(ClassMethod $classMethod): bool
     {
-        $soleStmt = $classMethod->stmts[0];
+        $soleStmt = $classMethod->stmts[0] ?? null;
+        if (! $soleStmt instanceof Stmt) {
+            return false;
+        }
 
         $parentCallArgs = $this->matchParentConstructorCallArgs($soleStmt);
         if ($parentCallArgs === null) {


### PR DESCRIPTION
One of the `phpstan.neon` ignores could be fixed at the source instead of suppressed.

`isParameterAndArgCountAndOrderIdentical()` read `$classMethod->stmts[0]` directly. PHPStan sees `stmts` as `array<Stmt>|null`, so it cannot prove offset `0` exists across the method boundary (the `count() === 1` guard lives in the caller). Add a local guard so the type is proven, then remove the matching ignore.

```diff
 private function isParameterAndArgCountAndOrderIdentical(ClassMethod $classMethod): bool
 {
-    $soleStmt = $classMethod->stmts[0];
+    $soleStmt = $classMethod->stmts[0] ?? null;
+    if (! $soleStmt instanceof Stmt) {
+        return false;
+    }

     $parentCallArgs = $this->matchParentConstructorCallArgs($soleStmt);
```

Dropped ignore:

```neon
# known non-empty class method
-
    identifier: offsetAccess.notFound
    message: '#Offset 0 might not exist on array<PhpParser\\Node\\Stmt>\|null#'
    path: rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingConstructorRector.php
```

`composer phpstan` green with the ignore removed.