### PR TITLE
[DeadCode] Skip RemoveDeadIfBlockRector on empty if with elseif and trailing else

### DIFF
--- a/rules-tests/DeadCode/Rector/If_/RemoveDeadIfBlockRector/Fixture/skip_empty_if_with_elseif_and_else.php.inc
+++ b/rules-tests/DeadCode/Rector/If_/RemoveDeadIfBlockRector/Fixture/skip_empty_if_with_elseif_and_else.php.inc
@@ -18,23 +18,3 @@ class EmptyIfWithElseIfAndElse
 }
 
 ?>
------
-<?php
-
-namespace Rector\Tests\DeadCode\Rector\If_\RemoveDeadIfBlockRector\Fixture;
-
-class EmptyIfWithElseIfAndElse
-{
-    public function calculatePrice($qty, $cond, $price1, $price2)
-    {
-        if ($qty >= 1 && !$cond) {
-            $total = $qty * $price1;
-        } else {
-            $total = $qty * $price2;
-        }
-
-        return $total;
-    }
-}
-
-?>

--- a/rules/DeadCode/Rector/If_/RemoveDeadIfBlockRector.php
+++ b/rules/DeadCode/Rector/If_/RemoveDeadIfBlockRector.php
@@ -131,6 +131,12 @@ CODE_SAMPLE
         // When the if body is blank but it has an elseif,
         // merge the negated if condition with the elseif condition
         if ($node->elseifs !== []) {
+            // A trailing else would run when the negated if condition is true,
+            // which the original empty if body never did, so keep the code as is.
+            if ($node->else instanceof Else_) {
+                return null;
+            }
+
             $firstElseIf = $node->elseifs[0];
             $cond = new BooleanAnd(
                 $this->conditionInverter->createInvertedCondition($node->cond),


### PR DESCRIPTION
Fixes rectorphp/rector#9884

`RemoveDeadIfBlockRector` changed behavior on an empty `if` body followed by `elseif` and a trailing `else`:

```php
if (in_array($a, $b)) {
} elseif (in_array($a, $c)) {
    echo "elseif";
} else {
    echo "else";
}
```

was merged into:

```php
if (!in_array($a, $b) && in_array($a, $c)) {
    echo "elseif";
} else {
    echo "else";
}
```

When the original `if` condition was true, the empty body ran nothing. After the merge the negated condition is false, so the `else` branch runs instead - a semantic change.

The merge is only safe when there is no trailing `else`. This bails out and keeps the code unchanged when an `else` is present. The existing `empty_if_with_elseif_and_else.php.inc` fixture (which encoded the wrong output) becomes a `skip_` fixture.

https://claude.ai/code/session_01MszFhfN8nK7KR3mBjda8P2