### PR TITLE
[TypeDeclaration] Skip noisy array-shape union return docblock in ReturnTypeFromStrictNewArrayRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector/Fixture/union_array_shapes_no_doc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector/Fixture/union_array_shapes_no_doc.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector\Fixture;
+
+final class UnionArrayShapesNoDoc
+{
+    public function getRowFormatBookEntry($abe, $onlyCashRegister = false)
+    {
+        $data = [];
+        foreach ($abe as $x) {
+            if ($onlyCashRegister) {
+                $data[] = ['amount' => 1, 'cash_register_id' => 2, 'text' => 't'];
+            } else {
+                $data[] = ['amount' => 1, 'date' => 'd', 'text' => 't'];
+            }
+        }
+
+        return $data;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector\Fixture;
+
+final class UnionArrayShapesNoDoc
+{
+    public function getRowFormatBookEntry($abe, $onlyCashRegister = false): array
+    {
+        $data = [];
+        foreach ($abe as $x) {
+            if ($onlyCashRegister) {
+                $data[] = ['amount' => 1, 'cash_register_id' => 2, 'text' => 't'];
+            } else {
+                $data[] = ['amount' => 1, 'date' => 'd', 'text' => 't'];
+            }
+        }
+
+        return $data;
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/NodeAnalyzer/StrictReturnNewArrayResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/StrictReturnNewArrayResolver.php
@@ -20,6 +20,8 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeTraverser;
+use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -202,6 +204,11 @@ final readonly class StrictReturnNewArrayResolver
 
     private function shouldAddReturnArrayDocType(Type $arrayType): bool
     {
+        // a union of multiple distinct array shapes produces a noisy doc type, skip it
+        if ($this->hasNoisyArrayShapeUnion($arrayType)) {
+            return false;
+        }
+
         if ($arrayType instanceof ConstantArrayType) {
             if ($arrayType->getIterableValueType() instanceof NeverType) {
                 return false;
@@ -214,5 +221,38 @@ final readonly class StrictReturnNewArrayResolver
         }
 
         return true;
+    }
+
+    private function hasNoisyArrayShapeUnion(Type $type): bool
+    {
+        $isNoisy = false;
+        TypeTraverser::map($type, function (Type $currentType, callable $traverse) use (&$isNoisy): Type {
+            if ($currentType instanceof UnionType && $this->hasMultipleArrayVariants($currentType)) {
+                $isNoisy = true;
+            }
+
+            return $traverse($currentType);
+        });
+
+        return $isNoisy;
+    }
+
+    private function hasMultipleArrayVariants(UnionType $unionType): bool
+    {
+        $arrayVariantCount = 0;
+        foreach ($unionType->getTypes() as $type) {
+            if (! $type->isArray()->yes()) {
+                continue;
+            }
+
+            // an empty array [] collapses into the sibling variant, ignore it
+            if ($type->getIterableValueType() instanceof NeverType) {
+                continue;
+            }
+
+            ++$arrayVariantCount;
+        }
+
+        return $arrayVariantCount >= 2;
     }
 }


### PR DESCRIPTION
When a method has multiple returns that produce a union of distinct array shapes, `ReturnTypeFromStrictNewArrayRector` added an unreadable `@return` docblock, e.g.:

```php
/**
 * @return array{amount: 1, cash_register_id: 2, text: 't'}[]|array{amount: 1, date: 'd', text: 't'}[]
 */
public function getRowFormatBookEntry($abe, $onlyCashRegister = false): array
```

Such a union of array shapes is noise and adds nothing over the native `: array` type.

This adds a complexity guard: when the resolved type contains (at any nesting) a union of 2+ distinct non-empty array variants, only the native `: array` type is added and the docblock is skipped. Simple cases (`list<int>`, `mixed[]`, `non-empty-array<array{c: mixed}>[]`) are unaffected, and the `mixed[]` fallback (empty `[]` collapsing into a sibling variant) is preserved.