### PR TITLE
[fix] Only touch private methods in AddParamArrayDocblockFromAssignsParamToParamReferenceRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromAssignsParamToParamReferenceRector/Fixture/override_dummy_array_param.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromAssignsParamToParamReferenceRector/Fixture/override_dummy_array_param.php.inc
@@ -7,7 +7,7 @@ final class OverrideDummyArrayParam
     /**
      * @param array $items
      */
-    public function run(array &$items)
+    private function run(array &$items)
     {
         $items[] = 'John';
     }
@@ -24,7 +24,7 @@ final class OverrideDummyArrayParam
     /**
      * @param string[] $items
      */
-    public function run(array &$items)
+    private function run(array &$items)
     {
         $items[] = 'John';
     }

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromAssignsParamToParamReferenceRector/Fixture/skip_dim_fetch_assign_deep.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromAssignsParamToParamReferenceRector/Fixture/skip_dim_fetch_assign_deep.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArray
 
 final class SkipDimFetchAssignDeep
 {
-    public function run(array &$items)
+    private function run(array &$items)
     {
         $items[][] = 'John';
     }

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromAssignsParamToParamReferenceRector/Fixture/skip_non_private_method.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromAssignsParamToParamReferenceRector/Fixture/skip_non_private_method.php.inc
@@ -2,11 +2,10 @@
 
 namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArrayDocblockFromAssignsParamToParamReferenceRector\Fixture;
 
-final class SkipMultipleAssigns
+final class SkipNonPrivateMethod
 {
-    private function run(array &$items)
+    protected function addMobileData(array &$data): void
     {
-        $items[] = 'John';
-        $items[] = 1000;
+        $data[] = 'value';
     }
 }

--- a/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromAssignsParamToParamReferenceRector/Fixture/some_class.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromAssignsParamToParamReferenceRector/Fixture/some_class.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Tests\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArray
 
 final class SomeClass
 {
-    public function run(array &$items)
+    private function run(array &$items)
     {
         $items[] = 'John';
     }
@@ -21,7 +21,7 @@ final class SomeClass
     /**
      * @param string[] $items
      */
-    public function run(array &$items)
+    private function run(array &$items)
     {
         $items[] = 'John';
     }

--- a/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromAssignsParamToParamReferenceRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/ClassMethod/AddParamArrayDocblockFromAssignsParamToParamReferenceRector.php
@@ -39,7 +39,7 @@ final class AddParamArrayDocblockFromAssignsParamToParamReferenceRector extends 
                     <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run(array &$names): void
+    private function run(array &$names): void
     {
         $names[] = 'John';
     }
@@ -52,7 +52,7 @@ final class SomeClass
     /**
      * @param string[] $names
      */
-    public function run(array &$names): void
+    private function run(array &$names): void
     {
         $names[] = 'John';
     }
@@ -80,6 +80,11 @@ CODE_SAMPLE
         $hasChanged = false;
 
         if ($node->getParams() === []) {
+            return null;
+        }
+
+        // a by-ref param type is invariant in PHPStan; narrowing it below array breaks callers passing a plain array, which are invisible for a non-private method
+        if (! $node->isPrivate()) {
             return null;
         }
 


### PR DESCRIPTION
A by-ref array param type is invariant in PHPStan. Narrowing it below `array` makes every caller passing a plain `array` fail:

```
Parameter &$data by-ref type of method OneSignalApi::addMobileData()
expects array<array<mixed>|string|null>, array given.
```

For a protected or public method those callers live outside the class and are invisible here, so restrict the rule to private methods. The public `run()` fixtures are converted to private.