### PR TITLE
[ChangesReporting] Deprecate github and gitlab output formats

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -72,6 +72,15 @@ parameters:
             message: '#deprecated (class|interface) Rector\\(Set|Bridge)\\#'
             path: src/Configuration/RectorConfigBuilder.php
 
+        # the deprecated github/gitlab output formatters are still tested until removed in next minor version
+        -
+            identifier: new.deprecatedClass
+            path: tests/ChangesReporting/Output/GitHubOutputFormatterTest.php
+
+        -
+            identifier: method.deprecatedClass
+            path: tests/ChangesReporting/Output/GitHubOutputFormatterTest.php
+
         -
             identifier: argument.templateType
             path: rules/TypeDeclaration/Rector/FunctionLike/AddClosureParamTypeForArrayReduceRector.php

--- a/src/ChangesReporting/Output/GitHubOutputFormatter.php
+++ b/src/ChangesReporting/Output/GitHubOutputFormatter.php
@@ -18,6 +18,8 @@ use Rector\ValueObject\Configuration;
 use Rector\ValueObject\ProcessResult;
 
 /**
+ * @deprecated Will be removed in next minor version, as Rector is not a static analysis tool.
+ *
  * @phpstan-type AnnotationProperties array{title?: string|null, file?: string|null, col?: int|null, endColumn?: int|null, line?: int|null, endLine?: int|null}
  * @see \Rector\Tests\ChangesReporting\Output\GitHubOutputFormatterTest
  */

--- a/src/ChangesReporting/Output/GitlabOutputFormatter.php
+++ b/src/ChangesReporting/Output/GitlabOutputFormatter.php
@@ -15,6 +15,9 @@ use Rector\Util\FileHasher;
 use Rector\ValueObject\Configuration;
 use Rector\ValueObject\ProcessResult;
 
+/**
+ * @deprecated Will be removed in next minor version, as Rector is not a static analysis tool.
+ */
 final readonly class GitlabOutputFormatter implements OutputFormatterInterface
 {
     private const string NAME = 'gitlab';

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -176,6 +176,16 @@ EOF
         // 3. reporting phaseRunning 2nd time with collectors data
         // report diffs and errors
         $outputFormat = $configuration->getOutputFormat();
+
+        // warn about deprecated static-analysis-oriented output formats, to be removed in next minor version
+        if (in_array($outputFormat, ['github', 'gitlab'], true)) {
+            $this->symfonyStyle->getErrorStyle()
+                ->warning(sprintf(
+                    'The "%s" output format is deprecated and will be removed in the next minor version, as Rector is not a static analysis tool.',
+                    $outputFormat
+                ));
+        }
+
         $outputFormatter = $this->outputFormatterCollector->getByName($outputFormat);
 
         $outputFormatter->report($processResult, $configuration);


### PR DESCRIPTION
Rector is a refactoring tool, **not a static analysis tool**. The `github` and `gitlab` output formats produce code-quality reports meant for static analysers (GitHub Actions annotations / GitLab CodeClimate JSON), which is a poor fit for Rector's diffs.

Deprecate both. They will be **removed in the next minor version**.

