### PR TITLE
[Php74] Keep comments above if on IfToNullCoalescingAssignRector

### DIFF
--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/keep_comment_above_if.php.inc
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/keep_comment_above_if.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+/**
+ * Fallback value description
+ *
+ * @var int $limit
+ */
+if (! isset($limit)) {
+    $limit = 100;
+}
+
+// simple comment
+if (! isset($name)) {
+    $name = 'default';
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+/**
+ * Fallback value description
+ *
+ * @var int $limit
+ */
+$limit ??= 100;
+
+// simple comment
+$name ??= 'default';
+
+?>

--- a/rules/Php74/Rector/If_/IfToNullCoalescingAssignRector.php
+++ b/rules/Php74/Rector/If_/IfToNullCoalescingAssignRector.php
@@ -113,7 +113,10 @@ CODE_SAMPLE
             return null;
         }
 
-        return new Expression(new AssignCoalesce($assign->var, $assign->expr));
+        $expression = new Expression(new AssignCoalesce($assign->var, $assign->expr));
+        $this->mirrorComments($expression, $node);
+
+        return $expression;
     }
 
     public function provideMinPhpVersion(): int


### PR DESCRIPTION
`IfToNullCoalescingAssignRector` builds a fresh `Expression` node for the `??=` statement and returns it. A new node carries no attributes, so the `COMMENTS` of the replaced `If_` are dropped — every docblock or line comment above the guard is lost.

### Before (rule fires, comment disappears)

```php
/**
 * Fallback value description
 *
 * @var int $limit
 */
if (! isset($limit)) {
    $limit = 100;
}

// simple comment
if (! isset($name)) {
    $name = 'default';
}
```

...becomes this — both comments are gone
```php
$limit ??= 100;

$name ??= 'default';
```

## Fix

Mirror the comments from the `If_` onto the new `Expression` before returning it.

### After

```php
/**
 * Fallback value description
 *
 * @var int $limit
 */
$limit ??= 100;

// simple comment
$name ??= 'default';
```

All three guard forms (`! isset()`, `is_null()`, `=== null`) share the single return path, so one fixture covers them.