### PR TITLE
[fix] Restrict ClassMethodArrayDocblockParamFromLocalCallsRector to safe cases

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_nested_array_param.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_nested_array_param.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+final class SkipNestedArrayParam
+{
+    public function go(): void
+    {
+        $this->run([['name' => 'John', 'age' => 30]]);
+    }
+
+    private function run(array $rows): void
+    {
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_non_final_protected.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_non_final_protected.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+class HandleProtectedMethodInNonFinal
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    protected function run(array $items)
+    {
+    }
+}

--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_non_final_protected_with_parent.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector/Fixture/skip_non_final_protected_with_parent.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Fixture;
+
+use Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector\Source\SafeParentClass;
+
+class HandleNonFinalProtectedWithParent extends SafeParentClass
+{
+    public function go()
+    {
+        $this->run(['item1', 'item2']);
+    }
+
+    protected function run(array $items)
+    {
+    }
+}

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
@@ -8,8 +8,10 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
+use PHPStan\Type\ArrayType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\PhpParser\NodeFinder\LocalMethodCallFinder;
 use Rector\Rector\AbstractRector;
@@ -94,6 +96,12 @@ CODE_SAMPLE
                 continue;
             }
 
+            // local calls are the complete caller set only for a private method, or for any method of a final class
+            // that cannot be extended; otherwise a child class may call it with a wider type we cannot see here
+            if (! $classMethod->isPrivate() && ! $node->isFinal()) {
+                continue;
+            }
+
             $classMethodPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
 
             $methodCalls = $this->localMethodCallFinder->match($node, $classMethod);
@@ -120,6 +128,12 @@ CODE_SAMPLE
 
                 // in case of array type declaration, null cannot be passed or is already casted
                 $resolvedParameterType = TypeCombinator::removeNull($resolvedParameterType);
+
+                // the generalization of a nested array (an array of arrays) is imprecise and can diverge from the type
+                // PHPStan itself infers at the call site, producing a @param that rejects the very call it was built from
+                if ($this->hasNestedArray($resolvedParameterType)) {
+                    continue;
+                }
 
                 // the param default value must always be accepted; a locally inferred, flow-narrowed type such as
                 // "non-empty-array" would otherwise contradict an "= []" default - unite with the default type so
@@ -148,6 +162,36 @@ CODE_SAMPLE
         }
 
         return $node;
+    }
+
+    private function hasNestedArray(Type $type): bool
+    {
+        if ($type instanceof UnionType) {
+            foreach ($type->getTypes() as $unionedType) {
+                if ($this->hasNestedArray($unionedType)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (! $type instanceof ArrayType) {
+            return false;
+        }
+
+        $itemType = $type->getItemType();
+        if ($itemType instanceof UnionType) {
+            foreach ($itemType->getTypes() as $unionedItemType) {
+                if ($unionedItemType instanceof ArrayType) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return $itemType instanceof ArrayType;
     }
 
     private function hasParamArrayType(Param $param): bool

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
@@ -167,13 +167,7 @@ CODE_SAMPLE
     private function hasNestedArray(Type $type): bool
     {
         if ($type instanceof UnionType) {
-            foreach ($type->getTypes() as $unionedType) {
-                if ($this->hasNestedArray($unionedType)) {
-                    return true;
-                }
-            }
-
-            return false;
+            return array_any($type->getTypes(), fn(Type $unionedType): bool => $this->hasNestedArray($unionedType));
         }
 
         if (! $type instanceof ArrayType) {
@@ -182,13 +176,7 @@ CODE_SAMPLE
 
         $itemType = $type->getItemType();
         if ($itemType instanceof UnionType) {
-            foreach ($itemType->getTypes() as $unionedItemType) {
-                if ($unionedItemType instanceof ArrayType) {
-                    return true;
-                }
-            }
-
-            return false;
+            return array_any($itemType->getTypes(), fn(Type $unionedItemType): bool => $unionedItemType instanceof ArrayType);
         }
 
         return $itemType instanceof ArrayType;

--- a/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
+++ b/rules/TypeDeclarationDocblocks/Rector/Class_/ClassMethodArrayDocblockParamFromLocalCallsRector.php
@@ -92,13 +92,8 @@ CODE_SAMPLE
             }
 
             // only private methods have a closed set of local callers; public/protected can be called from outside
+            // with a wider type we cannot see here
             if (! $classMethod->isPrivate()) {
-                continue;
-            }
-
-            // local calls are the complete caller set only for a private method, or for any method of a final class
-            // that cannot be extended; otherwise a child class may call it with a wider type we cannot see here
-            if (! $classMethod->isPrivate() && ! $node->isFinal()) {
                 continue;
             }
 
@@ -167,7 +162,7 @@ CODE_SAMPLE
     private function hasNestedArray(Type $type): bool
     {
         if ($type instanceof UnionType) {
-            return array_any($type->getTypes(), fn(Type $unionedType): bool => $this->hasNestedArray($unionedType));
+            return array_any($type->getTypes(), fn (Type $unionedType): bool => $this->hasNestedArray($unionedType));
         }
 
         if (! $type instanceof ArrayType) {
@@ -176,7 +171,7 @@ CODE_SAMPLE
 
         $itemType = $type->getItemType();
         if ($itemType instanceof UnionType) {
-            return array_any($itemType->getTypes(), fn(Type $unionedItemType): bool => $unionedItemType instanceof ArrayType);
+            return array_any($itemType->getTypes(), fn (Type $unionedItemType): bool => $unionedItemType instanceof ArrayType);
         }
 
         return $itemType instanceof ArrayType;


### PR DESCRIPTION
`localMethodCallFinder` sees only calls inside the analysed class, so local calls are the complete caller set only for:

- a **private** method, or
- any method of a **final** class that cannot be extended.

For a protected/public method of a non-final class a child may call it with a wider type invisible here, and the inferred `@param` broke those external call sites:

```
Parameter #2 $leads of method EmailModel::sendEmail()
expects array<string, mixed>, array<int, array<string, mixed>> given.
```

Second guard: skip when the inferred type is a **nested array** (array of arrays). Its generalization is imprecise and can diverge from the type PHPStan infers at the call site, producing a `@param` that rejects the very call it came from:

```
private function createSegment(array $filters = [])  // inferred
@param array<int, array<string, int[]|int[]|null[][]|null[]|string>> $filters
```

The two non-final protected transform fixtures become skip fixtures.