### PR TITLE
Require entropy ^0.4.12 for restored afterResolving() hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "composer/semver": "^3.4",
         "composer/xdebug-handler": "^3.0.5",
         "doctrine/inflector": "^2.1",
-        "entropy/entropy": "^0.4.9",
+        "entropy/entropy": "^0.4.12",
         "nette/utils": "^4.1.4",
         "nikic/php-parser": "^5.8",
         "ondram/ci-detector": "^4.2",


### PR DESCRIPTION
## Problem

entropy `0.4.11` shipped a revert that dropped `Container::afterResolving()`. `LazyContainerFactory` and `RectorConfig` rely on it (10 call sites) to wire circular type-mapper deps and bulk-inject services into every `AbstractRector`. Result on a fresh `composer install`:

```
[ERROR] Call to undefined method Rector\Config\RectorConfig::afterResolving()
```

Every container build fatals -> whole test suite errors (5154 errors).

## Fix

- entropy `0.4.12` restores `afterResolving()` (revert of the revert, tests + fixtures back).
- Bump the constraint here to `^0.4.12` so `0.4.11` can no longer resolve.

## Result

```
Tests: 5294, Assertions: 6226, Skipped: 1  (0 failures)
```