### PR TITLE
[DI] Use entropy autodiscover() over registerTagged() for order-independent service collections

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -53,7 +53,7 @@ jobs:
                     -
                         name: 'Active Classes'
                         run: |
-                            vendor/bin/class-leak check bin config src rules utils --skip-suffix "Rector" --skip-type="Rector\\Utils\\Compiler\\Unprefixer" --skip-type="Rector\\NodeCollector\\BinaryOpConditionsCollector" --skip-type="Rector\\Set\\Contract\\SetListInterface" --skip-type="Rector\\DependencyInjection\\PHPStan\\RichParserFactory" --skip-type="Rector\\Utils\\PHPStan\\Tests\\Rule\\SingleServiceRegistrationRule\\Source\\DuplicateRegistrationFactory" --skip-type="Rector\\Utils\\PHPStan\\Tests\\Rule\\SingleServiceRegistrationRule\\Source\\SingleRegistrationFactory"
+                            vendor/bin/class-leak check bin config src rules utils --skip-suffix "Rector" --skip-type="Rector\\Utils\\Compiler\\Unprefixer" --skip-type="Rector\\NodeCollector\\BinaryOpConditionsCollector" --skip-type="Rector\\Set\\Contract\\SetListInterface" --skip-type="Rector\\DependencyInjection\\PHPStan\\RichParserFactory" --skip-type="Rector\\Utils\\PHPStan\\Tests\\Rule\\SingleServiceRegistrationRule\\Source\\DuplicateRegistrationFactory" --skip-type="Rector\\Utils\\PHPStan\\Tests\\Rule\\SingleServiceRegistrationRule\\Source\\SingleRegistrationFactory" --skip-type="Rector\\ChangesReporting\\Contract\\Output\\OutputFormatterInterface" --skip-type="Rector\\NodeTypeResolver\\Contract\\NodeTypeResolverInterface" --skip-type="Rector\\CodingStyle\\Contract\\ClassNameImport\\ClassNameImportSkipVoterInterface" --skip-type="Rector\\Php80\\Contract\\ConverterAttributeDecoratorInterface"
 
                     -
                         name: 'Compatible PHPStan versions'

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -34,19 +34,6 @@ use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\ArrayP
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\PlainValueParser;
 use Rector\Caching\Cache;
 use Rector\Caching\CacheFactory;
-use Rector\ChangesReporting\Contract\Output\OutputFormatterInterface;
-use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
-use Rector\ChangesReporting\Output\GitHubOutputFormatter;
-use Rector\ChangesReporting\Output\GitlabOutputFormatter;
-use Rector\ChangesReporting\Output\JsonOutputFormatter;
-use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\AliasClassNameImportSkipVoter;
-use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\ClassLikeNameClassNameImportSkipVoter;
-use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\FullyQualifiedNameClassNameImportSkipVoter;
-use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\OriginalNameImportSkipVoter;
-use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\ReservedClassNameImportSkipVoter;
-use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\ShortClassImportSkipVoter;
-use Rector\CodingStyle\ClassNameImport\ClassNameImportSkipVoter\UsesClassNameImportSkipVoter;
-use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
 use Rector\Config\RectorConfig;
 use Rector\Configuration\ConfigurationRuleFilter;
 use Rector\Configuration\RenamedClassesDataCollector;
@@ -72,25 +59,9 @@ use Rector\NodeNameResolver\NodeNameResolver\ParamNameResolver;
 use Rector\NodeNameResolver\NodeNameResolver\PropertyNameResolver;
 use Rector\NodeNameResolver\NodeNameResolver\UseNameResolver;
 use Rector\NodeNameResolver\NodeNameResolver\VariableNameResolver;
-use Rector\NodeTypeResolver\Contract\NodeTypeResolverInterface;
 use Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory;
 use Rector\NodeTypeResolver\NodeTypeResolver;
-use Rector\NodeTypeResolver\NodeTypeResolver\CastTypeResolver;
-use Rector\NodeTypeResolver\NodeTypeResolver\ClassAndInterfaceTypeResolver;
-use Rector\NodeTypeResolver\NodeTypeResolver\ClassConstFetchTypeResolver;
-use Rector\NodeTypeResolver\NodeTypeResolver\IdentifierTypeResolver;
-use Rector\NodeTypeResolver\NodeTypeResolver\NameTypeResolver;
-use Rector\NodeTypeResolver\NodeTypeResolver\NewTypeResolver;
-use Rector\NodeTypeResolver\NodeTypeResolver\ParamTypeResolver;
-use Rector\NodeTypeResolver\NodeTypeResolver\PropertyFetchTypeResolver;
-use Rector\NodeTypeResolver\NodeTypeResolver\PropertyTypeResolver;
-use Rector\NodeTypeResolver\NodeTypeResolver\ScalarTypeResolver;
-use Rector\NodeTypeResolver\NodeTypeResolver\StaticCallMethodCallTypeResolver;
-use Rector\NodeTypeResolver\NodeTypeResolver\TraitTypeResolver;
 use Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\DynamicSourceLocatorProvider;
-use Rector\Php80\AttributeDecorator\DoctrineConverterAttributeDecorator;
-use Rector\Php80\AttributeDecorator\SensioParamConverterAttributeDecorator;
-use Rector\Php80\Contract\ConverterAttributeDecoratorInterface;
 use Rector\PhpAttribute\AnnotationToAttributeMapper;
 use Rector\PhpAttribute\AnnotationToAttributeMapper\ArrayAnnotationToAttributeMapper;
 use Rector\PhpAttribute\AnnotationToAttributeMapper\ArrayItemNodeAnnotationToAttributeMapper;
@@ -247,19 +218,6 @@ final class LazyContainerFactory
     ];
 
     /**
-     * @var array<class-string<ClassNameImportSkipVoterInterface>>
-     */
-    private const array CLASS_NAME_IMPORT_SKIPPER_CLASSES = [
-        AliasClassNameImportSkipVoter::class,
-        ClassLikeNameClassNameImportSkipVoter::class,
-        FullyQualifiedNameClassNameImportSkipVoter::class,
-        UsesClassNameImportSkipVoter::class,
-        ReservedClassNameImportSkipVoter::class,
-        ShortClassImportSkipVoter::class,
-        OriginalNameImportSkipVoter::class,
-    ];
-
-    /**
      * @var array<class-string<TypeMapperInterface>>
      */
     private const array TYPE_MAPPER_CLASSES = [
@@ -316,34 +274,6 @@ final class LazyContainerFactory
     ];
 
     /**
-     * @var array<class-string<OutputFormatterInterface>>
-     */
-    private const array OUTPUT_FORMATTER_CLASSES = [
-        ConsoleOutputFormatter::class,
-        JsonOutputFormatter::class,
-        GitlabOutputFormatter::class,
-        GitHubOutputFormatter::class,
-    ];
-
-    /**
-     * @var array<class-string<NodeTypeResolverInterface>>
-     */
-    private const array NODE_TYPE_RESOLVER_CLASSES = [
-        CastTypeResolver::class,
-        StaticCallMethodCallTypeResolver::class,
-        ClassAndInterfaceTypeResolver::class,
-        IdentifierTypeResolver::class,
-        NameTypeResolver::class,
-        NewTypeResolver::class,
-        ParamTypeResolver::class,
-        PropertyFetchTypeResolver::class,
-        ClassConstFetchTypeResolver::class,
-        PropertyTypeResolver::class,
-        ScalarTypeResolver::class,
-        TraitTypeResolver::class,
-    ];
-
-    /**
      * @var array<class-string<PhpParserNodeMapperInterface>>
      */
     private const array PHP_PARSER_NODE_MAPPER_CLASSES = [
@@ -355,14 +285,6 @@ final class LazyContainerFactory
         StringNodeMapper::class,
         UnionTypeNodeMapper::class,
         ExprNodeMapper::class,
-    ];
-
-    /**
-     * @var array<class-string<ConverterAttributeDecoratorInterface>>
-     */
-    private const array CONVERTER_ATTRIBUTE_DECORATOR_CLASSES = [
-        SensioParamConverterAttributeDecorator::class,
-        DoctrineConverterAttributeDecorator::class,
     ];
 
     /**
@@ -488,11 +410,7 @@ final class LazyContainerFactory
     private function registerNodeNameResolvers(RectorConfig $rectorConfig): void
     {
         // node name resolvers
-        $this->registerTagged(
-            $rectorConfig,
-            self::CONVERTER_ATTRIBUTE_DECORATOR_CLASSES,
-            ConverterAttributeDecoratorInterface::class
-        );
+        $rectorConfig->autodiscover(__DIR__ . '/../../rules/Php80/AttributeDecorator');
     }
 
     private function registerRectorAutowiring(RectorConfig $rectorConfig): void
@@ -546,13 +464,9 @@ final class LazyContainerFactory
         $this->registerTagged($rectorConfig, self::TYPE_MAPPER_CLASSES, TypeMapperInterface::class);
         $this->registerTagged($rectorConfig, self::PHPDOC_TYPE_MAPPER_CLASSES, PhpDocTypeMapperInterface::class);
         $this->registerTagged($rectorConfig, self::NODE_NAME_RESOLVER_CLASSES, NodeNameResolverInterface::class);
-        $this->registerTagged($rectorConfig, self::NODE_TYPE_RESOLVER_CLASSES, NodeTypeResolverInterface::class);
-        $this->registerTagged($rectorConfig, self::OUTPUT_FORMATTER_CLASSES, OutputFormatterInterface::class);
-        $this->registerTagged(
-            $rectorConfig,
-            self::CLASS_NAME_IMPORT_SKIPPER_CLASSES,
-            ClassNameImportSkipVoterInterface::class
-        );
+        $rectorConfig->autodiscover(__DIR__ . '/../NodeTypeResolver/NodeTypeResolver');
+        $rectorConfig->autodiscover(__DIR__ . '/../ChangesReporting/Output');
+        $rectorConfig->autodiscover(__DIR__ . '/../../rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter');
 
         $rectorConfig->singleton(
             SymfonyStyle::class,


### PR DESCRIPTION
Replaces four `registerTagged()` calls in `LazyContainerFactory` with entropy's `autodiscover()`, which scans a directory and registers everything found. Shorter, and it drops four hand-maintained class-string constants plus their imports.

Only the collections whose consumers are **order-independent** were converted, because `findByContract()` returns services in registration order and `autodiscover()` uses filesystem (readdir) order, not the curated constant order:

| Collection | Consumer pattern | Converted |
|---|---|---|
| `NodeTypeResolverInterface` | keyed by node class | yes |
| `OutputFormatterInterface` | keyed by `getName()` | yes |
| `ClassNameImportSkipVoterInterface` | `array_any` (any voter) | yes |
| `ConverterAttributeDecoratorInterface` | exact name match | yes |

First-match collections (`TypeMapperInterface`, `PhpDocTypeMapperInterface`, `PhpParserNodeMapperInterface`, `NodeNameResolverInterface`, `AnnotationToAttributeMapperInterface`) keep `registerTagged()` — their curated order is significant and must not depend on the filesystem.

```diff
-        $this->registerTagged($rectorConfig, self::NODE_TYPE_RESOLVER_CLASSES, NodeTypeResolverInterface::class);
-        $this->registerTagged($rectorConfig, self::OUTPUT_FORMATTER_CLASSES, OutputFormatterInterface::class);
-        $this->registerTagged(
-            $rectorConfig,
-            self::CLASS_NAME_IMPORT_SKIPPER_CLASSES,
-            ClassNameImportSkipVoterInterface::class
-        );
+        $rectorConfig->autodiscover(__DIR__ . '/../NodeTypeResolver/NodeTypeResolver');
+        $rectorConfig->autodiscover(__DIR__ . '/../ChangesReporting/Output');
+        $rectorConfig->autodiscover(__DIR__ . '/../../rules/CodingStyle/ClassNameImport/ClassNameImportSkipVoter');
```

Verified each converted contract still resolves the exact same service count after boot (4 / 12 / 7 / 2).
