### PR TITLE
Support PHPStan 2.2.10 scope changes

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.2.6"
+        "phpstan/phpstan": "^2.2.10"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "nikic/php-parser": "^5.8",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3.3",
-        "phpstan/phpstan": "^2.2.6",
+        "phpstan/phpstan": "^2.2.10",
         "react/child-process": "^0.6.5",
         "react/event-loop": "^1.6",
         "react/socket": "^1.17",

--- a/rules/DeadCode/NodeAnalyzer/CallCollectionAnalyzer.php
+++ b/rules/DeadCode/NodeAnalyzer/CallCollectionAnalyzer.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
+use PHPStan\Type\TypeCombinator;
 use Rector\Enum\ObjectReference;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
@@ -33,6 +34,11 @@ final readonly class CallCollectionAnalyzer
         foreach ($calls as $call) {
             $callerRoot = $call instanceof StaticCall ? $call->class : $call->var;
             $callerType = $this->nodeTypeResolver->getType($callerRoot);
+
+            // a nullsafe call caller is nullable by design; drop null to resolve the object class
+            if ($call instanceof NullsafeMethodCall) {
+                $callerType = TypeCombinator::removeNull($callerType);
+            }
 
             $callerTypeClassName = ClassNameFromObjectTypeResolver::resolve($callerType);
             if ($callerTypeClassName === null) {

--- a/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
+++ b/rules/Php81/NodeManipulator/NullToStrictStringIntConverter.php
@@ -17,7 +17,6 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Scalar\InterpolatedString;
 use PhpParser\Node\Scalar\String_;
-use PHPStan\Analyser\Fiber\FiberScope;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\Native\ExtendedNativeParameterReflection;
 use PHPStan\Reflection\ParametersAcceptor;
@@ -247,10 +246,6 @@ final readonly class NullToStrictStringIntConverter
         }
 
         $parentScope = $scope->getParentScope();
-        if ($parentScope instanceof FiberScope) {
-            $parentScope = $parentScope->toMutatingScope();
-        }
-
         if ($parentScope instanceof Scope) {
             return $parentScope->getType($expr) instanceof ErrorType;
         }

--- a/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
+++ b/src/NodeTypeResolver/PHPStan/Scope/PHPStanNodeScopeResolver.php
@@ -84,8 +84,8 @@ use PhpParser\Node\Stmt\Unset_;
 use PhpParser\Node\Stmt\While_;
 use PhpParser\Node\UnionType;
 use PhpParser\NodeTraverser;
-use PHPStan\Analyser\Fiber\FiberScope;
 use PHPStan\Analyser\MutatingScope;
+use PHPStan\Analyser\NodeCallbackScope;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Analyser\UndefinedVariableException;
@@ -157,8 +157,8 @@ final readonly class PHPStanNodeScopeResolver
             &$nodeCallback,
             $filePath,
         ): void {
-            if ($mutatingScope instanceof FiberScope) {
-                $mutatingScope = $mutatingScope->toMutatingScope();
+            if ($mutatingScope instanceof NodeCallbackScope) {
+                $mutatingScope = $mutatingScope->toWalkScope();
             }
 
             // the class reflection is resolved AFTER entering to class node
@@ -226,7 +226,6 @@ final readonly class PHPStanNodeScopeResolver
                 $node instanceof Eval_ ||
                 $node instanceof Print_ ||
                 $node instanceof Exit_ ||
-                $node instanceof ArrowFunction ||
                 $node instanceof Include_ ||
                 $node instanceof Instanceof_
             ) && $node->expr instanceof Expr) {
@@ -637,8 +636,13 @@ final readonly class PHPStanNodeScopeResolver
 
     private function processBinaryOp(BinaryOp $binaryOp, MutatingScope $mutatingScope): void
     {
-        $binaryOp->left->setAttribute(AttributeKey::SCOPE, $mutatingScope);
-        $binaryOp->right->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+        if (! $binaryOp->left->getAttribute(AttributeKey::SCOPE) instanceof MutatingScope) {
+            $binaryOp->left->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+        }
+
+        if (! $binaryOp->right->getAttribute(AttributeKey::SCOPE) instanceof MutatingScope) {
+            $binaryOp->right->setAttribute(AttributeKey::SCOPE, $mutatingScope);
+        }
     }
 
     private function processTernary(Ternary $ternary, MutatingScope $mutatingScope): void


### PR DESCRIPTION
PHPStan 2.2.10 emits node callbacks after a node's results are stored and replaces `FiberScope` with `NodeCallbackScope`. This flipped the parent/child callback ordering, so Rector's manual scope seeding on child expressions overwrote the correct, narrowed scope PHPStan had already attached. That broke type/scope resolution inside arrow functions, `&&`/`||` operands, and nullsafe calls.

### Changes

- **PHPStanNodeScopeResolver**
  - Unwrap the new `NodeCallbackScope` via `toWalkScope()`.
  - Stop clobbering the arrow-function body scope, so `fn($v) => $v['x']` infers from the outer array shape again.
  - Only seed a `BinaryOp` operand scope when PHPStan has not already set one, preserving `is_array()`/truthy narrowing on the right operand of `&&` and `||`.
- **CallCollectionAnalyzer** - strip `null` before resolving the object class of a nullsafe call caller; 2.2.10 no longer reports object class names for a nullable union, which made `RemoveUnusedPrivateMethodRector` drop methods called via `?->`.
- **NullToStrictStringIntConverter** - drop the handling for the removed `FiberScope`.
- Bump required `phpstan/phpstan` to `^2.2.10`.

### Fixed failing fixtures

- `SimplifyEmptyCheckOnEmptyArrayRector` - `replace_is_array_check`
- `RemoveUnusedPrivateMethodRector` - `keep_nullsafe_called_method`
- `RenameParamToMatchTypeRector` - `used_in_arrow_function_param`
- `AddArrowFunctionReturnTypeRector` - `return_by_array_shape_type`

Full test suite, ECS, PHPStan level 8, and `composer rector` all pass locally.