### PR TITLE
[CodeQuality] Skip CompleteDynamicPropertiesRector when a not autoloaded ancestor may declare the property

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/skip_property_from_not_autoloaded_grandparent.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector/Fixture/skip_property_from_not_autoloaded_grandparent.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector\Fixture;
+
+class SampleChild extends CancelableHandler
+{
+    public function getMessage()
+    {
+        return $this->configFactory->get('');
+    }
+}
+
+class CancelableHandler extends \NotAutoloaded\EmailHandler
+{
+}

--- a/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php
+++ b/rules/CodeQuality/Rector/Class_/CompleteDynamicPropertiesRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\CodeQuality\Rector\Class_;
 
 use PhpParser\Node;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
@@ -15,6 +14,7 @@ use Rector\CodeQuality\NodeFactory\MissingPropertiesFactory;
 use Rector\NodeAnalyzer\ClassAnalyzer;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ClassReflectionAnalyzer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -30,6 +30,7 @@ final class CompleteDynamicPropertiesRector extends AbstractRector
         private readonly ClassAnalyzer $classAnalyzer,
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
         private readonly MissingPropertiesResolver $missingPropertiesResolver,
+        private readonly ClassReflectionAnalyzer $classReflectionAnalyzer,
     ) {
     }
 
@@ -140,9 +141,25 @@ CODE_SAMPLE
             return true;
         }
 
-        return $class->extends instanceof FullyQualified && ! $this->reflectionProvider->hasClass(
-            $class->extends->toString()
-        );
+        // any not autoloaded ancestor may already declare the property, so we cannot safely add it
+        return $this->hasNotAutoloadedAncestor($classReflection);
+    }
+
+    private function hasNotAutoloadedAncestor(ClassReflection $classReflection): bool
+    {
+        $currentClassReflection = $classReflection;
+
+        while ($currentClassReflection instanceof ClassReflection) {
+            $parentClassName = $this->classReflectionAnalyzer->resolveParentClassName($currentClassReflection);
+
+            if ($parentClassName !== null && ! $this->reflectionProvider->hasClass($parentClassName)) {
+                return true;
+            }
+
+            $currentClassReflection = $currentClassReflection->getParentClass();
+        }
+
+        return false;
     }
 
     private function matchClassReflection(Class_ $class): ?ClassReflection


### PR DESCRIPTION
Fixes rectorphp/rector#9882

## Problem

`CompleteDynamicPropertiesRector` only verified that the **direct** parent class is autoloadable. When the used property is declared in a **not autoloaded grandparent** (or any higher ancestor), reflection cannot traverse into it, so `hasInstanceProperty()` returns `false` and the rule wrongly adds a `public $configFactory;` redeclaration to the child.

This is why the reporter could only reproduce it with the parent class in a separate, not-scanned file - once the ancestor is inlined, reflection sees the property and the rule correctly skips.

## Fix

Walk the whole ancestor chain via reflection. If any ancestor declares a parent that is not in the reflection provider, skip the class - a not autoloaded ancestor may already declare the property. This also subsumes the previous direct-parent-only check.

Added `skip_property_from_not_autoloaded_grandparent` fixture covering the child -> in-file middle -> not autoloaded grandparent chain.