### PR TITLE
[Php74] Fix isset guard never converting on IfToNullCoalescingAssignRector

### DIFF
--- a/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/isset_nullable_property.php.inc
+++ b/rules-tests/Php74/Rector/If_/IfToNullCoalescingAssignRector/Fixture/isset_nullable_property.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+class IssetNullableProperty
+{
+    private ?array $values = null;
+
+    public function get(): array
+    {
+        if (! isset($this->values)) {
+            $this->values = ['default'];
+        }
+
+        return $this->values;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php74\Rector\If_\IfToNullCoalescingAssignRector\Fixture;
+
+class IssetNullableProperty
+{
+    private ?array $values = null;
+
+    public function get(): array
+    {
+        $this->values ??= ['default'];
+
+        return $this->values;
+    }
+}
+
+?>

--- a/rules/Php74/Rector/If_/IfToNullCoalescingAssignRector.php
+++ b/rules/Php74/Rector/If_/IfToNullCoalescingAssignRector.php
@@ -17,11 +17,13 @@ use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
+use PHPStan\Reflection\Php\PhpPropertyReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\TypeCombinator;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -34,7 +36,8 @@ final class IfToNullCoalescingAssignRector extends AbstractRector implements Min
 {
     public function __construct(
         private readonly BetterNodeFinder $betterNodeFinder,
-        private readonly ValueResolver $valueResolver
+        private readonly ValueResolver $valueResolver,
+        private readonly ReflectionResolver $reflectionResolver
     ) {
     }
 
@@ -127,7 +130,12 @@ CODE_SAMPLE
             return false;
         }
 
-        $propertyType = $this->nodeTypeResolver->getType($expr);
+        $phpPropertyReflection = $this->reflectionResolver->resolvePropertyReflectionFromPropertyFetch($expr);
+        if (! $phpPropertyReflection instanceof PhpPropertyReflection) {
+            return false;
+        }
+
+        $propertyType = $phpPropertyReflection->getReadableType();
         if ($propertyType instanceof MixedType) {
             return false;
         }


### PR DESCRIPTION
The non-nullable property skip from #8387 reads the type off the fetch node returned by `matchNullGuardedExpr()`. For the `! isset($prop)` form that node sits *inside* `Isset_`, where PHPStan has already narrowed `null` out of the type. `TypeCombinator::containsNull()` is therefore always `false`, `isNonNullableProperty()` always returns `true`, and the skip fires for every property under `isset`, nullable or not.

### Before (same nullable property, three guard forms)

```php
class Demo
{
    private ?array $values = null;

    public function get(): array
    {
        // skipped, but should convert
        if (! isset($this->values)) {
            $this->values = ['default'];
        }

        // converts
        if (null === $this->values) {
            $this->values = ['default'];
        }

        // converts
        if (is_null($this->values)) {
            $this->values = ['default'];
        }

        return $this->values;
    }
}
```

Only the `isset` form is affected, so it was silently disabled for properties, including the case the rule advertises in its `CodeSample`.

## Fix

Resolve the declared type through `ReflectionResolver::resolvePropertyReflectionFromPropertyFetch()` instead of `nodeTypeResolver->getType()` on the fetch node. `getReadableType()` stays phpdoc-aware like the previous call, but carries no scope narrowing.

### After

```php
// nullable property, isset form
$this->values ??= ['default'];
```

`skip_typed_non_nullable_property.php.inc` keeps skipping, so the boundary #8387 intended is unchanged, the two fixtures now pin it from both sides.