### PR TITLE
Add back RectorConfig::tag() as a no-op BC layer

### DIFF
--- a/src/Config/RectorConfig.php
+++ b/src/Config/RectorConfig.php
@@ -608,6 +608,18 @@ final class RectorConfig extends Container
     }
 
     /**
+     * Backward-compatibility no-op. The former illuminate/container exposed tag()/tagged();
+     * the entropy container discovers services by contract, so tagging is not needed.
+     *
+     * @deprecated Tagging is no longer used, services are discovered by contract. The call is ignored.
+     * @param string|string[] $abstracts
+     * @param string|string[] $tags
+     */
+    public function tag(array|string $abstracts, array|string $tags): void
+    {
+    }
+
+    /**
      * @internal Used only for bridge
      * @return array<class-string<ConfigurableRectorInterface>, mixed>
      */


### PR DESCRIPTION
Fixes rectorphp/rector#9880

The DI container switch to entropy (#8362) dropped the `tag()` method that used to be inherited from `illuminate/container`. Configs and sets that still call `->tag()` now blow up with:

```
Call to undefined method Rector\Config\RectorConfig::tag()
```

even when the project never calls it directly (a set does).

This restores `tag()` as a deprecated no-op. Tagging is not needed anymore - the entropy container discovers services by contract - so the call is simply accepted and ignored to keep BC.

https://claude.ai/code/session_01SPWpEgoaHa33ypRUWccHHr