### PR TITLE
[BetterPhpDocParser] Keep import used only in an annotation array key

### DIFF
--- a/src/BetterPhpDocParser/NodeDecorator/ArrayItemClassNameDecorator.php
+++ b/src/BetterPhpDocParser/NodeDecorator/ArrayItemClassNameDecorator.php
@@ -39,20 +39,33 @@ final readonly class ArrayItemClassNameDecorator implements PhpDocNodeDecoratorI
                 return null;
             }
 
-            if (! is_string($node->value)) {
-                return null;
+            $valueClassName = $this->resolveClassFromScopeResolution($node->value, $phpNode);
+            if ($valueClassName !== null) {
+                $node->setAttribute(PhpDocAttributeKey::RESOLVED_CLASS, $valueClassName);
             }
 
-            $splitScopeResolution = explode('::', $node->value);
-            if (count($splitScopeResolution) !== 2) {
-                return null;
+            // e.g. @ORM\DiscriminatorMap({ SomeEnum::TOTP = "..." }), the class is in the key
+            $keyClassName = $this->resolveClassFromScopeResolution($node->key, $phpNode);
+            if ($keyClassName !== null) {
+                $node->setAttribute(PhpDocAttributeKey::RESOLVED_KEY_CLASS, $keyClassName);
             }
-
-            $className = $this->resolveFullyQualifiedClass($splitScopeResolution[0], $phpNode);
-            $node->setAttribute(PhpDocAttributeKey::RESOLVED_CLASS, $className);
 
             return $node;
         });
+    }
+
+    private function resolveClassFromScopeResolution(mixed $value, PhpNode $phpNode): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $splitScopeResolution = explode('::', $value);
+        if (count($splitScopeResolution) !== 2) {
+            return null;
+        }
+
+        return $this->resolveFullyQualifiedClass($splitScopeResolution[0], $phpNode);
     }
 
     private function resolveFullyQualifiedClass(string $className, PhpNode $phpNode): string

--- a/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
+++ b/src/BetterPhpDocParser/PhpDocInfo/PhpDocInfo.php
@@ -558,11 +558,15 @@ final class PhpDocInfo
             }
 
             $resolvedClass = $node->getAttribute(PhpDocAttributeKey::RESOLVED_CLASS);
-            if ($resolvedClass === null) {
-                return null;
+            if ($resolvedClass !== null) {
+                $classNames[] = $resolvedClass;
             }
 
-            $classNames[] = $resolvedClass;
+            $resolvedKeyClass = $node->getAttribute(PhpDocAttributeKey::RESOLVED_KEY_CLASS);
+            if ($resolvedKeyClass !== null) {
+                $classNames[] = $resolvedKeyClass;
+            }
+
             return $node;
         });
 

--- a/src/BetterPhpDocParser/ValueObject/PhpDocAttributeKey.php
+++ b/src/BetterPhpDocParser/ValueObject/PhpDocAttributeKey.php
@@ -15,6 +15,11 @@ final class PhpDocAttributeKey
      */
     public const string RESOLVED_CLASS = 'resolved_class';
 
+    /**
+     * Fully qualified name of class referenced in an array item key, e.g. SomeEnum::TOTP
+     */
+    public const string RESOLVED_KEY_CLASS = 'resolved_key_class';
+
     public const string PARENT = NativePhpDocAttributeKey::PARENT;
 
     public const string LAST_PHP_DOC_TOKEN_POSITION = 'last_token_position';

--- a/tests/Issues/NamespacedUseAutoImport/Fixture/skip_annotation_array_key_const.php.inc
+++ b/tests/Issues/NamespacedUseAutoImport/Fixture/skip_annotation_array_key_const.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Issues\NamespacedUseAutoImport\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Tests\Issues\NamespacedUseAutoImport\Source\SomeClass;
+
+/**
+ * @ORM\DiscriminatorMap({
+ *     SomeClass::TOTP = "totp",
+ *     SomeClass::EMAIL = "email"
+ * })
+ */
+class SkipAnnotationArrayKeyConst
+{
+}


### PR DESCRIPTION
Fixes wrong removal of a `use` import that is referenced only in the **key** side of a Doctrine annotation array, e.g. `@ORM\DiscriminatorMap({ SomeEnum::TOTP = ... })`.

Reported via demo: https://getrector.com/demo/a835e33e-668f-47f5-8cf8-604988f8b0de

## Problem

`ArrayItemClassNameDecorator` resolved the class name only from the array item **value** (`$node->value`). A class used solely in the **key** (`SomeEnum::TOTP`) got no `RESOLVED_CLASS`, so `getArrayItemNodeClassNames()` never reported it. With `removeUnusedImports()` on, `UnusedImportRemovingPostRector` then treated the import as unused and removed it.

Before:

```php
use Doctrine\ORM\Mapping as ORM;
use App\Enum\SomeEnum; // <- wrongly removed

/**
 * @ORM\DiscriminatorMap({
 *     SomeEnum::TOTP = "totp"
 * })
 */
class Foo {}
```

## Fix

- Resolve a class from the key side too, stored under a new `RESOLVED_KEY_CLASS` attribute.
- `getArrayItemNodeClassNames()` now collects both value and key resolved classes.

Covered by a skip fixture in `tests/Issues/NamespacedUseAutoImport`.