### PR TITLE
[ax] Disable progress bar when output is not a TTY

### DIFF
--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -150,11 +150,21 @@ final readonly class ConfigurationFactory
             return false;
         }
 
+        // no interactive terminal, e.g. piped output, CI or an agent - the redraws are just noise
+        if (! $this->isTtyOutput()) {
+            return false;
+        }
+
         if ($this->symfonyStyle->isVerbose()) {
             return false;
         }
 
         return $outputFormat === ConsoleOutputFormatter::NAME;
+    }
+
+    private function isTtyOutput(): bool
+    {
+        return defined('STDOUT') && stream_isatty(STDOUT);
     }
 
     private function shouldShowDiffs(InputInterface $input): bool


### PR DESCRIPTION
## Why

Rector is increasingly driven by non-human callers (agents, scripts) and piped/redirected output. In those contexts the progress bar is pure noise - it pollutes captured stdout and forces consumers to strip redraw sequences.

Currently the progress bar shows whenever output format is `console` and verbosity is normal. Whether the output is an actual terminal is never checked; `CiDetector` only tunes the redraw rate, it does not turn the bar off.

## What

Short-circuit `shouldShowProgressBar()` to `false` when STDOUT is not a TTY (piped output, CI, an agent). Interactive terminals are unaffected - the bar shows exactly as before.

```php
if (! $this->isTtyOutput()) {
    return false;
}
```

```php
private function isTtyOutput(): bool
{
    return defined('STDOUT') && stream_isatty(STDOUT);
}
```

## Behavior change to note

Non-TTY CI logs previously showed a `CiDetector`-tuned (slow-redraw, non-overwriting) progress bar; they now show none. This is intentional - less log spam - but is a visible change for human CI users, not only agents. `--no-progress-bar` and verbose modes behaved this way already; a real terminal is unchanged.

`CiDetector` is left in place for now; a follow-up can remove the redraw tuning that this makes largely redundant.

## Tests

- `composer check-cs` - clean
- `vendor/bin/phpunit tests/Configuration/ConfigurationFactoryTest.php` - green