### PR TITLE
Fix double backslash in FunctionFirstClassCallableRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FuncCall/FunctionFirstClassCallableRector/Fixture/leading_backslash.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/FunctionFirstClassCallableRector/Fixture/leading_backslash.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\FunctionFirstClassCallableRector\Fixture;
+
+final class LeadingBackslash
+{
+    public function run(array $input)
+    {
+        return \array_map('\trim', $input);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\FunctionFirstClassCallableRector\Fixture;
+
+final class LeadingBackslash
+{
+    public function run(array $input)
+    {
+        return \array_map(\trim(...), $input);
+    }
+}
+
+?>

--- a/rules/CodingStyle/Rector/FuncCall/FunctionFirstClassCallableRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/FunctionFirstClassCallableRector.php
@@ -101,11 +101,14 @@ CODE_SAMPLE
                 continue;
             }
 
+            $isFullyQualified = str_starts_with($arg->value->value, '\\');
+            $callableName = ltrim($arg->value->value, '\\');
+
             $node->args[$key] = new Arg(
                 new FuncCall(
-                    str_contains($arg->value->value, '\\')
-                        ? new FullyQualified($arg->value->value)
-                        : new Name($arg->value->value),
+                    $isFullyQualified || str_contains($callableName, '\\')
+                        ? new FullyQualified($callableName)
+                        : new Name($callableName),
                     [new VariadicPlaceholder()]
                 ),
                 name: $arg->name


### PR DESCRIPTION
Fixes rectorphp/rector#9871

`FunctionFirstClassCallableRector` produced invalid PHP for a fully qualified string callable with a leading backslash. The leading `\` was passed straight into `FullyQualified`, which then printed a doubled backslash.

```diff
-\array_map('\trim', $input);
+\array_map(\trim(...), $input);
```

Before the fix the output was `\array_map(\\trim(...), $input)` - invalid syntax.

Fix: strip the leading backslash before building the name and keep it fully qualified when one was present.
