### PR TITLE
[Caching] Invalidate on configured rule value change, reuse full-run cache for --only

### DIFF
--- a/src/Caching/Detector/ChangedFilesDetector.php
+++ b/src/Caching/Detector/ChangedFilesDetector.php
@@ -61,8 +61,14 @@ final class ChangedFilesDetector
 
     public function hasFileChanged(string $filePath): bool
     {
-        $fileInfoCacheKey = $this->getFilePathCacheKey($filePath);
-        $cachedValue = $this->cache->load($fileInfoCacheKey, CacheKey::FILE_HASH_KEY);
+        $cachedValue = $this->cache->load($this->getFilePathCacheKey($filePath), CacheKey::FILE_HASH_KEY);
+
+        // a scoped (--only) run reuses the full-run cache: a file left clean by all rules stays
+        // clean under a single rule too, and the content is still compared below
+        if ($cachedValue === null && $this->scopeSuffix !== '') {
+            $unscopedCacheKey = $this->fileHasher->hash($this->resolvePath($filePath));
+            $cachedValue = $this->cache->load($unscopedCacheKey, CacheKey::FILE_HASH_KEY);
+        }
 
         if ($cachedValue !== null) {
             $currentFileHash = $this->hashFile($filePath);

--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -215,6 +215,9 @@ final class RectorConfig extends Container
             $configuration
         );
 
+        // feed values into the cache hash, so a changed configuration invalidates the cache
+        SimpleParameterProvider::setParameter(Option::RULE_CONFIGURATIONS, $this->ruleConfigurations);
+
         $this->rule($rectorClass);
 
         $this->afterResolving($rectorClass, function (ConfigurableRectorInterface $configurableRector) use (

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -219,6 +219,11 @@ final class Option
     public const string REGISTERED_RECTOR_SETS = 'registered_rector_sets';
 
     /**
+     * @internal For cache invalidation when a configurable rule value changes
+     */
+    public const string RULE_CONFIGURATIONS = 'rule_configurations';
+
+    /**
      * @internal For verify RectorConfigBuilder instance recreated
      */
     public const string IS_RECTORCONFIG_BUILDER_RECREATED = 'is_rectorconfig_builder_recreated';

--- a/tests/Caching/Config/FileHashComputer/FileHashComputerTest.php
+++ b/tests/Caching/Config/FileHashComputer/FileHashComputerTest.php
@@ -23,6 +23,11 @@ final class FileHashComputerTest extends AbstractLazyTestCase
      */
     private array $originalFileExtensions = [];
 
+    /**
+     * @var mixed[]
+     */
+    private array $originalRuleConfigurations = [];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -32,12 +37,14 @@ final class FileHashComputerTest extends AbstractLazyTestCase
         // the parameter bag is a global static shared across the whole test process, restore it after
         $this->originalRules = SimpleParameterProvider::provideArrayParameter(Option::REGISTERED_RECTOR_RULES);
         $this->originalFileExtensions = SimpleParameterProvider::provideArrayParameter(Option::FILE_EXTENSIONS);
+        $this->originalRuleConfigurations = SimpleParameterProvider::provideArrayParameter(Option::RULE_CONFIGURATIONS);
     }
 
     protected function tearDown(): void
     {
         SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_RULES, $this->originalRules);
         SimpleParameterProvider::setParameter(Option::FILE_EXTENSIONS, $this->originalFileExtensions);
+        SimpleParameterProvider::setParameter(Option::RULE_CONFIGURATIONS, $this->originalRuleConfigurations);
     }
 
     public function testOutputAffectingParameterChangesHash(): void
@@ -65,5 +72,23 @@ final class FileHashComputerTest extends AbstractLazyTestCase
         $hashAfter = $this->fileHashComputer->compute($configFilePath);
 
         $this->assertSame($hashBefore, $hashAfter);
+    }
+
+    public function testConfiguredRuleValueChangeChangesHash(): void
+    {
+        $configFilePath = __DIR__ . '/Fixture/rector.php';
+
+        SimpleParameterProvider::setParameter(Option::RULE_CONFIGURATIONS, [
+            'Rector\\SomeRule' => ['old value'],
+        ]);
+        $hashBefore = $this->fileHashComputer->compute($configFilePath);
+
+        // same rule, changed configuration value must invalidate the cache
+        SimpleParameterProvider::setParameter(Option::RULE_CONFIGURATIONS, [
+            'Rector\\SomeRule' => ['new value'],
+        ]);
+        $hashAfter = $this->fileHashComputer->compute($configFilePath);
+
+        $this->assertNotSame($hashBefore, $hashAfter);
     }
 }

--- a/tests/Caching/Detector/ChangedFilesDetectorTest.php
+++ b/tests/Caching/Detector/ChangedFilesDetectorTest.php
@@ -63,6 +63,36 @@ final class ChangedFilesDetectorTest extends AbstractLazyTestCase
         $this->assertTrue($this->changedFilesDetector->hasFileChanged($filePath));
     }
 
+    public function testScopedRunReusesFullRunCache(): void
+    {
+        $filePath = __DIR__ . '/Source/file.php';
+
+        // full run caches the file as clean
+        $this->changedFilesDetector->setActiveScope(null, null);
+        $this->changedFilesDetector->addCacheableFile($filePath);
+        $this->changedFilesDetector->cacheFile($filePath);
+        $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
+
+        // an --only run reuses the full-run cache instead of re-analysing the file
+        $this->changedFilesDetector->setActiveScope('Rector\\SomeRule', null);
+        $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
+    }
+
+    public function testScopedCacheDoesNotLeakToFullRun(): void
+    {
+        $filePath = __DIR__ . '/Source/file.php';
+
+        // a scoped run only caches under its own key
+        $this->changedFilesDetector->setActiveScope('Rector\\SomeRule', null);
+        $this->changedFilesDetector->addCacheableFile($filePath);
+        $this->changedFilesDetector->cacheFile($filePath);
+        $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
+
+        // a full run must not treat the file as cached, as only one rule ran
+        $this->changedFilesDetector->setActiveScope(null, null);
+        $this->assertTrue($this->changedFilesDetector->hasFileChanged($filePath));
+    }
+
     public function testCacheKeptWhenRuleRemoved(): void
     {
         $filePath = $this->cacheFileUnderRules(['Rector\\RuleA', 'Rector\\RuleB']);


### PR DESCRIPTION
Two independent caching improvements.

### 1. Configured rule value changes now invalidate the cache

`withConfiguredRule()` stored its configuration on the `RectorConfig` instance only, never in the parameter bag that feeds the cache hash. So changing a rule's configuration - same rule class, different values - did not invalidate the cache and the old result was served.

```diff
 // rector.php
 return RectorConfig::configure()
     ->withConfiguredRule(SomeRector::class, [
-        'old value',
+        'new value',
     ]);
```

Before: cache kept, files re-analysed with the stale value.
After: cache dropped, files re-analysed with the new value.

The merged configuration is now pushed into a `RULE_CONFIGURATIONS` parameter, so it flows into the strict cache hash automatically. Upgrading invalidates the cache once for projects using configured rules.

### 2. `--only <Rule>` reuses the full-run cache

Each `--only` selection has its own cache namespace (#8075), so a file left clean by a prior full run was re-analysed under `--only`, even when nothing changed.

A scoped run now falls back to the full-run cache: a file the full run left clean (all rules at a fixed point) stays clean under a single rule too, and the file content is still compared, so a real edit is still picked up. The fallback is read only - a scoped run still writes only under its own key, so it never claims a full fixed point.

Before: `--only SomeRector` after a full run re-analyses every file.
After: it skips files the full run already left clean.