### PR TITLE
[Naming] Fix partial rename in RenameVariableToMatchMethodCallReturnTypeRector with same-named nested arrow param

### DIFF
--- a/rules-tests/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector/Fixture/rename_usage_with_same_named_arrow_param.php.inc
+++ b/rules-tests/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector/Fixture/rename_usage_with_same_named_arrow_param.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector\Source\SortableBuilder;
+
+final class RenameUsageWithSameNamedArrowParam
+{
+    public function index(): array
+    {
+        $query = SortableBuilder::for(self::class)
+            ->allowedSorts(fn (SortableBuilder $query): SortableBuilder => $query->defaultSort('x'))
+            ->defaultSort('part_type');
+
+        return $query->jsonPaginate();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector\Fixture;
+
+use Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector\Source\SortableBuilder;
+
+final class RenameUsageWithSameNamedArrowParam
+{
+    public function index(): array
+    {
+        $sortableBuilder = SortableBuilder::for(self::class)
+            ->allowedSorts(fn (SortableBuilder $query): SortableBuilder => $query->defaultSort('x'))
+            ->defaultSort('part_type');
+
+        return $sortableBuilder->jsonPaginate();
+    }
+}
+
+?>

--- a/rules-tests/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector/Source/SortableBuilder.php
+++ b/rules-tests/Naming/Rector/Assign/RenameVariableToMatchMethodCallReturnTypeRector/Source/SortableBuilder.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Naming\Rector\Assign\RenameVariableToMatchMethodCallReturnTypeRector\Source;
+
+final class SortableBuilder
+{
+    public static function for(string $class): self
+    {
+        return new self();
+    }
+
+    public function allowedSorts(callable $callback): self
+    {
+        return $this;
+    }
+
+    public function defaultSort(string $sort): self
+    {
+        return $this;
+    }
+
+    public function jsonPaginate(): array
+    {
+        return [];
+    }
+}

--- a/rules/Naming/VariableRenamer.php
+++ b/rules/Naming/VariableRenamer.php
@@ -116,6 +116,12 @@ final readonly class VariableRenamer
             return false;
         }
 
+        // the tracked function-like is only reset on enter, so it can linger past its own body;
+        // a variable located after it is no longer inside it and its params must be ignored
+        if ($variable->getStartTokenPos() > $functionLike->getEndTokenPos()) {
+            return false;
+        }
+
         $scope = $variable->getAttribute(AttributeKey::SCOPE);
         $functionLikeScope = $functionLike->getAttribute(AttributeKey::SCOPE);
 


### PR DESCRIPTION
Fixes rectorphp/rector#9872

## Problem

`RenameVariableToMatchMethodCallReturnTypeRector` renamed a variable at its assignment but left later usages untouched when a nested arrow function declared a parameter of the same name:

```php
$query = QueryBuilder::for(PartMapping::class)
    ->allowedSorts(fn (Builder $query, bool $descending): Builder => $query->orderBy('part_type'))
    ->defaultSort('part_type');

return $this->apiPaginatedResponse($query->jsonPaginate());
```

resulted in:

```php
$queryBuilder = QueryBuilder::for(PartMapping::class)
    ->allowedSorts(fn (Builder $query, bool $descending): Builder => $query->orderBy('part_type'))
    ->defaultSort('part_type');

// still $query, now undefined
return $this->apiPaginatedResponse($query->jsonPaginate());
```

## Cause

`VariableRenamer::renameVariableInFunctionLike()` tracks the innermost `$currentFunctionLike` while traversing, but that tracker is only updated on enter and never reset on leave (the traverser is enter-only). Once traversal left the arrow function, `$currentFunctionLike` still pointed at it, so `isParamInParentFunction()` matched the later `$query` usage against the arrow function param of the same name and skipped it.

## Fix

Ignore the tracked function-like when the variable sits after its body (token position), so params of an already-left arrow function no longer block the rename.