### PR TITLE
[dx] Deprecate SetList::INSTANCEOF, move rules into code-quality and type-declaration sets

### DIFF
--- a/config/set/instanceof.php
+++ b/config/set/instanceof.php
@@ -2,11 +2,9 @@
 
 declare(strict_types=1);
 
-use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\Config\RectorConfig;
 
+// note: all instanceof rules were moved to code quality and type declaration sets
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rules([
-        FlipTypeControlToUseExclusiveTypeRector::class,
-    ]);
+    $rectorConfig->rules([]);
 };

--- a/config/set/instanceof.php
+++ b/config/set/instanceof.php
@@ -4,15 +4,9 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\Config\RectorConfig;
-use Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector;
-use Rector\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector;
-use Rector\TypeDeclaration\Rector\While_\WhileNullableToInstanceofRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
         FlipTypeControlToUseExclusiveTypeRector::class,
-        FlipNegatedTernaryInstanceofRector::class,
-        BinaryOpNullableToInstanceofRector::class,
-        WhileNullableToInstanceofRector::class,
     ]);
 };

--- a/config/set/instanceof.php
+++ b/config/set/instanceof.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Rector\CodeQuality\Rector\FuncCall\InlineIsAInstanceOfRector;
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\If_\RemoveDeadInstanceOfRector;
 use Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector;
 use Rector\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector;
 use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
@@ -16,7 +15,6 @@ return static function (RectorConfig $rectorConfig): void {
         EmptyOnNullableObjectToInstanceOfRector::class,
         InlineIsAInstanceOfRector::class,
         FlipTypeControlToUseExclusiveTypeRector::class,
-        RemoveDeadInstanceOfRector::class,
         FlipNegatedTernaryInstanceofRector::class,
         BinaryOpNullableToInstanceofRector::class,
         WhileNullableToInstanceofRector::class,

--- a/config/set/instanceof.php
+++ b/config/set/instanceof.php
@@ -2,18 +2,14 @@
 
 declare(strict_types=1);
 
-use Rector\CodeQuality\Rector\FuncCall\InlineIsAInstanceOfRector;
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\Config\RectorConfig;
 use Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector;
 use Rector\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector;
-use Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector;
 use Rector\TypeDeclaration\Rector\While_\WhileNullableToInstanceofRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
-        EmptyOnNullableObjectToInstanceOfRector::class,
-        InlineIsAInstanceOfRector::class,
         FlipTypeControlToUseExclusiveTypeRector::class,
         FlipNegatedTernaryInstanceofRector::class,
         BinaryOpNullableToInstanceofRector::class,

--- a/src/Config/Level/TypeDeclarationLevel.php
+++ b/src/Config/Level/TypeDeclarationLevel.php
@@ -8,6 +8,7 @@ use Rector\CodeQuality\Rector\Class_\ReturnIteratorInDataProviderRector;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\Symfony\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector;
 use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
+use Rector\TypeDeclaration\Rector\BooleanAnd\BinaryOpNullableToInstanceofRector;
 use Rector\TypeDeclaration\Rector\Class_\AddTestsVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\Class_\ChildDoctrineRepositoryClassTypeRector;
 use Rector\TypeDeclaration\Rector\Class_\MergeDateTimePropertyTypeDeclarationRector;
@@ -78,6 +79,7 @@ use Rector\TypeDeclaration\Rector\FunctionLike\AddReturnTypeDeclarationFromYield
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector;
+use Rector\TypeDeclaration\Rector\While_\WhileNullableToInstanceofRector;
 
 final class TypeDeclarationLevel
 {
@@ -126,6 +128,8 @@ final class TypeDeclarationLevel
 
         // php 7.4
         EmptyOnNullableObjectToInstanceOfRector::class,
+        WhileNullableToInstanceofRector::class,
+        BinaryOpNullableToInstanceofRector::class,
 
         // php 7.4
         TypedPropertyFromStrictConstructorRector::class,

--- a/src/Set/ValueObject/SetList.php
+++ b/src/Set/ValueObject/SetList.php
@@ -131,6 +131,9 @@ final class SetList
      */
     public const string EARLY_RETURN = __DIR__ . '/../../../config/set/early-return.php';
 
+    /**
+     * @deprecated Use code-quality set instead, as most instanceof rules were moved there
+     */
     public const string INSTANCEOF = __DIR__ . '/../../../config/set/instanceof.php';
 
     public const string IF = __DIR__ . '/../../../config/set/if.php';


### PR DESCRIPTION
The `instanceof` set overlapped heavily with `code-quality` and `type-declaration`. This consolidates the rules and deprecates the set:

- Removed duplicates already present elsewhere: `RemoveDeadInstanceOfRector` (dead-code), `InlineIsAInstanceOfRector` + `FlipNegatedTernaryInstanceofRector` + `FlipTypeControlToUseExclusiveTypeRector` (code-quality), `EmptyOnNullableObjectToInstanceOfRector` (type-declaration).
- Moved `WhileNullableToInstanceofRector` and `BinaryOpNullableToInstanceofRector` into `TypeDeclarationLevel`, next to `EmptyOnNullableObjectToInstanceOfRector`.
- The `instanceof` set is now empty; `SetList::INSTANCEOF` is deprecated in favor of the code-quality set.