### PR TITLE
[dx] Move if-set rules into code-quality and coding-style sets, deprecate SetList::IF

### DIFF
--- a/config/set/if.php
+++ b/config/set/if.php
@@ -2,29 +2,15 @@
 
 declare(strict_types=1);
 
-use Rector\CodeQuality\Rector\Expression\InlineIfToExplicitIfRector;
-use Rector\CodeQuality\Rector\Expression\TernaryFalseExpressionToIfRector;
-use Rector\CodeQuality\Rector\If_\ArrayExplicitBoolCompareRector;
 use Rector\CodeQuality\Rector\If_\CombineIfRector;
-use Rector\CodeQuality\Rector\If_\CompleteMissingIfElseBracketRector;
 use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
-use Rector\CodeQuality\Rector\If_\ObjectExplicitBoolCompareRector;
-use Rector\CodeQuality\Rector\If_\ShortenElseIfRector;
 use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
-use Rector\CodingStyle\Rector\If_\AlternativeIfToBracketRector;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
-        AlternativeIfToBracketRector::class,
-        CompleteMissingIfElseBracketRector::class,
-        InlineIfToExplicitIfRector::class,
-        TernaryFalseExpressionToIfRector::class,
-        ArrayExplicitBoolCompareRector::class,
-        ObjectExplicitBoolCompareRector::class,
         ExplicitBoolCompareRector::class,
         CombineIfRector::class,
-        ShortenElseIfRector::class,
         SimplifyIfElseToTernaryRector::class,
     ]);
 };

--- a/src/Config/Level/CodeQualityLevel.php
+++ b/src/Config/Level/CodeQualityLevel.php
@@ -27,6 +27,8 @@ use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRe
 use Rector\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector;
 use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodeQuality\Rector\Equal\UseIdenticalOverEqualWithSameTypeRector;
+use Rector\CodeQuality\Rector\Expression\InlineIfToExplicitIfRector;
+use Rector\CodeQuality\Rector\Expression\TernaryFalseExpressionToIfRector;
 use Rector\CodeQuality\Rector\For_\ForRepeatedCountToOwnVariableRector;
 use Rector\CodeQuality\Rector\Foreach_\ForeachItemsAssignToEmptyArrayToAssignRector;
 use Rector\CodeQuality\Rector\Foreach_\ForeachToInArrayRector;
@@ -49,7 +51,10 @@ use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\CodeQuality\Rector\Identical\SimplifyArraySearchRector;
 use Rector\CodeQuality\Rector\Identical\SimplifyConditionsRector;
 use Rector\CodeQuality\Rector\Identical\StrlenZeroToIdenticalEmptyStringRector;
+use Rector\CodeQuality\Rector\If_\ArrayExplicitBoolCompareRector;
 use Rector\CodeQuality\Rector\If_\ConsecutiveNullCompareReturnsToNullCoalesceQueueRector;
+use Rector\CodeQuality\Rector\If_\ObjectExplicitBoolCompareRector;
+use Rector\CodeQuality\Rector\If_\ShortenElseIfRector;
 use Rector\CodeQuality\Rector\If_\SimplifyIfNotNullReturnRector;
 use Rector\CodeQuality\Rector\If_\SimplifyIfNullableReturnRector;
 use Rector\CodeQuality\Rector\If_\SimplifyIfReturnBoolRector;
@@ -137,6 +142,9 @@ final class CodeQualityLevel
         CompleteDynamicPropertiesRector::class,
         IsAWithStringWithThirdArgumentRector::class,
         StrlenZeroToIdenticalEmptyStringRector::class,
+        ArrayExplicitBoolCompareRector::class,
+        ObjectExplicitBoolCompareRector::class,
+        ShortenElseIfRector::class,
         ThrowWithPreviousExceptionRector::class,
         RemoveSoleValueSprintfRector::class,
         ExplicitReturnNullRector::class,
@@ -154,6 +162,8 @@ final class CodeQualityLevel
         NewStaticToNewSelfRector::class,
         VariableConstFetchToClassConstFetchRector::class,
         SingularSwitchToIfRector::class,
+        InlineIfToExplicitIfRector::class,
+        TernaryFalseExpressionToIfRector::class,
         SwitchTrueToMatchRector::class,
         SimplifyIfNullableReturnRector::class,
         CallUserFuncWithArrowFunctionToInlineRector::class,

--- a/src/Config/Level/CodingStyleLevel.php
+++ b/src/Config/Level/CodingStyleLevel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Config\Level;
 
+use Rector\CodeQuality\Rector\If_\CompleteMissingIfElseBracketRector;
 use Rector\CodingStyle\Rector\Assign\SplitDoubleAssignRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\ClassConst\SplitGroupedClassConstantsRector;
@@ -16,6 +17,7 @@ use Rector\CodingStyle\Rector\FuncCall\CallUserFuncToMethodCallRector;
 use Rector\CodingStyle\Rector\FuncCall\StrictArraySearchRector;
 use Rector\CodingStyle\Rector\FuncCall\StrictInArrayRector;
 use Rector\CodingStyle\Rector\FuncCall\VersionCompareFuncCallToConstantRector;
+use Rector\CodingStyle\Rector\If_\AlternativeIfToBracketRector;
 use Rector\CodingStyle\Rector\Property\SplitGroupedPropertiesRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\CodingStyle\Rector\Stmt\RemoveUselessAliasInUseStatementRector;
@@ -49,6 +51,8 @@ final class CodingStyleLevel
         SeparateMultiUseImportsRector::class,
         NewlineBetweenClassLikeStmtsRector::class,
         NewlineAfterStatementRector::class,
+        AlternativeIfToBracketRector::class,
+        CompleteMissingIfElseBracketRector::class,
         SimplifyQuoteEscapeRector::class,
         StringClassNameToClassConstantRector::class,
         CatchExceptionNameMatchingTypeRector::class,

--- a/src/Set/ValueObject/SetList.php
+++ b/src/Set/ValueObject/SetList.php
@@ -136,6 +136,9 @@ final class SetList
      */
     public const string INSTANCEOF = __DIR__ . '/../../../config/set/instanceof.php';
 
+    /**
+     * @deprecated Use code-quality and coding-style sets instead, as the if rules were moved there or deprecated
+     */
     public const string IF = __DIR__ . '/../../../config/set/if.php';
 
     public const string CARBON = __DIR__ . '/../../../config/set/datetime-to-carbon.php';


### PR DESCRIPTION
Move rules that live in the `CodeQuality` and `CodingStyle` namespaces but were registered in the `if` set into their level sets:

- `AlternativeIfToBracketRector`, `CompleteMissingIfElseBracketRector` -> `CodingStyleLevel`
- `InlineIfToExplicitIfRector`, `TernaryFalseExpressionToIfRector`, `ArrayExplicitBoolCompareRector`, `ObjectExplicitBoolCompareRector`, `ShortenElseIfRector` -> `CodeQualityLevel`

Deprecate `SetList::IF`, as the if set is being emptied (its remaining entries are deprecated rules handled in separate PRs).

Part of splitting the if-set cleanup into focused PRs.