### PR TITLE
[Naming] Skip valid singular name with "ous" suffix on RenameForeachValueVariableToMatchExprVariableRector

### DIFF
--- a/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/rename_to_singular_anonymous.php.inc
+++ b/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/rename_to_singular_anonymous.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector\Fixture;
+
+class RenameToSingularAnonymous
+{
+    public function run(array $anonymousClassNodes)
+    {
+        foreach ($anonymousClassNodes as $node) {
+            echo $node;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector\Fixture;
+
+class RenameToSingularAnonymous
+{
+    public function run(array $anonymousClassNodes)
+    {
+        foreach ($anonymousClassNodes as $anonymousClassNode) {
+            echo $anonymousClassNode;
+        }
+    }
+}
+
+?>

--- a/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_valid_singular_anonymous.php.inc
+++ b/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_valid_singular_anonymous.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector\Fixture;
+
+class SkipValidSingularAnonymous
+{
+    public function run(array $anonymousClassNodes)
+    {
+        foreach ($anonymousClassNodes as $anonymousClassNode) {
+            echo $anonymousClassNode;
+        }
+    }
+}

--- a/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
+++ b/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
@@ -90,10 +90,16 @@ final readonly class InflectorSingularResolver
 
         $resolvedName = '';
         foreach ($camelCases as $camelCase) {
-            if (in_array($camelCase[self::CAMELCASE], ['is', 'has', 'cms', 'this'], true)) {
-                $value = $camelCase[self::CAMELCASE];
+            $camelCaseValue = (string) $camelCase[self::CAMELCASE];
+
+            // words ending in "ous" are adjectives, not plurals, e.g. "anonymous", "previous"
+            if (in_array($camelCaseValue, ['is', 'has', 'cms', 'this'], true) || str_ends_with(
+                $camelCaseValue,
+                'ous'
+            )) {
+                $value = $camelCaseValue;
             } else {
-                $value = $this->inflector->singularize((string) $camelCase[self::CAMELCASE]);
+                $value = $this->inflector->singularize($camelCaseValue);
             }
 
             $resolvedName .= $value;

--- a/tests/Naming/ExpectedNameResolver/InflectorSingularResolverTest.php
+++ b/tests/Naming/ExpectedNameResolver/InflectorSingularResolverTest.php
@@ -42,5 +42,10 @@ final class InflectorSingularResolverTest extends AbstractLazyTestCase
         yield ['staticCallsToNews', 'staticCallToNew'];
         yield ['newsToMethodCalls', 'newToMethodCall'];
         yield ['hasFilters', 'hasFilter'];
+
+        // "ous" adjectives must be kept as is
+        yield ['anonymousClassNodes', 'anonymousClassNode'];
+        yield ['previousItems', 'previousItem'];
+        yield ['anonymous', 'anonymous'];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9866

singular with `ous` suffix like `anonymous`, `previous` are valid singular name, so the `s` suffix should not be removed.