### PR TITLE
[CI] Allow rector-laravel dev-main check to fail without blocking

### DIFF
--- a/.github/workflows/rector_laravel_rector_dev.yaml
+++ b/.github/workflows/rector_laravel_rector_dev.yaml
@@ -27,4 +27,7 @@ jobs:
 
             -   run: git clone https://github.com/driftingly/rector-laravel.git
             -   run: composer require rector/rector:dev-main --working-dir rector-laravel
+
+                # downstream 3rd-party repo tested against dev-main; allowed to fail without blocking
             -   run: cd rector-laravel && vendor/bin/phpunit
+                continue-on-error: true


### PR DESCRIPTION
The `Rector Laravel with dev-main` job clones the 3rd-party `driftingly/rector-laravel` repo and runs its test suite against `rector/rector:dev-main`. A failure there reflects downstream drift, not a regression in this repo, yet it currently blocks the PR status.

Marks the job `continue-on-error: true` so it still runs and reports, but no longer blocks merges.

```diff
     rector_laravel_rector_dev:
         runs-on: ubuntu-latest
+
+        # downstream 3rd-party repo tested against dev-main; allowed to fail without blocking
+        continue-on-error: true
```