### PR TITLE
[TypeDeclarationDocblocks] Return empty "[]" as "mixed[]" instead of "array{}" on bare "@return array"

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/bare_array_empty_to_mixed.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector/Fixture/bare_array_empty_to_mixed.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockReturnArrayFromDirectArrayInstanceRector\Fixture;
+
+class BareArrayEmptyToMixed
+{
+    /**
+     * @return array
+     */
+    public function getRefreshTokenKeys()
+    {
+        return [];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockReturnArrayFromDirectArrayInstanceRector\Fixture;
+
+class BareArrayEmptyToMixed
+{
+    /**
+     * @return mixed[]
+     */
+    public function getRefreshTokenKeys()
+    {
+        return [];
+    }
+}
+
+?>

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/DocblockReturnArrayFromDirectArrayInstanceRector.php
@@ -11,10 +11,12 @@ use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\Type\Constant\ConstantArrayType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\BetterPhpDocParser\ValueObject\Type\SpacingAwareArrayTypeNode;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclarationDocblocks\NodeFinder\ReturnNodeFinder;
 use Rector\TypeDeclarationDocblocks\TagNodeAnalyzer\UsefulArrayTagNodeAnalyzer;
@@ -114,6 +116,17 @@ CODE_SAMPLE
             return null;
         }
 
+        // bare "@return array" with "return []" -> "mixed[]", better than "array{}"
+        if ($soleReturn->expr->items === [] && $this->hasBareArrayReturnTag($phpDocInfo)) {
+            $this->phpDocTypeChanger->changeReturnTypeNode(
+                $node,
+                $phpDocInfo,
+                new SpacingAwareArrayTypeNode(new IdentifierTypeNode('mixed'))
+            );
+
+            return $node;
+        }
+
         // resolve simple type
         $returnedType = $this->getType($soleReturn->expr);
         if (! $returnedType instanceof ConstantArrayType) {
@@ -146,5 +159,15 @@ CODE_SAMPLE
 
         // better than array{}
         return $returnTagValueNode->type instanceof ArrayTypeNode;
+    }
+
+    private function hasBareArrayReturnTag(PhpDocInfo $phpDocInfo): bool
+    {
+        $returnTagValueNode = $phpDocInfo->getReturnTagValue();
+        if (! $returnTagValueNode instanceof ReturnTagValueNode) {
+            return false;
+        }
+
+        return $returnTagValueNode->type instanceof IdentifierTypeNode && $returnTagValueNode->type->name === 'array';
     }
 }


### PR DESCRIPTION
When a method has a bare `@return array` docblock and its sole body statement is `return [];`, `DocblockReturnArrayFromDirectArrayInstanceRector` previously rewrote it to `@return array{}`.

`array{}` describes an always-empty array shape, which is rarely the intent for a method that just happens to return `[]` in one branch. This turns that case into the looser, more useful `mixed[]`:

```php
 /**
- * @return array
+ * @return mixed[]
  */
 public function getRefreshTokenKeys()
 {
     return [];
 }
```

Scope kept narrow on purpose:
- only fires on a bare `@return array` tag (not `@return mixed`, `iterable`, or an existing generic),
- only for a direct empty `return []`,
- `@return mixed[]` and typed `X[]` empties keep being skipped, and no-docblock empties keep generalizing as before.

https://claude.ai/code/session_011MyFdoaYnfDEvdM9o3kiyq