### PR TITLE
[TypeDeclaration] Add doc return type only for list and generic arrays in ReturnTypeFromStrictNewArrayRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector/Fixture/deep_nested_array.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector/Fixture/deep_nested_array.php.inc
@@ -32,9 +32,6 @@ namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNe
 
 final class DeepNestedArray
 {
-    /**
-     * @return non-empty-array<array{c: mixed}>[]
-     */
     public function test(): array {
         $arr = [];
         $rows = $this->getRows();

--- a/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector/Fixture/union_reservation_array_shapes_no_doc.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/ClassMethod/ReturnTypeFromStrictNewArrayRector/Fixture/union_reservation_array_shapes_no_doc.php.inc
@@ -1,0 +1,73 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector\Fixture;
+
+final class UnionReservationArrayShapesNoDoc
+{
+    public function getReservations($items, $withInvoice = false)
+    {
+        $data = [];
+        foreach ($items as $item) {
+            if ($withInvoice) {
+                $data[] = [
+                    'currency' => 'EUR',
+                    'creation_date' => 'd',
+                    'guarantee' => 1,
+                    'invoice_recipient_id' => 5,
+                    'invoice_free_text' => 't',
+                    'status' => 'ok',
+                    'type' => 'a',
+                ];
+            } else {
+                $data[] = [
+                    'currency' => 'EUR',
+                    'creation_date' => 'd',
+                    'guarantee' => 1,
+                    'status' => 'ok',
+                    'type' => 'a',
+                ];
+            }
+        }
+
+        return $data;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector\Fixture;
+
+final class UnionReservationArrayShapesNoDoc
+{
+    public function getReservations($items, $withInvoice = false): array
+    {
+        $data = [];
+        foreach ($items as $item) {
+            if ($withInvoice) {
+                $data[] = [
+                    'currency' => 'EUR',
+                    'creation_date' => 'd',
+                    'guarantee' => 1,
+                    'invoice_recipient_id' => 5,
+                    'invoice_free_text' => 't',
+                    'status' => 'ok',
+                    'type' => 'a',
+                ];
+            } else {
+                $data[] = [
+                    'currency' => 'EUR',
+                    'creation_date' => 'd',
+                    'guarantee' => 1,
+                    'status' => 'ok',
+                    'type' => 'a',
+                ];
+            }
+        }
+
+        return $data;
+    }
+}
+
+?>

--- a/rules/TypeDeclaration/NodeAnalyzer/StrictReturnNewArrayResolver.php
+++ b/rules/TypeDeclaration/NodeAnalyzer/StrictReturnNewArrayResolver.php
@@ -17,11 +17,9 @@ use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeTraverser;
-use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -204,55 +202,22 @@ final readonly class StrictReturnNewArrayResolver
 
     private function shouldAddReturnArrayDocType(Type $arrayType): bool
     {
-        // a union of multiple distinct array shapes produces a noisy doc type, skip it
-        if ($this->hasNoisyArrayShapeUnion($arrayType)) {
-            return false;
-        }
-
-        if ($arrayType instanceof ConstantArrayType) {
-            if ($arrayType->getIterableValueType() instanceof NeverType) {
-                return false;
-            }
-
-            // handle only simple arrays
-            if (! $arrayType->getIterableKeyType()->isInteger()->yes()) {
-                return false;
-            }
-        }
-
-        return true;
+        // only plain list<> and generic array<> doc types are worth adding;
+        // array shapes produce noisy, fragile doc types, skip them
+        return ! $this->hasArrayShape($arrayType);
     }
 
-    private function hasNoisyArrayShapeUnion(Type $type): bool
+    private function hasArrayShape(Type $type): bool
     {
-        $isNoisy = false;
-        TypeTraverser::map($type, function (Type $currentType, callable $traverse) use (&$isNoisy): Type {
-            if ($currentType instanceof UnionType && $this->hasMultipleArrayVariants($currentType)) {
-                $isNoisy = true;
+        $hasArrayShape = false;
+        TypeTraverser::map($type, function (Type $currentType, callable $traverse) use (&$hasArrayShape): Type {
+            if ($currentType instanceof ConstantArrayType && $currentType->getKeyTypes() !== [] && ! $currentType->isList()->yes()) {
+                $hasArrayShape = true;
             }
 
             return $traverse($currentType);
         });
 
-        return $isNoisy;
-    }
-
-    private function hasMultipleArrayVariants(UnionType $unionType): bool
-    {
-        $arrayVariantCount = 0;
-        foreach ($unionType->getTypes() as $type) {
-            if (! $type->isArray()->yes()) {
-                continue;
-            }
-
-            // an empty array [] collapses into the sibling variant, ignore it
-            if ($type->getIterableValueType() instanceof NeverType) {
-                continue;
-            }
-
-            ++$arrayVariantCount;
-        }
-
-        return $arrayVariantCount >= 2;
+        return $hasArrayShape;
     }
 }


### PR DESCRIPTION
Follow-up to #8422.

The rule now adds a doc return type **only** for plain `list<...>` and generic `array<...>`/`mixed[]` types. Any array **shape** (`array{...}`) — single, nested, or a union of several — is skipped: it always keeps the `: array` native return type but drops the noisy, fragile shape docblock.

Replaces the previous union-only skip with a single `hasArrayShape()` check that walks the type tree via `TypeTraverser`. Adds a reservation-style union fixture; updates `deep_nested_array` (nested shape) to no longer emit a shape docblock.