### PR TITLE
[Php74] Skip non-nullable typed property on IfToNullCoalescingAssignRector

### DIFF
--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/skip_typed_non_nullable_property.php.inc
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/skip_typed_non_nullable_property.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+class SkipTypedNonNullableProperty
+{
+    private static array $parameters;
+
+    public function get(): array
+    {
+        if (! isset(self::$parameters)) {
+            self::$parameters = ['default'];
+        }
+
+        return self::$parameters;
+    }
+}

--- a/rules/Php74/Rector/If_/IfToNullCoalescingAssignRector.php
+++ b/rules/Php74/Rector/If_/IfToNullCoalescingAssignRector.php
@@ -12,9 +12,13 @@ use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Isset_;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\TypeCombinator;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
@@ -95,6 +99,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // a typed non-nullable property can never be null on the left of ??=
+        if ($this->isNonNullableProperty($testedExpr)) {
+            return null;
+        }
+
         // the assigned value must not reference the target, e.g. $x = $x + 1
         $selfReference = $this->betterNodeFinder->findFirst(
             $assign->expr,
@@ -110,6 +119,20 @@ CODE_SAMPLE
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::NULL_COALESCE_ASSIGN;
+    }
+
+    private function isNonNullableProperty(Expr $expr): bool
+    {
+        if (! $expr instanceof PropertyFetch && ! $expr instanceof StaticPropertyFetch) {
+            return false;
+        }
+
+        $propertyType = $this->nodeTypeResolver->getType($expr);
+        if ($propertyType instanceof MixedType) {
+            return false;
+        }
+
+        return ! TypeCombinator::containsNull($propertyType);
     }
 
     private function matchNullGuardedExpr(Expr $expr): ?Expr


### PR DESCRIPTION
`IfToNullCoalescingAssignRector` rewrites a null guard `if` into `??=` without checking the target is nullable. When the target is a typed non-nullable property, the `??=` left side can never be null, so PHPStan flags it:

> Static property `Foo::$parameters` (array) on left side of `??=` is not nullable — `nullCoalesce.property`

### Before (rule fires, produces invalid code)

```php
class TokenHelper
{
    private static array $parameters;

    public function get(): array
    {
        // rule turns this...
        if (! isset(self::$parameters)) {
            self::$parameters = ['default'];
        }

        return self::$parameters;
    }
}
```

```php
// ...into this — PHPStan: left side of ??= is not nullable
self::$parameters ??= ['default'];
```

## Fix

Skip when the guarded target is a `PropertyFetch` / `StaticPropertyFetch` with a declared non-nullable type. Untyped properties (`MixedType`) still convert as before.

### After

```php
// typed non-nullable property left unchanged
if (! isset(self::$parameters)) {
    self::$parameters = ['default'];
}
```