### PR TITLE
[ci] Bump lock-threads to v6 in target repository lock workflow

### DIFF
--- a/build/target-repository/.github/workflows/lock.yaml
+++ b/build/target-repository/.github/workflows/lock.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: dessant/lock-threads@v5
+            - uses: dessant/lock-threads@v6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
rectorphp/rector's weekly "Lock closed issues" job has failed 14 runs in a row, from 2026-05-24 to 2026-08-23. Last green run was 2026-05-17.

Every run ends with:

```
##[error]"github-token" length must be less than or equal to 100 characters long
```

lock-threads v5 declares `'github-token': Joi.string().trim().max(100)` in `src/schema.js`, and the token GitHub hands the job now runs longer than that. v6 raises the cap to 1000.

This repo hit the same failure and fixed it. #8339 bumped `.github/workflows/lock.yaml` from v5 to v6 on 2026-08-10, and that workflow went green on 2026-08-16 and 2026-08-23 after 11 consecutive failures. The copy under `build/target-repository/`, which ships to rectorphp/rector, was not part of that bump and remained on v5.

This applies the same one-line bump to the file that was missed. v6 accepts every input this workflow sets, so behaviour is unchanged.

How I checked it: for each workflow pinning lock-threads, I resolved that ref's `src/schema.js` upstream and compared its github-token cap against the length the CI error proves the token exceeds. Run against unmodified main it flags this file and passes the root one. With the bump it passes. Pinning v4 fails the same way v5 does, so moving off v5 is not by itself sufficient.
