### PR TITLE
[Config] Only registered rules count as active rules

### DIFF
--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -568,6 +568,38 @@ final class RectorConfig extends Container
         }
     }
 
+    /**
+     * The container caches every instance it builds, so a rule that another service takes as a
+     * constructor dependency is cached like any other object. Returned unfiltered it would count
+     * as an active rule although no config ever registered it — and this is where the active set
+     * comes from on both paths: the node traverser is autowired from an "@param RectorInterface[]"
+     * parameter, and AbstractRectorTestCase reads the same list.
+     *
+     * The narrowing keys off the requested contract, so a wider one still sees every instance -
+     * findByContract(NodeVisitor::class) includes unregistered rules, since RectorInterface
+     * extends NodeVisitor.
+     *
+     * @template TType as object
+     *
+     * @param class-string<TType> $contractClass
+     * @return list<TType>
+     */
+    public function findByContract(string $contractClass): array
+    {
+        $instances = parent::findByContract($contractClass);
+
+        if (! is_a($contractClass, RectorInterface::class, true)) {
+            return $instances;
+        }
+
+        return array_values(
+            array_filter(
+                $instances,
+                fn (object $instance): bool => isset($this->registeredRectorClasses[$instance::class])
+            )
+        );
+    }
+
     public function reportingRealPath(bool $absolute = true): void
     {
         SimpleParameterProvider::setParameter(Option::ABSOLUTE_FILE_PATH, $absolute);

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -7,6 +7,7 @@ namespace Rector\Testing\PHPUnit;
 use Iterator;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
+use PhpParser\NodeVisitor;
 use PHPUnit\Framework\ExpectationFailedException;
 use Rector\Application\ApplicationFileProcessor;
 use Rector\Autoloading\AdditionalAutoloader;
@@ -100,8 +101,15 @@ abstract class AbstractRectorTestCase extends AbstractLazyTestCase implements Re
             $this->forgetRectorsRules();
             $rectorConfig->resetRuleConfigurations();
 
-            // this has to be always empty, so we can add new rules with their configuration
-            $this->assertEmpty($rectorConfig->findByContract(RectorInterface::class));
+            // this has to be always empty, so we can add new rules with their configuration.
+            // asked through the wider contract on purpose: the rule contract now reports only
+            // registered rules, and the registered list was just cleared, so it would answer
+            // "empty" without looking at what the forget above actually left behind
+            $leftOverRectors = array_filter(
+                $rectorConfig->findByContract(NodeVisitor::class),
+                static fn (NodeVisitor $nodeVisitor): bool => $nodeVisitor instanceof RectorInterface
+            );
+            $this->assertSame([], $leftOverRectors);
 
             $this->bootFromConfigFiles([$configFile]);
 

--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -7,6 +7,7 @@ namespace Rector\Tests\Config;
 use Rector\Config\RectorConfig;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Contract\Rector\RectorInterface;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
@@ -14,6 +15,8 @@ use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\RenameProperty;
 use Rector\Symfony\Set\SymfonySetList;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\Tests\Config\Source\DependencyOnlyRector;
+use Rector\Tests\Config\Source\RegisteringRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 
 final class RectorConfigTest extends AbstractLazyTestCase
@@ -88,5 +91,22 @@ final class RectorConfigTest extends AbstractLazyTestCase
 
         $registeredRectorRules = SimpleParameterProvider::provideArrayParameter(Option::REGISTERED_RECTOR_RULES);
         $this->assertNotContains(RenamePropertyRector::class, $registeredRectorRules);
+    }
+
+    public function testRuleTakenOnlyAsDependencyIsNotActive(): void
+    {
+        $rectorConfig = $this->getContainer();
+
+        $rectorConfig->rule(RegisteringRector::class);
+
+        // building the registered rule also builds and caches its constructor dependency,
+        // which is a rule too - but one no config asked for
+        $activeRectorClasses = array_map(
+            static fn (object $rector): string => $rector::class,
+            $rectorConfig->findByContract(RectorInterface::class)
+        );
+
+        $this->assertContains(RegisteringRector::class, $activeRectorClasses);
+        $this->assertNotContains(DependencyOnlyRector::class, $activeRectorClasses);
     }
 }

--- a/tests/Config/Source/DependencyOnlyRector.php
+++ b/tests/Config/Source/DependencyOnlyRector.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Config\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Never registered. It exists only as a constructor dependency of @see RegisteringRector,
+ * which is enough for the container to build and cache it.
+ */
+final class DependencyOnlyRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('', []);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [String_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return null;
+    }
+}

--- a/tests/Config/Source/RegisteringRector.php
+++ b/tests/Config/Source/RegisteringRector.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Config\Source;
+
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class RegisteringRector extends AbstractRector
+{
+    public function __construct(
+        private readonly DependencyOnlyRector $dependencyOnlyRector
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('', []);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [String_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return $this->dependencyOnlyRector->refactor($node);
+    }
+}


### PR DESCRIPTION
`findByContract()` returns every instance the container cached, so a rule that another service takes as a constructor dependency counts as active although no config registered it. `RectorNodeTraverser` (autowired from `@param RectorInterface[]`) and `AbstractRectorTestCase` both read that list, so it hits `bin/rector`, not just tests:

```
bin/rector process <dir> --dry-run --config <config registering one rule>

-        return 'marker';
+        return 'rewritten by an unregistered rule';
Applied rules:
 * UnregisteredMarkerRector
```

Before 2.6.4 the same decision was `tagged(RectorInterface::class)`, filled by `rule()` — registration decided what was active, not existence.

Fix: `RectorConfig::findByContract()` intersects with `$registeredRectorClasses` when the contract is a rule contract. Other and wider contracts are untouched.

Test in `tests/Config/RectorConfigTest`. Found in ssch/typo3-rector, where `ValidateAttributeDecorator` takes `StringClassNameToClassConstantRector` in its constructor.

_Assisted by claude-code:claude-fable-5_
