### PR TITLE
[CodeQuality] Skip same local method call in InlineIfToExplicitIfRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Expression/InlineIfToExplicitIfRector/Fixture/skip_same_local_method_call.php.inc
+++ b/rules-tests/CodeQuality/Rector/Expression/InlineIfToExplicitIfRector/Fixture/skip_same_local_method_call.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Expression\InlineIfToExplicitIfRector\Fixture;
+
+class SkipSameLocalMethodCall
+{
+    public function run($asset)
+    {
+        $this->validateMimeType($asset->getRemoteMimeTypeFromHeader())
+            && $this->validateMimeType($asset->getRemoteMimeTypeFromMagicBytes());
+    }
+
+    private function validateMimeType($mimeType): bool
+    {
+        return $mimeType !== null;
+    }
+}

--- a/rules/CodeQuality/Rector/Expression/InlineIfToExplicitIfRector.php
+++ b/rules/CodeQuality/Rector/Expression/InlineIfToExplicitIfRector.php
@@ -10,6 +10,8 @@ use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
 use PhpParser\Node\Expr\BinaryOp\BooleanOr;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
 use Rector\NodeManipulator\BinaryOpManipulator;
@@ -97,6 +99,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->isSameLocalMethodCall($booleanExpr->left, $booleanExpr->right)) {
+            return null;
+        }
+
         $leftStaticType = $this->getType($booleanExpr->left);
         if (! $leftStaticType->isBoolean()->yes()) {
             return null;
@@ -111,5 +117,26 @@ CODE_SAMPLE
 
         $this->mirrorComments($if, $expression);
         return $if;
+    }
+
+    private function isSameLocalMethodCall(Expr $left, Expr $right): bool
+    {
+        if (! $left instanceof MethodCall) {
+            return false;
+        }
+
+        if (! $right instanceof MethodCall) {
+            return false;
+        }
+
+        if (! $left->var instanceof Variable || ! $this->isName($left->var, 'this')) {
+            return false;
+        }
+
+        if (! $right->var instanceof Variable || ! $this->isName($right->var, 'this')) {
+            return false;
+        }
+
+        return $this->nodeNameResolver->areNamesEqual($left->name, $right->name);
     }
 }


### PR DESCRIPTION
Skip conversion when both sides of the boolean expression are `$this->foo(...)` method calls of the same name.

```php
$this->validateMimeType($asset->getRemoteMimeTypeFromHeader())
    && $this->validateMimeType($asset->getRemoteMimeTypeFromMagicBytes());
```

Such combined validation reads better as a single expression than split into an explicit `if`.