### PR TITLE
[dx] Mark deprecated prepared sets params and withCacheMetaExtension with @deprecated

### DIFF
--- a/src/Configuration/RectorConfigBuilder.php
+++ b/src/Configuration/RectorConfigBuilder.php
@@ -640,6 +640,11 @@ final class RectorConfigBuilder
     // there is no withPhp80Sets() and above,
     // as we already use PHP 8.0 and should go with withPhpSets() instead
 
+    /**
+     * @param bool $instanceOf @deprecated Use $codeQuality instead, as most instanceof rules were moved there
+     * @param bool $if @deprecated Use $codeQuality and $codingStyle instead, as the if rules were moved there or deprecated
+     * @param bool $earlyReturn @deprecated Use $codeQuality instead, as all early return rules were moved there
+     */
     public function withPreparedSets(
         bool $deadCode = false,
         bool $codeQuality = false,
@@ -788,6 +793,7 @@ final class RectorConfigBuilder
 
     /**
      * @param class-string $cacheMetaExtensionClass
+     * @deprecated Niche mechanism, no longer applied. Let Rector handle cache on its own.
      */
     #[Deprecated(message: <<<'TXT'
     Niche mechanism, no longer applied. Let Rector handle cache on its own. If custom


### PR DESCRIPTION
Add `@deprecated` docblock annotations:

- `withPreparedSets()` - `@param` `@deprecated` for `$instanceOf`, `$if`, `$earlyReturn`, matching the 3 deprecated `SetList` consts (rules moved into code-quality/coding-style sets).
- `withCacheMetaExtension()` - `@deprecated` docblock tag to complement the existing `#[Deprecated]` attribute, so IDEs that read docblocks also flag it.
