### PR TITLE
Bump phpstan/phpstan to ^2.2.12

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "phpstan/phpstan": "^2.2.10"
+        "phpstan/phpstan": "^2.2.12"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "nikic/php-parser": "^5.8",
         "ondram/ci-detector": "^4.2",
         "phpstan/phpdoc-parser": "^2.3.3",
-        "phpstan/phpstan": "^2.2.10",
+        "phpstan/phpstan": "^2.2.12",
         "react/child-process": "^0.6.5",
         "react/event-loop": "^1.6",
         "react/socket": "^1.17",


### PR DESCRIPTION
Raise `phpstan/phpstan` constraint from `^2.2.10` to `^2.2.12` in both root and target-repository composer.json.

https://claude.ai/code/session_01JQswXt93QMNWcHx2oXR5or