### PR TITLE
Add fixtures for arrow functions returning a ?? expression

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/coalesce_non_nullable_param.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/coalesce_non_nullable_param.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector\Fixture;
+
+class CoalesceNonNullableParam
+{
+    public function run()
+    {
+        fn (int $value) => $value ?? null;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector\Fixture;
+
+class CoalesceNonNullableParam
+{
+    public function run()
+    {
+        fn (int $value): int => $value ?? null;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/coalesce_nullable_param.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/coalesce_nullable_param.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector\Fixture;
+
+class CoalesceNullableParam
+{
+    public function run()
+    {
+        fn (?string $value) => $value ?? null;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector\Fixture;
+
+class CoalesceNullableParam
+{
+    public function run()
+    {
+        fn (?string $value): ?string => $value ?? null;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/skip_coalesce_mixed.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ArrowFunction/AddArrowFunctionReturnTypeRector/Fixture/skip_coalesce_mixed.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector\Fixture;
+
+class SkipCoalesceMixed
+{
+    public function run()
+    {
+        fn (array $attributes) => $attributes['duration'] ?? null;
+    }
+}


### PR DESCRIPTION
`AddArrowFunctionReturnTypeRector` has no fixture where the arrow function body is a `??` expression. On 2.6.4 that case got the type wrong:

```php
fn (int $value) => $value ?? null;
// became
fn (int $value): null => $value ?? null;
```

Calling that throws a TypeError. Main gets all three cases below right already, so there is no source change here, just the fixtures to keep it that way:

- nullable param, `?string`
- non-nullable param, `int`
- `mixed` from an untyped array, no type added

On 2.6.4 each one came out as `: null`.
