### PR TITLE
[TypeDeclarationDocblocks] Skip contradicting @param array when local call type conflicts with default value

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/default_array_with_known_type.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/default_array_with_known_type.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class DefaultArrayWithKnownType
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    private function run(array $items = [])
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class DefaultArrayWithKnownType
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    /**
+     * @param string[] $items
+     */
+    private function run(array $items = [])
+    {
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_non_empty_array_contradicting_default.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_non_empty_array_contradicting_default.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class SkipNonEmptyArrayContradictingDefault
+{
+    public function callee(array $row = [])
+    {
+        return $row;
+    }
+
+    public function caller(array $row)
+    {
+        return $row['state'] && $this->callee($row);
+    }
+
+    public function caller2()
+    {
+        return $this->callee(['state' => 5, 'name' => 'x']);
+    }
+}

--- a/rules/TypeDeclarationDocblocks/NodeDocblockTypeDecorator.php
+++ b/rules/TypeDeclarationDocblocks/NodeDocblockTypeDecorator.php
@@ -149,6 +149,7 @@ final readonly class NodeDocblockTypeDecorator
             return false;
         }
 
-        return $type->getKeyType() instanceof IntegerType;
+        // both plain "mixed[]" (integer key) and a fully mixed-keyed array carry no useful value
+        return $type->getKeyType() instanceof IntegerType || $type->getKeyType() instanceof MixedType;
     }
 }

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypeDeclarationDocblocks\Rector\Class_;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
@@ -129,6 +130,14 @@ CODE_SAMPLE
 
                 // in case of array type declaration, null cannot be passed or is already casted
                 $resolvedParameterType = TypeCombinator::removeNull($resolvedParameterType);
+
+                // the param default value must always be accepted; a locally inferred, flow-narrowed type such as
+                // "non-empty-array" would otherwise contradict an "= []" default - unite with the default type so
+                // the resulting @param never conflicts with the method signature
+                if ($param->default instanceof Expr) {
+                    $defaultType = $this->nodeTypeResolver->getType($param->default);
+                    $resolvedParameterType = TypeCombinator::union($resolvedParameterType, $defaultType);
+                }
 
                 $hasClassMethodChanged = $this->nodeDocblockTypeDecorator->decorateGenericIterableParamType(
                     $resolvedParameterType,


### PR DESCRIPTION
Fixes rectorphp/rector#9864

`ClassMethodArrayDocblockParamFromLocalCallsRector` inferred a `@param` from local call sites that could contradict the callee's own default value.

When an argument is a plain `array` variable, PHPStan flow-narrows it (e.g. after `$row['state'] && ...`) to `non-empty-array&hasOffsetValue(...)`. That narrowed type leaked into the generated docblock, producing a `non-empty-array` component on a param that declares `= []` - self-contradictory, and a source of PHPStan false positives (notably with `#[\Override]`).

### Before

```php
class Minimal
{
    public function callee(array $row = [])
    {
        return $row;
    }

    public function caller(array $row)
    {
        return $row['state'] && $this->callee($row);
    }

    public function caller2()
    {
        return $this->callee(['state' => 5, 'name' => 'x']);
    }
}
```

```diff
 class Minimal
 {
+    /**
+     * @param non-empty-array|array<string, int>|array<string, string> $row
+     */
     public function callee(array $row = [])
```

### After

The default value is united into the inferred type, so the `non-empty-array` narrowing collapses to a plain mixed array, which is then correctly recognized as valueless and skipped - no docblock added.

Genuinely useful cases are unaffected: a literal call still narrows a defaulted param.

```php
public function go()
{
    $this->run(['item1', 'item2']);
}

private function run(array $items = [])
{
}
```

```diff
+    /**
+     * @param string[] $items
+     */
     private function run(array $items = [])
```

### Changes

- `ClassMethodArrayDocblockParamFromLocalCallsRector` - unite the resolved param type with the default value type so the docblock can never contradict the signature.
- `NodeDocblockTypeDecorator::isArrayMixed()` - also treat a mixed-keyed mixed array as valueless (previously only integer-keyed), so the collapsed `mixed[]` is skipped instead of emitted.
- Two fixtures: the skipped contradiction case, and a defaulted param that still narrows from a literal call.
