### PR TITLE
[TypeDeclarationDocblocks] Guard DocblockVarArrayFromPropertyDefaultsRector against unsound narrowing

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector/Fixture/array_union_generic_same_type.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector/Fixture/array_union_generic_same_type.php.inc
@@ -7,7 +7,7 @@ use stdClass;
 
 class ArrayUnionGenericSameType
 {
-    protected array $dependencies = [
+    private array $dependencies = [
         stdClass::class,
         DateTime::class,
     ];
@@ -27,7 +27,7 @@ class ArrayUnionGenericSameType
     /**
      * @var array<int, class-string<\stdClass>|class-string<\DateTime>>
      */
-    protected array $dependencies = [
+    private array $dependencies = [
         stdClass::class,
         DateTime::class,
     ];

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector/Fixture/skip_empty_nested_array.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector/Fixture/skip_empty_nested_array.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\DocblockVarArrayFromPropertyDefaultsRector\Fixture;
+
+final class SkipEmptyNestedArray
+{
+    private array $payload = ['create' => [], 'update' => []];
+
+    public function add(string $key, array $item): void
+    {
+        $this->payload['create'][$key] = $item;
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector/Fixture/skip_non_private_property.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector/Fixture/skip_non_private_property.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\DocblockVarArrayFromPropertyDefaultsRector\Fixture;
+
+class SkipNonPrivateProperty
+{
+    protected array $configParams = ['enabled' => true, 'name' => 'value'];
+}

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector.php
@@ -6,6 +6,7 @@ namespace Rector\TypeDeclarationDocblocks\Rector\Class_;
 
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
+use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\PropertyItem;
@@ -80,12 +81,22 @@ CODE_SAMPLE
                 continue;
             }
 
+            // only private properties are safe; a protected/public one can be reassigned with a wider type by a child class we cannot see here
+            if (! $property->isPrivate()) {
+                continue;
+            }
+
             if (count($property->props) > 1) {
                 continue;
             }
 
             $soleProperty = $property->props[0];
             if (! $soleProperty->default instanceof Array_) {
+                continue;
+            }
+
+            // an empty nested array default generalizes to never[], which then rejects every real value assigned later
+            if ($this->hasEmptyNestedArray($soleProperty->default)) {
                 continue;
             }
 
@@ -116,6 +127,29 @@ CODE_SAMPLE
         }
 
         return $node;
+    }
+
+    private function hasEmptyNestedArray(Array_ $array): bool
+    {
+        foreach ($array->items as $arrayItem) {
+            if (! $arrayItem instanceof ArrayItem) {
+                continue;
+            }
+
+            if (! $arrayItem->value instanceof Array_) {
+                continue;
+            }
+
+            if ($arrayItem->value->items === []) {
+                return true;
+            }
+
+            if ($this->hasEmptyNestedArray($arrayItem->value)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function hasUsefulParentPropertyVarTag(Class_ $class, Property $property, Type $propertyDefaultType): bool


### PR DESCRIPTION
Two cases produced a `@var` narrower than the values actually stored in the property.

**Non-private property** - a child class can reassign it with a wider type that is invisible from the declaring class:

```
Property AbstractMauticTestCase::$configParams (array<string, bool|string>)
does not accept array<string, bool|int|string>.
```

**Empty nested array default** - e.g. `['create' => [], 'update' => []]` generalizes to `never[]`, which then rejects every real value assigned later:

```
Property ExampleSyncDataExchange::$payload (array<string, never[]>)
does not accept array<string, array<array<string, mixed>>>.
```

Restrict to private properties and skip empty nested array defaults. The existing `array_union_generic_same_type` fixture used a protected property; converted to private to keep the transform meaningful.