### PR TITLE
[dx] Set Option::SOURCE parameter from the resolved paths

### DIFF
--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -168,15 +168,19 @@ final readonly class ConfigurationFactory
         if ($commandLinePaths !== []) {
             // mark the run as narrowed, so unused skip reporting can be disabled to avoid false positives
             SimpleParameterProvider::setParameter(Option::IS_RUN_NARROWED, true);
-            $this->setFilesWithoutExtensionParameter($commandLinePaths);
-            return $commandLinePaths;
+            $paths = $commandLinePaths;
+        } else {
+            // fallback to parameter
+            $paths = SimpleParameterProvider::provideArrayParameter(Option::PATHS);
         }
 
-        // fallback to parameter
-        $configPaths = SimpleParameterProvider::provideArrayParameter(Option::PATHS);
-        $this->setFilesWithoutExtensionParameter($configPaths);
+        $this->setFilesWithoutExtensionParameter($paths);
 
-        return $configPaths;
+        // extensions read the processed paths from here; without this only the test harness
+        // sets it, so the parameter is empty in a real run
+        SimpleParameterProvider::setParameter(Option::SOURCE, $paths);
+
+        return $paths;
     }
 
     /**

--- a/src/Configuration/Parameter/SimpleParameterProvider.php
+++ b/src/Configuration/Parameter/SimpleParameterProvider.php
@@ -21,6 +21,7 @@ final class SimpleParameterProvider
      * @var array<Option::*>
      */
     private const array CACHE_IGNORED_PARAMETER_NAMES = [
+        Option::SOURCE,
         Option::PARALLEL,
         Option::PARALLEL_JOB_SIZE,
         Option::PARALLEL_MAX_NUMBER_OF_PROCESSES,

--- a/tests/Configuration/ConfigurationFactoryTest.php
+++ b/tests/Configuration/ConfigurationFactoryTest.php
@@ -50,64 +50,40 @@ final class ConfigurationFactoryTest extends AbstractLazyTestCase
 
     public function testPublishesCommandLinePathsAsSourceParameter(): void
     {
-        $originalPaths = SimpleParameterProvider::provideArrayParameter(Option::PATHS);
-        $originalSource = SimpleParameterProvider::provideArrayParameter(Option::SOURCE);
-        $originalIsRunNarrowed = SimpleParameterProvider::provideBoolParameter(Option::IS_RUN_NARROWED, false);
+        SimpleParameterProvider::setParameter(Option::PATHS, [__DIR__ . '/config']);
 
-        try {
-            SimpleParameterProvider::setParameter(Option::PATHS, [__DIR__ . '/config']);
+        $this->make(ConfigurationFactory::class)
+            ->createFromInput($this->createInput([__DIR__ . '/Source']));
 
-            $this->make(ConfigurationFactory::class)
-                ->createFromInput($this->createInput([__DIR__ . '/Source']));
-
-            $this->assertSame(
-                [__DIR__ . '/Source'],
-                SimpleParameterProvider::provideArrayParameter(Option::SOURCE)
-            );
-        } finally {
-            SimpleParameterProvider::setParameter(Option::PATHS, $originalPaths);
-            SimpleParameterProvider::setParameter(Option::SOURCE, $originalSource);
-            SimpleParameterProvider::setParameter(Option::IS_RUN_NARROWED, $originalIsRunNarrowed);
-        }
+        $this->assertSame(
+            [__DIR__ . '/Source'],
+            SimpleParameterProvider::provideArrayParameter(Option::SOURCE)
+        );
     }
 
     public function testPublishesConfiguredPathsAsSourceParameterWhenNoneGivenOnTheCommandLine(): void
     {
-        $originalPaths = SimpleParameterProvider::provideArrayParameter(Option::PATHS);
-        $originalSource = SimpleParameterProvider::provideArrayParameter(Option::SOURCE);
+        SimpleParameterProvider::setParameter(Option::PATHS, [__DIR__ . '/config']);
 
-        try {
-            SimpleParameterProvider::setParameter(Option::PATHS, [__DIR__ . '/config']);
+        $this->make(ConfigurationFactory::class)
+            ->createFromInput($this->createInput([]));
 
-            $this->make(ConfigurationFactory::class)
-                ->createFromInput($this->createInput([]));
-
-            $this->assertSame(
-                [__DIR__ . '/config'],
-                SimpleParameterProvider::provideArrayParameter(Option::SOURCE)
-            );
-        } finally {
-            SimpleParameterProvider::setParameter(Option::PATHS, $originalPaths);
-            SimpleParameterProvider::setParameter(Option::SOURCE, $originalSource);
-        }
+        $this->assertSame(
+            [__DIR__ . '/config'],
+            SimpleParameterProvider::provideArrayParameter(Option::SOURCE)
+        );
     }
 
     public function testSourceParameterIsOutsideTheCacheInvalidationHash(): void
     {
         // The processed paths change per invocation. Were they hashed, running Rector on a
         // single file and then on the whole project would drop the cache each time.
-        $originalSource = SimpleParameterProvider::provideArrayParameter(Option::SOURCE);
+        SimpleParameterProvider::setParameter(Option::SOURCE, ['src']);
+        $hashForOnePath = SimpleParameterProvider::hashForCacheInvalidation();
 
-        try {
-            SimpleParameterProvider::setParameter(Option::SOURCE, ['src']);
-            $hashForOnePath = SimpleParameterProvider::hashForCacheInvalidation();
+        SimpleParameterProvider::setParameter(Option::SOURCE, ['tests', 'src/Some/Other.php']);
 
-            SimpleParameterProvider::setParameter(Option::SOURCE, ['tests', 'src/Some/Other.php']);
-
-            $this->assertSame($hashForOnePath, SimpleParameterProvider::hashForCacheInvalidation());
-        } finally {
-            SimpleParameterProvider::setParameter(Option::SOURCE, $originalSource);
-        }
+        $this->assertSame($hashForOnePath, SimpleParameterProvider::hashForCacheInvalidation());
     }
 
     /**

--- a/tests/Configuration/ConfigurationFactoryTest.php
+++ b/tests/Configuration/ConfigurationFactoryTest.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace Rector\Tests\Configuration;
 
 use Rector\Configuration\ConfigurationFactory;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Console\ProcessConfigureDecorator;
 use Rector\FileSystem\FilesFinder;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 
 final class ConfigurationFactoryTest extends AbstractLazyTestCase
 {
@@ -41,5 +46,80 @@ final class ConfigurationFactoryTest extends AbstractLazyTestCase
             realpath(__DIR__ . '/../../tests-paths/path/NoExtensionFile'),
             realpath($thirdFilePath),
         );
+    }
+
+    public function testPublishesCommandLinePathsAsSourceParameter(): void
+    {
+        $originalPaths = SimpleParameterProvider::provideArrayParameter(Option::PATHS);
+        $originalSource = SimpleParameterProvider::provideArrayParameter(Option::SOURCE);
+        $originalIsRunNarrowed = SimpleParameterProvider::provideBoolParameter(Option::IS_RUN_NARROWED, false);
+
+        try {
+            SimpleParameterProvider::setParameter(Option::PATHS, [__DIR__ . '/config']);
+
+            $this->make(ConfigurationFactory::class)
+                ->createFromInput($this->createInput([__DIR__ . '/Source']));
+
+            $this->assertSame(
+                [__DIR__ . '/Source'],
+                SimpleParameterProvider::provideArrayParameter(Option::SOURCE)
+            );
+        } finally {
+            SimpleParameterProvider::setParameter(Option::PATHS, $originalPaths);
+            SimpleParameterProvider::setParameter(Option::SOURCE, $originalSource);
+            SimpleParameterProvider::setParameter(Option::IS_RUN_NARROWED, $originalIsRunNarrowed);
+        }
+    }
+
+    public function testPublishesConfiguredPathsAsSourceParameterWhenNoneGivenOnTheCommandLine(): void
+    {
+        $originalPaths = SimpleParameterProvider::provideArrayParameter(Option::PATHS);
+        $originalSource = SimpleParameterProvider::provideArrayParameter(Option::SOURCE);
+
+        try {
+            SimpleParameterProvider::setParameter(Option::PATHS, [__DIR__ . '/config']);
+
+            $this->make(ConfigurationFactory::class)
+                ->createFromInput($this->createInput([]));
+
+            $this->assertSame(
+                [__DIR__ . '/config'],
+                SimpleParameterProvider::provideArrayParameter(Option::SOURCE)
+            );
+        } finally {
+            SimpleParameterProvider::setParameter(Option::PATHS, $originalPaths);
+            SimpleParameterProvider::setParameter(Option::SOURCE, $originalSource);
+        }
+    }
+
+    public function testSourceParameterIsOutsideTheCacheInvalidationHash(): void
+    {
+        // The processed paths change per invocation. Were they hashed, running Rector on a
+        // single file and then on the whole project would drop the cache each time.
+        $originalSource = SimpleParameterProvider::provideArrayParameter(Option::SOURCE);
+
+        try {
+            SimpleParameterProvider::setParameter(Option::SOURCE, ['src']);
+            $hashForOnePath = SimpleParameterProvider::hashForCacheInvalidation();
+
+            SimpleParameterProvider::setParameter(Option::SOURCE, ['tests', 'src/Some/Other.php']);
+
+            $this->assertSame($hashForOnePath, SimpleParameterProvider::hashForCacheInvalidation());
+        } finally {
+            SimpleParameterProvider::setParameter(Option::SOURCE, $originalSource);
+        }
+    }
+
+    /**
+     * @param string[] $paths
+     */
+    private function createInput(array $paths): ArrayInput
+    {
+        $command = new Command('process');
+        ProcessConfigureDecorator::decorate($command);
+
+        return new ArrayInput([
+            Option::SOURCE => $paths,
+        ], $command->getDefinition());
     }
 }


### PR DESCRIPTION
`Option::SOURCE` is only written to `SimpleParameterProvider` by `AbstractRectorTestCase`. A real run leaves it empty, so an extension reading the processed paths from the parameter works under the test harness and gets `[]` in production.

I hit this in a rules package that reads `Option::PATHS` and falls back to `Option::SOURCE` to learn which paths a run covers. The fallback works in its tests and never fires in a real run.

`ConfigurationFactory::resolvePaths()` now sets it to the paths it resolved: the command line when given, `Option::PATHS` otherwise. It already sets `IS_RUN_NARROWED` and `FILES_WITHOUT_EXTENSION` there.

`Option::SOURCE` is also in `CACHE_IGNORED_PARAMETER_NAMES`: the resolved paths change per invocation, so hashing them would drop the cache whenever the target changes.
