### PR TITLE
[ax] Run Drupal dev-main check on main only, not on every PR

### DIFF
--- a/.github/workflows/rector_drupal_rector_dev.yaml
+++ b/.github/workflows/rector_drupal_rector_dev.yaml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - main
-    pull_request: null
 
 env:
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361


### PR DESCRIPTION
## Why

`rector_drupal_rector_dev.yaml` ran on every PR (`pull_request: null`). It clones an external repo (`palantirnet/drupal-rector`) and runs its phpunit against `rector:dev-main`. That makes PR results depend on the state of a third-party repo - flaky and outside this repo's control.

## What

Drop the `pull_request` trigger. The check still runs on `push` to `main`, so Drupal breakage is caught right after merge - just not gating each PR.

## Note

If this check is set as a required status check in branch protection, that entry should be removed too, otherwise PRs may wait on a check that no longer reports.