### PR TITLE
[Php85] Skip nested compound assignment in ArrayFirstLastRector

### DIFF
--- a/rules-tests/Php85/Rector/ArrayDimFetch/ArrayFirstLastRector/Fixture/skip_as_nested_assign.php.inc
+++ b/rules-tests/Php85/Rector/ArrayDimFetch/ArrayFirstLastRector/Fixture/skip_as_nested_assign.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\ArrayDimFetch\ArrayFirstLastRector\Fixture;
+
+final class SkipAsNestedAssign
+{
+    public function run(array $result, $lastInsertedId)
+    {
+        $result[\array_key_last($result)]['id'] = $lastInsertedId;
+    }
+}

--- a/rules-tests/Php85/Rector/ArrayDimFetch/ArrayFirstLastRector/Fixture/skip_as_nested_assign_op.php.inc
+++ b/rules-tests/Php85/Rector/ArrayDimFetch/ArrayFirstLastRector/Fixture/skip_as_nested_assign_op.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Php85\Rector\ArrayDimFetch\ArrayFirstLastRector\Fixture;
+
+final class SkipAsNestedAssignOp
+{
+    public function run(array $result, $lastInsertedId)
+    {
+        $result[\array_key_last($result)][0] += $lastInsertedId;
+    }
+}

--- a/src/PhpParser/NodeVisitor/AssignedToNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/AssignedToNodeVisitor.php
@@ -6,6 +6,8 @@ namespace Rector\PhpParser\NodeVisitor;
 
 use PhpParser\Node;
 use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignOp;
 use PhpParser\Node\Expr\AssignRef;
@@ -22,7 +24,7 @@ final class AssignedToNodeVisitor extends NodeVisitorAbstract implements Decorat
     public function enterNode(Node $node): ?Node
     {
         if ($node instanceof AssignOp) {
-            $node->var->setAttribute(AttributeKey::IS_ASSIGN_OP_VAR, true);
+            $this->markAssignOpVar($node->var);
             return null;
         }
 
@@ -53,5 +55,20 @@ final class AssignedToNodeVisitor extends NodeVisitorAbstract implements Decorat
         }
 
         return null;
+    }
+
+    /**
+     * Marks the whole dim fetch chain, not just the outermost node: $array[$key][0] += 1 writes
+     * to $array[$key] as well, so a rule that rewrites the inner fetch would change a write
+     * into a read of a temporary value.
+     */
+    private function markAssignOpVar(Expr $expr): void
+    {
+        $expr->setAttribute(AttributeKey::IS_ASSIGN_OP_VAR, true);
+
+        while ($expr instanceof ArrayDimFetch) {
+            $expr = $expr->var;
+            $expr->setAttribute(AttributeKey::IS_ASSIGN_OP_VAR, true);
+        }
     }
 }


### PR DESCRIPTION
## Description

`ArrayFirstLastRector` rewrites `$array[array_key_last($array)][0] += 1` to `array_last($array)[0] += 1`. `array_last()` returns a value rather than a reference, so the compound assignment writes into a temporary and is discarded, silently:

```php
$a = [[0, 0, 0]];
array_last($a)[2] += 5;          // $a[0][2] stays 0
$a[array_key_last($a)][2] += 5;  // $a[0][2] becomes 5
```

`shouldSkip()` checks `IS_ASSIGN_OP_VAR`, but `AssignedToNodeVisitor` sets that attribute only on the outermost node of the assignment target. For `$array[$key][0] += 1` that is the outer dim fetch, while the rule matches the inner one, so the guard does not apply. The plain assignment form was already skipped through PHPStan's `Scope::isInExpressionAssign()`, which is why the existing `skip_as_assign_op` fixture did not catch this.

## Fix

`AssignedToNodeVisitor` now marks the whole dim fetch chain, which reflects what the assignment does: `$array[$key][0] += 1` writes to `$array[$key]` as well. `ArrayDimFetchToMethodCallRector` reads the same attribute and benefits too.

Fixtures for both the compound and the plain nested form are added.