### PR TITLE
[TypeDeclarationDocblocks] Fix invalid array-in-key docblock when narrowing long array unions

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_heterogeneous_nested_array_key.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_heterogeneous_nested_array_key.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class SkipHeterogeneousNestedArrayKey
+{
+    public function one()
+    {
+        return $this->sink([["x" => 1], "s"]);
+    }
+
+    public function two()
+    {
+        return $this->sink([[["d" => 1]]]);
+    }
+
+    protected function sink(array $data)
+    {
+        return $data;
+    }
+}

--- a/rules/Privatization/TypeManipulator/TypeNormalizer.php
+++ b/rules/Privatization/TypeManipulator/TypeNormalizer.php
@@ -196,10 +196,14 @@ final readonly class TypeNormalizer
             return null;
         }
 
-        $arrayUniqueKeyType = $this->arrayTypeLeastCommonDenominatorResolver->sharedArrayStructure(
+        $sharedArrayStructure = $this->arrayTypeLeastCommonDenominatorResolver->sharedArrayStructure(
             ...$unionType->getTypes()
         );
-        return new ArrayType($arrayUniqueKeyType, new MixedType());
+        if (! $sharedArrayStructure instanceof ArrayType) {
+            return null;
+        }
+
+        return $sharedArrayStructure;
     }
 
     /**


### PR DESCRIPTION
Fixes rectorphp/rector#9865

`ClassMethodArrayDocblockParamFromLocalCallsRector` could emit an invalid docblock with an array type in the array-key slot, e.g. `@param array<mixed[], mixed> $data`.

## Cause

When a resolved param type is a union of arrays whose printed form exceeds the max length, `TypeNormalizer::generalizeConstantTypes()` narrows it via `narrowToAlwaysKnownArrayType()`:

```php
$arrayUniqueKeyType = $this->arrayTypeLeastCommonDenominatorResolver->sharedArrayStructure(...);
return new ArrayType($arrayUniqueKeyType, new MixedType());
```

`sharedArrayStructure()` already returns a full array *structure* (e.g. `array<int, mixed>`), but the code dropped it into the *key* slot of a new `ArrayType`, yielding `array<array<int, mixed>, mixed>` which prints as the invalid `array<mixed[], mixed>`. The variable name `$arrayUniqueKeyType` shows the structure was mistaken for a key type.

## Fix

Return the shared array structure directly. The heterogeneous case from the issue now narrows to a plain `mixed[]`, which the existing mixed-array guard skips, so no invalid docblock is written.

Added a `skip_*` fixture reproducing the exact case from the issue.
