### PR TITLE
[CI] Bump lock-threads to v6 in target repository lock workflow

### DIFF
--- a/build/target-repository/.github/workflows/lock.yaml
+++ b/build/target-repository/.github/workflows/lock.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: dessant/lock-threads@v5
+            - uses: dessant/lock-threads@v6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The root `.github/workflows/lock.yaml` was bumped from `dessant/lock-threads@v5` to `@v6` in #8339, but the copy under `build/target-repository/` (which ships to `rectorphp/rector`) was missed and stayed on v5.

v5 declares `github-token: Joi.string().trim().max(100)`. The token GitHub now hands the job runs longer than 100 chars, so every run fails with:

```
##[error]"github-token" length must be less than or equal to 100 characters long
```

v6 raises the cap to 1000. It accepts every input this workflow already sets, so behaviour is unchanged.

```diff
-            - uses: dessant/lock-threads@v5
+            - uses: dessant/lock-threads@v6
```

Same one-line fix as #8377, rebased on current `main` so CI is green.