### PR TITLE
[DeadCode] Keep empty method when parent class or interface is out of analyzed scope

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_unresolvable_interface.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_unresolvable_interface.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Fixture;
+
+final class SkipUnresolvableInterface implements \App\OutOfScope\PostingInterface
+{
+    public function submitPosting(): void
+    {
+    }
+}

--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_unresolvable_parent.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/skip_unresolvable_parent.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector\Fixture;
+
+final class SkipUnresolvableParent extends \App\OutOfScope\AbstractPosting
+{
+    protected function submitPosting(): void
+    {
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
@@ -156,6 +156,11 @@ CODE_SAMPLE
             return true;
         }
 
+        // parent class or interface is out of analyzed scope, keep method as it may implement an abstract requirement
+        if ($this->hasUnresolvableParentOrInterface($class, $classMethod, $scope->getClassReflection())) {
+            return true;
+        }
+
         if ($this->paramAnalyzer->hasPropertyPromotion($classMethod->params)) {
             return true;
         }
@@ -182,6 +187,28 @@ CODE_SAMPLE
         }
 
         return $this->isAttributeMarkerConstructor($classMethod, $classReflection);
+    }
+
+    private function hasUnresolvableParentOrInterface(
+        Class_ $class,
+        ClassMethod $classMethod,
+        ?ClassReflection $classReflection
+    ): bool {
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        // a protected empty method only exists to override/implement a parent's method;
+        // if the parent is out of scope, keep it to avoid breaking an abstract requirement
+        if ($classMethod->isProtected() && $class->extends instanceof Name && ! $classReflection->getParentClass() instanceof ClassReflection) {
+            return true;
+        }
+
+        $interfaceNames = array_map(
+            static fn (ClassReflection $classReflection): string => $classReflection->getName(),
+            $classReflection->getInterfaces()
+        );
+        return array_any($class->implements, fn (Name $name): bool => ! in_array($this->getName($name), $interfaceNames, true));
     }
 
     private function hasDeprecatedAnnotation(ClassMethod $classMethod): bool


### PR DESCRIPTION
Fixes rectorphp/rector#9881

`RemoveEmptyClassMethodRector` removed an empty method whose abstract requirement lives in a parent class or interface located outside the analyzed paths. Reflection cannot see the out-of-scope parent, so the rule wrongly treated the method as unnecessary.

Before (analyzing only the child directory, `AbstractPosting` out of scope):

```php
final class SAPPosting extends AbstractPosting
{
    protected function submitPosting(Posting $posting): void
    {
    }
}
```

was reduced to an empty class, breaking the abstract requirement.

Now the method is kept when:
- it is `protected` and the parent class cannot be resolved (typical abstract override), or
- an implemented interface is out of scope.

Public methods on classes extending an unresolvable framework base (e.g. Presenter/Controller) still get removed as before, so existing behavior is preserved.

https://claude.ai/code/session_01QswFbKfL2DRR9FTdAAKZPL