### PR TITLE
Use unused-public bundled in class-leak 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,10 +54,9 @@
         "symfony/process": "^8.1",
         "symplify/easy-coding-standard": "^13.2.13",
         "symplify/phpstan-rules": "^14.13",
-        "tomasvotruba/class-leak": "^2.1",
+        "tomasvotruba/class-leak": "^2.2",
         "tomasvotruba/fast-unit": "^0.1",
         "tomasvotruba/type-coverage": "^2.3.6",
-        "tomasvotruba/unused-public": "^2.2",
         "tracy/tracy": "^2.12"
     },
     "replace": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 includes:
     - vendor/symplify/phpstan-rules/config/symplify-rules.neon
     - vendor/symplify/phpstan-rules/config/rector-rules.neon
+    - vendor/tomasvotruba/class-leak/config/unused-public-extension.neon
 
 rules:
     - Rector\Utils\PHPStan\Rule\RegisterRelatedPolyfillRectorRule
@@ -58,7 +59,7 @@ parameters:
         narrow_param: true
         narrow_return: true
 
-    # see https://github.com/TomasVotruba/unused-public
+    # bundled in tomasvotruba/class-leak, see https://github.com/TomasVotruba/class-leak
     unused_public:
         methods: true
         properties: true


### PR DESCRIPTION
class-leak 2.2 now bundles the unused-public PHPStan extension, so the standalone `tomasvotruba/unused-public` dependency is redundant.

## Changes
- Bump `tomasvotruba/class-leak` to `^2.2`
- Remove `tomasvotruba/unused-public`
- Include the bundled extension in `phpstan.neon`:
  `vendor/tomasvotruba/class-leak/config/unused-public-extension.neon`

The `unused_public` parameters are unchanged. Verified locally that the rules still fire (e.g. `public.method.unused`).