### PR TITLE
[TypeDeclarationDocblocks] Widen "never[]" to "mixed[]" in generated @var array docblock

### DIFF
--- a/rules-tests/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector/Fixture/query_parts_empty_arrays.php.inc
+++ b/rules-tests/TypeDeclarationDocblocks/Rector/Class_/DocblockVarArrayFromPropertyDefaultsRector/Fixture/query_parts_empty_arrays.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\DocblockVarArrayFromPropertyDefaultsRector\Fixture;
+
+final class QueryPartsEmptyArrays
+{
+    private array $queryParts = [
+        'select'     => [],
+        'from'       => [],
+        'where'      => [],
+        'parameters' => [],
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclarationDocblocks\Rector\Class_\DocblockVarArrayFromPropertyDefaultsRector\Fixture;
+
+final class QueryPartsEmptyArrays
+{
+    /**
+     * @var array<string, mixed[]>
+     */
+    private array $queryParts = [
+        'select'     => [],
+        'from'       => [],
+        'where'      => [],
+        'parameters' => [],
+    ];
+}
+
+?>

--- a/rules/TypeDeclarationDocblocks/NodeDocblockTypeDecorator.php
+++ b/rules/TypeDeclarationDocblocks/NodeDocblockTypeDecorator.php
@@ -16,6 +16,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeTraverser;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Privatization\TypeManipulator\TypeNormalizer;
@@ -113,6 +114,18 @@ final readonly class NodeDocblockTypeDecorator
     private function createTypeNode(Type $type): TypeNode
     {
         $generalizedType = $this->typeNormalizer->generalizeConstantTypes($type);
+
+        // empty array default "[]" resolves to "never[]"; widen to "mixed[]" to keep the docblock useful
+        $generalizedType = TypeTraverser::map(
+            $generalizedType,
+            static function (Type $type, callable $traverse): Type {
+                if ($type instanceof NeverType) {
+                    return new MixedType();
+                }
+
+                return $traverse($type);
+            }
+        );
 
         // turn into rather generic short return typeOrTypeNode, to keep it open to extension later and readable to human
         $typeNode = $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($generalizedType);


### PR DESCRIPTION
Empty array defaults resolved to `never[]` item types in `DocblockVarArrayFromPropertyDefaultsRector`.

Before:

```php
private array $queryParts = [
    'select'     => [],
    'from'       => [],
    'where'      => [],
    'parameters' => [],
];
```

generated:

```php
/**
 * @var array<string, never[]>
 */
```

`never[]` is not useful. Now maps `never` to `mixed`:

```php
/**
 * @var array<string, mixed[]>
 */
```

https://claude.ai/code/session_01AV3g3eHaZNnT7X1CoW4Xnc