### PR TITLE
[ax] Add --max-changes option to stop after N changes

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -134,6 +134,7 @@ final class ApplicationFileProcessor
         $fileDiffs = [];
 
         $totalChanged = 0;
+        $totalChangeCount = 0;
         foreach ($filePaths as $filePath) {
             if ($preFileCallback !== null) {
                 $preFileCallback($filePath);
@@ -152,6 +153,7 @@ final class ApplicationFileProcessor
                 $currentFileDiff = $fileProcessResult->getFileDiff();
                 if ($currentFileDiff instanceof FileDiff) {
                     $fileDiffs[] = $currentFileDiff;
+                    $totalChangeCount += count($currentFileDiff->getRectorChanges());
                 }
 
                 // progress bar on parallel handled on runParallel()
@@ -161,6 +163,12 @@ final class ApplicationFileProcessor
 
                 if ($fileProcessResult->hasChanged()) {
                     ++$totalChanged;
+                }
+
+                // stop once the requested number of changes is reached, leaving the rest untouched
+                $maxChanges = $configuration->getMaxChanges();
+                if ($maxChanges !== null && $totalChangeCount >= $maxChanges) {
+                    break;
                 }
             } catch (Throwable $throwable) {
                 $this->changedFilesDetector->invalidateFile($filePath);

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -10,6 +10,7 @@ use Rector\FileSystem\FilePathFilter;
 use Rector\ValueObject\Configuration;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
 
 /**
  * @see \Rector\Tests\Configuration\ConfigurationFactoryTest
@@ -97,6 +98,13 @@ final readonly class ConfigurationFactory
             $isParallel = false;
         }
 
+        $maxChanges = $this->resolveMaxChanges($input);
+
+        // a global change counter cannot be shared across parallel workers, so enforce the limit in a single process
+        if ($maxChanges !== null) {
+            $isParallel = false;
+        }
+
         $memoryLimit = $this->resolveMemoryLimit($input);
 
         $isReportingWithRealPath = SimpleParameterProvider::provideBoolParameter(Option::ABSOLUTE_FILE_PATH);
@@ -140,7 +148,21 @@ final readonly class ConfigurationFactory
             $isComposerBased,
             $isPhpOnly,
             $filters,
+            $maxChanges,
         );
+    }
+
+    private function resolveMaxChanges(InputInterface $input): ?int
+    {
+        $maxChanges = $input->getOption(Option::MAX_CHANGES);
+        if ($maxChanges === null) {
+            return null;
+        }
+
+        $maxChanges = (int) $maxChanges;
+        Assert::positiveInteger($maxChanges);
+
+        return $maxChanges;
     }
 
     private function shouldShowProgressBar(InputInterface $input, string $outputFormat): bool

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -148,6 +148,8 @@ final class Option
 
     public const string RULES_SUMMARY = 'rules-summary';
 
+    public const string MAX_CHANGES = 'max-changes';
+
     public const string CONFIG = 'config';
 
     /**

--- a/src/Console/ProcessConfigureDecorator.php
+++ b/src/Console/ProcessConfigureDecorator.php
@@ -102,5 +102,12 @@ final class ProcessConfigureDecorator
             InputOption::VALUE_NONE,
             'Show summary of rules applied during the run.'
         );
+
+        $command->addOption(
+            Option::MAX_CHANGES,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Stop after this many changes are made, leaving the rest untouched. Forces non-parallel run.'
+        );
     }
 }

--- a/src/ValueObject/Configuration.php
+++ b/src/ValueObject/Configuration.php
@@ -39,7 +39,13 @@ final readonly class Configuration
         private bool $isComposerBased = false,
         private bool $isPhpOnly = false,
         private array $filters = [],
+        private ?int $maxChanges = null,
     ) {
+    }
+
+    public function getMaxChanges(): ?int
+    {
+        return $this->maxChanges;
     }
 
     public function isComposerBased(): bool

--- a/tests/Application/ApplicationFileProcessor/ApplicationFileProcessorTest.php
+++ b/tests/Application/ApplicationFileProcessor/ApplicationFileProcessorTest.php
@@ -76,4 +76,25 @@ final class ApplicationFileProcessorTest extends AbstractLazyTestCase
         $this->changedFilesDetector->setActiveScope(null, null);
         $this->assertTrue($this->changedFilesDetector->hasFileChanged($filePath));
     }
+
+    public function testMaxChangesStopsAfterLimit(): void
+    {
+        self::$rectorConfig = null;
+        $this->bootFromConfigFiles([__DIR__ . '/config-max-changes.php']);
+        $applicationFileProcessor = $this->make(ApplicationFileProcessor::class);
+
+        $filePaths = [
+            __DIR__ . '/Source/WithTwoClosuresFirst.php',
+            __DIR__ . '/Source/WithTwoClosuresSecond.php',
+        ];
+
+        // each file holds 2 closures = 2 changes; the first file alone reaches the limit of 2,
+        // so the run stops before touching the second file - proving changes are counted, not files
+        $processResult = $applicationFileProcessor->processFiles($filePaths, new Configuration(
+            isDryRun: true,
+            maxChanges: 2,
+        ));
+
+        $this->assertCount(1, $processResult->getFileDiffs());
+    }
 }

--- a/tests/Application/ApplicationFileProcessor/Source/WithTwoClosuresFirst.php
+++ b/tests/Application/ApplicationFileProcessor/Source/WithTwoClosuresFirst.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Application\ApplicationFileProcessor\Source;
+
+final class WithTwoClosuresFirst
+{
+    public function run(): void
+    {
+        $first = function () {
+            return 1;
+        };
+
+        $second = function () {
+            return 2;
+        };
+    }
+}

--- a/tests/Application/ApplicationFileProcessor/Source/WithTwoClosuresSecond.php
+++ b/tests/Application/ApplicationFileProcessor/Source/WithTwoClosuresSecond.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Application\ApplicationFileProcessor\Source;
+
+final class WithTwoClosuresSecond
+{
+    public function run(): void
+    {
+        $first = function () {
+            return 1;
+        };
+
+        $second = function () {
+            return 2;
+        };
+    }
+}

--- a/tests/Application/ApplicationFileProcessor/config-max-changes.php
+++ b/tests/Application/ApplicationFileProcessor/config-max-changes.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->cacheDirectory(sys_get_temp_dir() . '/_rector_max_changes_test');
+    $rectorConfig->rule(ClosureToArrowFunctionRector::class);
+};


### PR DESCRIPTION
## Why

Agents and scripts running Rector unattended need a blast-radius rail: apply a bounded number of changes per run, review, then continue - instead of rewriting a whole codebase in one pass. There was no way to cap how much a single run does.

## What

New `--max-changes=N` option. Once N changes (rule applications) have been made, the run stops and leaves the remaining files untouched.

```bash
rector process --dry-run --max-changes=50
# > stops once 50 changes are reached, rest skipped
```

- `N` counts changes (rule applications, i.e. `RectorWithLineChange` entries), not files - a single file can carry several.
- Enforced in the sequential file loop (`ApplicationFileProcessor::processFiles`): after each file, if the cumulative change count reached the limit, break.
- The limit is checked between files; the file that crosses the threshold is finished, so the applied total can slightly exceed N (a file is processed atomically). It never starts the next file.
- A global counter cannot be shared across parallel workers, so `--max-changes` forces a single-process run (same approach `--debug` uses).
- `N` must be a positive integer; `0` or non-numeric is rejected.

The changes made before the stop are kept (written on a real run, shown on `--dry-run`) - the point is a bounded chunk of work, not a rollback.

## Tests

- `testMaxChangesStopsAfterLimit` in `ApplicationFileProcessorTest`: two files, 2 closures (= 2 changes) each; `--max-changes=2` stops after the first file -> only 1 file diff, proving changes are counted, not files.
- `composer check-cs`, `composer phpstan` clean; verified on the CLI.