### PR TITLE
[ax] Add per-line rule attribution to JSON output

### DIFF
--- a/src/ChangesReporting/Output/Factory/JsonOutputFactory.php
+++ b/src/ChangesReporting/Output/Factory/JsonOutputFactory.php
@@ -39,10 +39,19 @@ final class JsonOutputFactory
             ;
 
             if ($configuration->shouldShowDiffs() && $fileDiff->getDiff() !== '') {
+                $changes = [];
+                foreach ($fileDiff->getRectorChanges() as $rectorWithLineChange) {
+                    $changes[] = [
+                        'rector' => $rectorWithLineChange->getRectorClass(),
+                        'line' => $rectorWithLineChange->getLine(),
+                    ];
+                }
+
                 $errorsJson[Bridge::FILE_DIFFS][] = [
                     'file' => $filePath,
                     'diff' => $fileDiff->getDiff(),
                     'applied_rectors' => $fileDiff->getRectorClasses(),
+                    'changes' => $changes,
                 ];
             }
 

--- a/src/ChangesReporting/ValueObject/RectorWithLineChange.php
+++ b/src/ChangesReporting/ValueObject/RectorWithLineChange.php
@@ -32,6 +32,11 @@ final readonly class RectorWithLineChange implements SerializableInterface
         return $this->rectorClass;
     }
 
+    public function getLine(): int
+    {
+        return $this->line;
+    }
+
     /**
      * @param array<string, mixed> $json
      */

--- a/tests/ChangesReporting/Output/Factory/JsonOutputFactoryTest.php
+++ b/tests/ChangesReporting/Output/Factory/JsonOutputFactoryTest.php
@@ -7,6 +7,7 @@ namespace Rector\Tests\ChangesReporting\Output\Factory;
 use PHPUnit\Framework\TestCase;
 use Rector\ChangesReporting\Output\Factory\JsonOutputFactory;
 use Rector\ChangesReporting\ValueObject\RectorWithLineChange;
+use Rector\Php80\Rector\Identical\StrEndsWithRector;
 use Rector\Php80\Rector\Identical\StrStartsWithRector;
 use Rector\ValueObject\Configuration;
 use Rector\ValueObject\Error\SystemError;
@@ -42,6 +43,35 @@ final class JsonOutputFactoryTest extends TestCase
         );
 
         $expectedOutput = (string) file_get_contents(__DIR__ . '/../Fixtures/without_diffs.json');
+        $this->assertSame($expectedOutput, $actualOutput);
+    }
+
+    public function testReportShouldAttributeEachRectorToItsLine(): void
+    {
+        $diff = '--- Original' . PHP_EOL . '+++ New' . PHP_EOL .
+            '@@ -38,5 +39,6 @@' . PHP_EOL .
+            'return true;' . PHP_EOL . '}' . PHP_EOL;
+
+        $actualOutput = JsonOutputFactory::create(
+            new ProcessResult(
+                [],
+                [
+                    new FileDiff(
+                        'some/file.php',
+                        $diff,
+                        'diff console formatted',
+                        [
+                            new RectorWithLineChange(StrStartsWithRector::class, 38),
+                            new RectorWithLineChange(StrEndsWithRector::class, 42),
+                        ]
+                    ),
+                ],
+                1
+            ),
+            new Configuration(showDiffs: true)
+        );
+
+        $expectedOutput = (string) file_get_contents(__DIR__ . '/../Fixtures/with_diffs.json');
         $this->assertSame($expectedOutput, $actualOutput);
     }
 }

--- a/tests/ChangesReporting/Output/Fixtures/with_diffs.json
+++ b/tests/ChangesReporting/Output/Fixtures/with_diffs.json
@@ -1,0 +1,29 @@
+{
+    "totals": {
+        "changed_files": 1,
+        "errors": 0
+    },
+    "file_diffs": [
+        {
+            "file": "some/file.php",
+            "diff": "--- Original\n+++ New\n@@ -38,5 +39,6 @@\nreturn true;\n}\n",
+            "applied_rectors": [
+                "Rector\\Php80\\Rector\\Identical\\StrEndsWithRector",
+                "Rector\\Php80\\Rector\\Identical\\StrStartsWithRector"
+            ],
+            "changes": [
+                {
+                    "rector": "Rector\\Php80\\Rector\\Identical\\StrStartsWithRector",
+                    "line": 38
+                },
+                {
+                    "rector": "Rector\\Php80\\Rector\\Identical\\StrEndsWithRector",
+                    "line": 42
+                }
+            ]
+        }
+    ],
+    "changed_files": [
+        "some/file.php"
+    ]
+}


### PR DESCRIPTION
## Why

The `--output-format=json` payload lists `applied_rectors` as a flat, de-duplicated array of class strings per file. It drops the line each rule fired at - even though Rector already tracks it internally (`RectorWithLineChange` carries `{rector_class, line}`). Machine consumers (agents, editors, CI annotations) had to re-parse the raw `diff` blob to guess which rule touched which line.

## What

Emit an additive `changes` array on each file diff, pairing every rule application with its line:

```json
{
    "file": "some/file.php",
    "diff": "--- Original\n+++ New\n@@ -38,5 +39,6 @@\n...",
    "applied_rectors": [
        "Rector\\Php80\\Rector\\Identical\\StrEndsWithRector",
        "Rector\\Php80\\Rector\\Identical\\StrStartsWithRector"
    ],
    "changes": [
        { "rector": "Rector\\Php80\\Rector\\Identical\\StrStartsWithRector", "line": 38 },
        { "rector": "Rector\\Php80\\Rector\\Identical\\StrEndsWithRector", "line": 42 }
    ]
}
```

- `applied_rectors` is kept unchanged - backward compatible, no consumer breaks.
- `changes` reuses `FileDiff::getRectorChanges()`, which already holds the per-line data; only a `getLine()` getter was missing on `RectorWithLineChange`.

`line` is the node's source line when the rule fired, not the post-change hunk line - approximate but enough to jump to or group by rule. Structuring the diff into machine hunks is a larger, separate change.

## Tests

- New `testReportShouldAttributeEachRectorToItsLine` with a `with_diffs.json` fixture.
- `composer check-cs` clean, existing JSON test still green.