### PR TITLE
[Caching] Use atomic rename() on non-Windows in FileCacheStorage to avoid partially written cache reads on parallel run

### DIFF
--- a/src/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/src/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -73,23 +73,32 @@ final readonly class FileCacheStorage implements CacheStorageInterface
 
         /**
          * @see https://github.com/rectorphp/rector/issues/9876
-         * @see https://github.com/rectorphp/rector/issues/8432
-         * @see https://github.com/php/php-src/issues/7910
          *
-         * Cover compatibility for Windows and Unix systems
+         * Try the atomic write first, as rename() also works on unaffected Windows PHP versions
          */
-        $writeSuccess = \DIRECTORY_SEPARATOR === '/'
-            ? @\rename($tmpPath, $filePath)
-            : @\copy($tmpPath, $filePath);
-        @\unlink($tmpPath);
-
-        if ($writeSuccess) {
+        $renameSuccess = @\rename($tmpPath, $filePath);
+        if ($renameSuccess) {
             return;
         }
 
-        if (\DIRECTORY_SEPARATOR === '/' || ! \file_exists($filePath)) {
+        if (\DIRECTORY_SEPARATOR === '/') {
             throw new CachingException(\sprintf('Could not write data to cache file %s.', $filePath));
         }
+
+        /**
+         * @see https://github.com/rectorphp/rector/issues/8432
+         * @see https://github.com/php/php-src/issues/7910
+         *
+         * Fall back only on affected Windows PHP versions where rename() failed
+         */
+        $copySuccess = @\copy($tmpPath, $filePath);
+        @\unlink($tmpPath);
+
+        if ($copySuccess) {
+            return;
+        }
+
+        throw new CachingException(\sprintf('Could not write data to cache file %s.', $filePath));
     }
 
     public function clean(string $key): void

--- a/src/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/src/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -81,7 +81,7 @@ final readonly class FileCacheStorage implements CacheStorageInterface
             return;
         }
 
-        if (\DIRECTORY_SEPARATOR === '/') {
+        if (\DIRECTORY_SEPARATOR === '/' || ! \file_exists($filePath)) {
             throw new CachingException(\sprintf('Could not write data to cache file %s.', $filePath));
         }
 

--- a/src/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/src/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -70,10 +70,21 @@ final readonly class FileCacheStorage implements CacheStorageInterface
 
         // for performance reasons we don't use SmartFileSystem
         FileSystem::write($tmpPath, \sprintf("<?php declare(strict_types = 1);\n\nreturn %s;", $exported), null);
-        $copySuccess = @\copy($tmpPath, $filePath);
+
+        /**
+         * @see https://github.com/rectorphp/rector/issues/9876
+         * @see https://github.com/rectorphp/rector/issues/8432
+         *
+         * Cover compatibility for Windows and Unix systems
+         */
+        $writeSuccess = \DIRECTORY_SEPARATOR === '/'
+            ? @\rename($tmpPath, $filePath)
+            : @\copy($tmpPath, $filePath);
+
+        // already moved by rename() on success, then unlink() is no-op on it
         @\unlink($tmpPath);
 
-        if ($copySuccess) {
+        if ($writeSuccess) {
             return;
         }
 

--- a/src/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/src/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -74,14 +74,13 @@ final readonly class FileCacheStorage implements CacheStorageInterface
         /**
          * @see https://github.com/rectorphp/rector/issues/9876
          * @see https://github.com/rectorphp/rector/issues/8432
+         * @see https://github.com/php/php-src/issues/7910
          *
          * Cover compatibility for Windows and Unix systems
          */
         $writeSuccess = \DIRECTORY_SEPARATOR === '/'
             ? @\rename($tmpPath, $filePath)
             : @\copy($tmpPath, $filePath);
-
-        // already moved by rename() on success, then unlink() is no-op on it
         @\unlink($tmpPath);
 
         if ($writeSuccess) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9876