### PR TITLE
Include the exit code and stderr when a bin/rector output assertion fails

### DIFF
--- a/tests/Bin/RectorTest.php
+++ b/tests/Bin/RectorTest.php
@@ -35,6 +35,10 @@ final class RectorTest extends TestCase
     {
         $process = Process::fromShellCommandline($command);
         $process->run();
-        $this->assertSame($expectedOutput, preg_replace('/ +/', ' ', $process->getOutput()));
+        $this->assertSame($expectedOutput, preg_replace('/ +/', ' ', $process->getOutput()), sprintf(
+            'exit code %s, stderr: %s',
+            $process->getExitCode() ?? 'not started',
+            $process->getErrorOutput()
+        ));
     }
 }


### PR DESCRIPTION
`testConsoleOutput` asserts on `getOutput()` alone, so when the spawned `bin/rector` writes nothing to stdout the failure is a diff against an empty string with no reason attached. The exit code and anything on stderr are both dropped.

That is exactly what a failing run looks like in PHPStan's integration job, where all three cases report `''` including the `--version` one:

```
1) ...testConsoleOutput@Version with data ('/usr/bin/php8.4 bin/rector --version', 'Rector @package_version@\n')
-'Rector @package_version@
+''
```

Nothing there says whether the process failed to start, fataled, or exited non-zero.

`assertSame()` takes a message, so this puts both in the failure:

```
exit code 0, stderr:
Failed asserting that two strings are identical.
```

No new test: the change is in the assertion itself, and I checked it renders by pointing one expectation at a deliberately wrong string. `tests/Bin` stays green (3 tests, 3 assertions), `vendor/bin/ecs` is clean on the file, and `vendor/bin/phpstan analyse tests/Bin/RectorTest.php` reports no errors.

`getExitCode()` is nullable, so it is rendered with `%s` and a fallback rather than `%d`, which would print a misleading `0` for a process that never started.
