### PR TITLE
[fix] Skip keyed and direct property assigns in AddVarArrayDocblockFromDimFetchAssignRector

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector/Fixture/skip_keyed_assign.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector/Fixture/skip_keyed_assign.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\AddVarArrayDocblockFromDimFetchAssignRector\Fixture;
+
+final class SkipKeyedAssign
+{
+    private array $response = [];
+
+    public function run(): void
+    {
+        $this->response[] = [
+            'name' => 'John',
+        ];
+
+        $this->response['error'] = 'some error';
+        $this->response['done']  = true;
+    }
+}

--- a/rules/TypeDeclarationDocblocks/NodeFinder/ArrayDimFetchFinder.php
+++ b/rules/TypeDeclarationDocblocks/NodeFinder/ArrayDimFetchFinder.php
@@ -91,6 +91,36 @@ final readonly class ArrayDimFetchFinder
     }
 
     /**
+     * Any write to the property other than a bare append $this->someProperty[] = ...,
+     * i.e. a keyed dim assign $this->someProperty['key'] = ... or a direct $this->someProperty = ...
+     */
+    public function hasNonAppendAssignToPropertyName(Class_ $class, string $variableName): bool
+    {
+        $assigns = $this->betterNodeFinder->findInstancesOfScoped($class->getMethods(), Assign::class);
+
+        foreach ($assigns as $assign) {
+            if ($assign->var instanceof PropertyFetch && $this->isThisPropertyNamed($assign->var, $variableName)) {
+                return true;
+            }
+
+            if (! $assign->var instanceof ArrayDimFetch) {
+                continue;
+            }
+
+            // bare append, already covered by findDimFetchAssignToPropertyName()
+            if (! $assign->var->dim instanceof Expr) {
+                continue;
+            }
+
+            if ($assign->var->var instanceof PropertyFetch && $this->isThisPropertyNamed($assign->var->var, $variableName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @return ArrayDimFetch[]
      */
     public function findByVariableName(Node $node, string $variableName): array
@@ -104,6 +134,15 @@ final readonly class ArrayDimFetchFinder
 
             return $this->nodeNameResolver->isName($arrayDimFetch->var, $variableName);
         });
+    }
+
+    private function isThisPropertyNamed(PropertyFetch $propertyFetch, string $propertyName): bool
+    {
+        if (! $this->nodeNameResolver->isName($propertyFetch->var, 'this')) {
+            return false;
+        }
+
+        return $this->nodeNameResolver->isName($propertyFetch->name, $propertyName);
     }
 
     /**

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/AddVarArrayDocblockFromDimFetchAssignRector.php
@@ -101,6 +101,11 @@ CODE_SAMPLE
 
             $propertyName = $this->getName($property);
 
+            // a keyed dim assign ($this->prop['x'] = ...) or a direct assign carries a value type this rule does not read from bare appends; skip to avoid a too-narrow @var
+            if ($this->arrayDimFetchFinder->hasNonAppendAssignToPropertyName($node, $propertyName)) {
+                continue;
+            }
+
             $assignedExprs = $this->arrayDimFetchFinder->findDimFetchAssignToPropertyName($node, $propertyName);
 
             $assignedExprTypes = [];


### PR DESCRIPTION
The rule inferred `@var` only from bare appends `$this->prop[] = ...`. When the same property is also written with a keyed dim assign `$this->prop['error'] = 'text'` or a direct `$this->prop = ...`, those value types were ignored and the resulting `@var` was too narrow, rejecting them:

```
Property FileController::$response (array<array<string, string>>)
does not accept array<array<string, string>|string>.
```

Skip such properties instead. A new finder helper detects keyed/direct assigns; bare-append-only properties are unaffected.