### PR TITLE
[CI] Cron backstop to rebuild scoped rector on missed sibling dispatch

### DIFF
--- a/.github/workflows/poll_siblings_rebuild.yaml
+++ b/.github/workflows/poll_siblings_rebuild.yaml
@@ -1,0 +1,65 @@
+# Safety net for the event-driven dispatch_build_scoped_rector.yaml in each rector-* sibling.
+# If a sibling's merged-PR dispatch is ever dropped, this cron notices the newer sibling main
+# and re-runs build_scoped_rector.yaml. It is a backstop, not the primary trigger.
+name: Poll Siblings And Rebuild
+
+on:
+    schedule:
+        # every 15 min; GitHub floors scheduled runs at ~5 min and delays high-frequency crons
+        - cron: '*/15 * * * *'
+    workflow_dispatch: null
+
+permissions:
+    actions: write
+
+jobs:
+    poll_siblings_rebuild:
+        # only on the canonical repo, never forks
+        if: github.repository == 'rectorphp/rector-src'
+
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+
+        steps:
+            -
+                name: "Rebuild if any sibling main is newer than the last scoped build"
+                env:
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                run: |
+                    set -euo pipefail
+
+                    SIBLINGS="rector-phpunit rector-doctrine rector-symfony rector-downgrade-php"
+
+                    # skip while rector-src main sits on a tagged release commit; the tag/empty-commit
+                    # path is handled by the sibling dispatcher, not by this backstop
+                    MAIN_SHA=$(gh api repos/rectorphp/rector-src/commits/main --jq '.sha')
+                    if gh api repos/rectorphp/rector-src/tags --jq '.[].commit.sha' | grep -qx "$MAIN_SHA"; then
+                        echo "rector-src main $MAIN_SHA is a tagged commit, skipping"
+                        exit 0
+                    fi
+
+                    # start of the most recent build_scoped_rector run (any conclusion)
+                    LAST_BUILD=$(gh api \
+                        repos/rectorphp/rector-src/actions/workflows/build_scoped_rector.yaml/runs \
+                        --jq '.workflow_runs[0].created_at // "1970-01-01T00:00:00Z"')
+                    LAST_BUILD_TS=$(date -d "$LAST_BUILD" +%s)
+                    echo "last scoped build: $LAST_BUILD"
+
+                    NEWER=0
+                    for SIB in $SIBLINGS; do
+                        COMMIT_DATE=$(gh api "repos/rectorphp/$SIB/commits/main" --jq '.commit.committer.date')
+                        COMMIT_TS=$(date -d "$COMMIT_DATE" +%s)
+                        if [ "$COMMIT_TS" -gt "$LAST_BUILD_TS" ]; then
+                            echo "$SIB main ($COMMIT_DATE) is newer than the last build"
+                            NEWER=1
+                        else
+                            echo "$SIB main ($COMMIT_DATE) already built"
+                        fi
+                    done
+
+                    if [ "$NEWER" -eq 1 ]; then
+                        echo "Dispatching build_scoped_rector.yaml"
+                        gh workflow run build_scoped_rector.yaml --repo rectorphp/rector-src --ref main
+                    else
+                        echo "All siblings already built, nothing to do"
+                    fi


### PR DESCRIPTION
## Why

Merging a PR into a `rector-*` sibling (phpunit/doctrine/symfony/downgrade-php) should rebuild `rectorphp/rector` via `build_scoped_rector.yaml`, driven by each sibling's `dispatch_build_scoped_rector.yaml`. That dispatch is event-driven and can be dropped — e.g. rector-phpunit #770's merge commit fired **zero** Actions (a `GITHUB_TOKEN` merge push does not trigger `push` workflows), so the rebuild never happened.

The sibling-side trigger is being fixed separately (rectorphp/rector-phpunit#774). This PR adds an independent **backstop** so a single missed event can never leave the scoped build stale.

## What

`poll_siblings_rebuild.yaml`, cron every 15 min:

1. Skip while `rector-src` main is on a tagged release commit (that path stays with the sibling dispatcher).
2. Compare each sibling `main` commit date against the start time of the last `build_scoped_rector` run.
3. If any sibling is newer, `gh workflow run build_scoped_rector.yaml`.

Self-converging: a dispatched build updates the last-build timestamp, so the next tick sees nothing new. No stored state, uses the repo `GITHUB_TOKEN` (`actions: write`), guarded to `rectorphp/rector-src` only.

> Note: 15 min is deliberate — GitHub floors scheduled workflows near 5 min and deprioritises high-frequency crons, so a tighter interval is not honored anyway. Event-driven dispatch remains the fast path; this only catches misses.