### PR TITLE
[Console] Fix newline formatting of deprecated skipped rules warning

### DIFF
--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -111,9 +111,9 @@ EOF
         // 0. warn about skipped rules that are deprecated
         if ($this->skippedClassResolver->resolveDeprecatedSkippedClasses() !== []) {
             $this->symfonyStyle->warning(sprintf(
-                'These rules are skipped, but are deprecated. Most likely you do not need to skip them anymore as not part of any set and remove them: %s* %s',
+                'These rules are skipped, but are deprecated. Most likely you do not need to skip them anymore as not part of any set and remove them: %s%s',
                 "\n\n",
-                implode(' * ', $this->skippedClassResolver->resolveDeprecatedSkippedClasses()) . "\n"
+                '* ' . implode("\n* ", $this->skippedClassResolver->resolveDeprecatedSkippedClasses()) . "\n"
             ));
         }
 


### PR DESCRIPTION
Deprecated skipped rules were joined with ` * ` on a single line instead of one rule per line.

### Before

```
 [WARNING] These rules are skipped, but are deprecated. ...:

           * Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector *
           Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsWithoutExpectationsAttributeRector
```

### After

```
 [WARNING] These rules are skipped, but are deprecated. ...:

           * Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector
           * Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsWithoutExpectationsAttributeRector
```

Each rule now on its own line with a leading `*` bullet.