### PR TITLE
[ax] Add validate-config command for config hygiene checks

### DIFF
--- a/src/Console/Command/ValidateConfigCommand.php
+++ b/src/Console/Command/ValidateConfigCommand.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Console\Command;
+
+use Rector\Console\ExitCode;
+use Rector\Reporting\DeprecatedRulesReporter;
+use Rector\Reporting\MissConfigurationReporter;
+use Rector\Skipper\SkipCriteriaResolver\SkippedClassResolver;
+use Rector\ValueObject\Configuration;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @see \Rector\Tests\Console\Command\ValidateConfigCommandTest
+ */
+final class ValidateConfigCommand extends Command
+{
+    public function __construct(
+        private readonly SymfonyStyle $symfonyStyle,
+        private readonly DeprecatedRulesReporter $deprecatedRulesReporter,
+        private readonly MissConfigurationReporter $missConfigurationReporter,
+        private readonly SkippedClassResolver $skippedClassResolver,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('validate-config');
+        $this->setDescription('Report config hygiene issues without processing any files');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $issueCount = 0;
+
+        $issueCount += $this->deprecatedRulesReporter->reportDeprecatedRules();
+        $issueCount += $this->deprecatedRulesReporter->reportDeprecatedSkippedRules();
+        $issueCount += $this->deprecatedRulesReporter->reportDeprecatedCacheMetaExtensions();
+        $issueCount += $this->deprecatedRulesReporter->reportDeprecatedPhpSetsMethods();
+        $issueCount += $this->deprecatedRulesReporter->reportDeprecatedAttributesSetsArgs();
+        $issueCount += $this->deprecatedRulesReporter->reportDeprecatedComposerBasedArgs();
+        $issueCount += $this->deprecatedRulesReporter->reportDeprecatedRectorUnsupportedMethods();
+
+        $issueCount += $this->missConfigurationReporter->reportSkippedNeverRegisteredRules();
+        $issueCount += $this->missConfigurationReporter->reportSkippedNonRectorClasses();
+
+        $issueCount += $this->reportDeprecatedSkippedClasses();
+        $issueCount += $this->reportSetAndRulesDuplicatedRegistrations();
+
+        if ($issueCount === 0) {
+            $this->symfonyStyle->success('Config is valid, no issues found');
+            return ExitCode::SUCCESS;
+        }
+
+        $this->symfonyStyle->error(sprintf(
+            '%d config %s found, see the warnings above',
+            $issueCount,
+            $issueCount === 1 ? 'issue' : 'issues'
+        ));
+
+        return ExitCode::FAILURE;
+    }
+
+    private function reportDeprecatedSkippedClasses(): int
+    {
+        $deprecatedSkippedClasses = $this->skippedClassResolver->resolveDeprecatedSkippedClasses();
+        if ($deprecatedSkippedClasses === []) {
+            return 0;
+        }
+
+        $this->symfonyStyle->warning(sprintf(
+            'These rules are skipped, but are deprecated. Most likely you do not need to skip them anymore, remove them: %s%s',
+            "\n\n",
+            '* ' . implode("\n* ", $deprecatedSkippedClasses) . "\n"
+        ));
+
+        return count($deprecatedSkippedClasses);
+    }
+
+    private function reportSetAndRulesDuplicatedRegistrations(): int
+    {
+        $setAndRulesDuplicatedRegistrations = new Configuration()
+            ->getBothSetAndRulesDuplicatedRegistrations();
+        if ($setAndRulesDuplicatedRegistrations === []) {
+            return 0;
+        }
+
+        $this->symfonyStyle->warning(sprintf(
+            'These rules are registered in both sets and "withRules()". Remove them from "withRules()" to avoid duplications: %s* %s',
+            "\n\n",
+            implode(' * ', $setAndRulesDuplicatedRegistrations) . "\n"
+        ));
+
+        return count($setAndRulesDuplicatedRegistrations);
+    }
+}

--- a/src/Console/Command/ValidateConfigCommand.php
+++ b/src/Console/Command/ValidateConfigCommand.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\Console\Command;
 
+use Nette\Utils\Json;
+use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
+use Rector\ChangesReporting\Output\JsonOutputFormatter;
+use Rector\Configuration\Option;
 use Rector\Console\ExitCode;
 use Rector\Reporting\DeprecatedRulesReporter;
 use Rector\Reporting\MissConfigurationReporter;
@@ -11,6 +15,7 @@ use Rector\Skipper\SkipCriteriaResolver\SkippedClassResolver;
 use Rector\ValueObject\Configuration;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -32,10 +37,24 @@ final class ValidateConfigCommand extends Command
     {
         $this->setName('validate-config');
         $this->setDescription('Report config hygiene issues without processing any files');
+        $this->addOption(
+            Option::OUTPUT_FORMAT,
+            null,
+            InputOption::VALUE_REQUIRED,
+            sprintf('Output format: "%s" or "%s"', ConsoleOutputFormatter::NAME, JsonOutputFormatter::NAME),
+            ConsoleOutputFormatter::NAME
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $isJsonOutput = $input->getOption(Option::OUTPUT_FORMAT) === JsonOutputFormatter::NAME;
+
+        // silence the human-readable warnings, so only the JSON payload lands on stdout
+        if ($isJsonOutput) {
+            $this->symfonyStyle->setVerbosity(OutputInterface::VERBOSITY_QUIET);
+        }
+
         $issueCount = 0;
 
         $issueCount += $this->deprecatedRulesReporter->reportDeprecatedRules();
@@ -51,6 +70,14 @@ final class ValidateConfigCommand extends Command
 
         $issueCount += $this->reportDeprecatedSkippedClasses();
         $issueCount += $this->reportSetAndRulesDuplicatedRegistrations();
+
+        if ($isJsonOutput) {
+            echo Json::encode([
+                'valid' => $issueCount === 0,
+                'issue_count' => $issueCount,
+            ], pretty: true) . PHP_EOL;
+            return $issueCount === 0 ? ExitCode::SUCCESS : ExitCode::FAILURE;
+        }
 
         if ($issueCount === 0) {
             $this->symfonyStyle->success('Config is valid, no issues found');

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -37,6 +37,7 @@ use Rector\Console\Command\CustomRuleCommand;
 use Rector\Console\Command\ListRulesCommand;
 use Rector\Console\Command\ProcessCommand;
 use Rector\Console\Command\SetupCICommand;
+use Rector\Console\Command\ValidateConfigCommand;
 use Rector\Console\Command\WorkerCommand;
 use Rector\Console\ConsoleApplication;
 use Rector\Console\Style\SymfonyStyleFactory;
@@ -158,6 +159,7 @@ final class LazyContainerFactory
 
         $rectorConfig->singleton(ProcessCommand::class);
         $rectorConfig->singleton(WorkerCommand::class);
+        $rectorConfig->singleton(ValidateConfigCommand::class);
         $rectorConfig->singleton(SetupCICommand::class);
         $rectorConfig->singleton(ListRulesCommand::class);
         $rectorConfig->singleton(CustomRuleCommand::class);

--- a/src/Reporting/DeprecatedRulesReporter.php
+++ b/src/Reporting/DeprecatedRulesReporter.php
@@ -23,11 +23,12 @@ final readonly class DeprecatedRulesReporter
     ) {
     }
 
-    public function reportDeprecatedRules(): void
+    public function reportDeprecatedRules(): int
     {
         /** @var string[] $registeredRectorRules */
         $registeredRectorRules = SimpleParameterProvider::provideArrayParameter(Option::REGISTERED_RECTOR_RULES);
 
+        $reportedCount = 0;
         foreach ($registeredRectorRules as $registeredRectorRule) {
             if (! is_a($registeredRectorRule, DeprecatedInterface::class, true)) {
                 continue;
@@ -39,88 +40,112 @@ final readonly class DeprecatedRulesReporter
                     $registeredRectorRule
                 )
             );
+            ++$reportedCount;
         }
+
+        return $reportedCount;
     }
 
-    public function reportDeprecatedSkippedRules(): void
+    public function reportDeprecatedSkippedRules(): int
     {
         /** @var string[] $skippedRectorRules */
         $skippedRectorRules = SimpleParameterProvider::provideArrayParameter(Option::SKIPPED_RECTOR_RULES);
 
+        $reportedCount = 0;
         foreach ($skippedRectorRules as $skippedRectorRule) {
             if (! is_a($skippedRectorRule, DeprecatedInterface::class, true)) {
                 continue;
             }
 
             $this->symfonyStyle->warning(sprintf('Skipped rule "%s" is deprecated', $skippedRectorRule));
+            ++$reportedCount;
         }
+
+        return $reportedCount;
     }
 
-    public function reportDeprecatedCacheMetaExtensions(): void
+    public function reportDeprecatedCacheMetaExtensions(): int
     {
         /** @var string[] $cacheMetaExtensions */
         $cacheMetaExtensions = SimpleParameterProvider::provideArrayParameter(Option::CACHE_META_EXTENSIONS);
 
+        $reportedCount = 0;
         foreach ($cacheMetaExtensions as $cacheMetumExtension) {
             $this->symfonyStyle->warning(sprintf(
                 'Cache meta extension "%s" is deprecated and no longer applied. It is a niche mechanism, let Rector handle cache on its own. If custom invalidation is needed, handle it in CI in a more generic way, e.g. by clearing the cache directory.',
                 $cacheMetumExtension
             ));
+            ++$reportedCount;
         }
+
+        return $reportedCount;
     }
 
-    public function reportDeprecatedPhpSetsMethods(): void
+    public function reportDeprecatedPhpSetsMethods(): int
     {
         /** @var string[] $deprecatedPhpSetsMethods */
         $deprecatedPhpSetsMethods = SimpleParameterProvider::provideArrayParameter(
             Option::DEPRECATED_PHP_SETS_METHODS
         );
 
+        $reportedCount = 0;
         foreach (array_unique($deprecatedPhpSetsMethods) as $deprecatedPhpSetsMethod) {
             $this->symfonyStyle->warning(sprintf(
                 'The "->%s()" method is deprecated and no longer applied. Use "->withPhpLevel()" instead, to raise PHP level one rule at a time.',
                 $deprecatedPhpSetsMethod
             ));
+            ++$reportedCount;
         }
+
+        return $reportedCount;
     }
 
-    public function reportDeprecatedAttributesSetsArgs(): void
+    public function reportDeprecatedAttributesSetsArgs(): int
     {
         /** @var string[] $deprecatedAttributesSetsArgs */
         $deprecatedAttributesSetsArgs = SimpleParameterProvider::provideArrayParameter(
             Option::DEPRECATED_ATTRIBUTES_SETS_ARGS
         );
 
+        $reportedCount = 0;
         foreach (array_unique($deprecatedAttributesSetsArgs) as $deprecatedAttributesSetsArg) {
             $this->symfonyStyle->warning(sprintf(
                 'The "->withAttributesSets(%s: true)" argument is deprecated and no longer applied. It is already included in the "symfony: true" argument, use it instead.',
                 $deprecatedAttributesSetsArg
             ));
+            ++$reportedCount;
         }
+
+        return $reportedCount;
     }
 
-    public function reportDeprecatedComposerBasedArgs(): void
+    public function reportDeprecatedComposerBasedArgs(): int
     {
         /** @var string[] $deprecatedComposerBasedArgs */
         $deprecatedComposerBasedArgs = SimpleParameterProvider::provideArrayParameter(
             Option::DEPRECATED_COMPOSER_BASED_ARGS
         );
 
+        $reportedCount = 0;
         foreach (array_unique($deprecatedComposerBasedArgs) as $deprecatedComposerBasedArg) {
             $this->symfonyStyle->warning(sprintf(
                 'The "->withComposerBased(%s: true)" argument is deprecated and no longer applied. It only added named args to 2 methods of a single package, register the rule directly if needed.',
                 $deprecatedComposerBasedArg
             ));
+            ++$reportedCount;
         }
+
+        return $reportedCount;
     }
 
-    public function reportDeprecatedRectorUnsupportedMethods(): void
+    public function reportDeprecatedRectorUnsupportedMethods(): int
     {
         // to be added in related PR
         if (! class_exists(FileNode::class)) {
-            return;
+            return 0;
         }
 
+        $reportedCount = 0;
         foreach ($this->rectors as $rector) {
             $beforeTraverseMethodReflection = new ReflectionMethod($rector, 'beforeTraverse');
             if ($beforeTraverseMethodReflection->getDeclaringClass()->getName() === $rector::class) {
@@ -129,7 +154,10 @@ final readonly class DeprecatedRulesReporter
                     $rector::class,
                     FileNode::class
                 ));
+                ++$reportedCount;
             }
         }
+
+        return $reportedCount;
     }
 }

--- a/src/Reporting/MissConfigurationReporter.php
+++ b/src/Reporting/MissConfigurationReporter.php
@@ -47,7 +47,7 @@ final readonly class MissConfigurationReporter
         $this->symfonyStyle->listing($spacedUnusedSkips);
     }
 
-    public function reportSkippedNeverRegisteredRules(): void
+    public function reportSkippedNeverRegisteredRules(): int
     {
         $registeredRules = SimpleParameterProvider::provideArrayParameter(Option::REGISTERED_RECTOR_RULES);
         $skippedRules = SimpleParameterProvider::provideArrayParameter(Option::SKIPPED_RECTOR_RULES);
@@ -61,7 +61,7 @@ final readonly class MissConfigurationReporter
         );
 
         if ($neverRegisteredSkippedRules === []) {
-            return;
+            return 0;
         }
 
         $this->symfonyStyle->warning(sprintf(
@@ -71,16 +71,18 @@ final readonly class MissConfigurationReporter
         ));
 
         $this->symfonyStyle->listing($neverRegisteredSkippedRules);
+
+        return count($neverRegisteredSkippedRules);
     }
 
-    public function reportSkippedNonRectorClasses(): void
+    public function reportSkippedNonRectorClasses(): int
     {
         $skippedNonRectorClasses = SimpleParameterProvider::provideArrayParameter(
             Option::SKIPPED_NON_RECTOR_CLASSES
         );
 
         if ($skippedNonRectorClasses === []) {
-            return;
+            return 0;
         }
 
         $this->symfonyStyle->warning(sprintf(
@@ -91,6 +93,8 @@ final readonly class MissConfigurationReporter
             count($skippedNonRectorClasses) > 1 ? 'they can' : 'it can',
             RectorInterface::class
         ));
+
+        return count($skippedNonRectorClasses);
     }
 
     /**

--- a/tests/Console/Command/Source/DeprecatedFixtureRule.php
+++ b/tests/Console/Command/Source/DeprecatedFixtureRule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Console\Command\Source;
+
+use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
+
+final class DeprecatedFixtureRule implements DeprecatedInterface
+{
+}

--- a/tests/Console/Command/ValidateConfigCommandTest.php
+++ b/tests/Console/Command/ValidateConfigCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Console\Command;
+
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Configuration\VendorMissAnalyseGuard;
+use Rector\Console\Command\ValidateConfigCommand;
+use Rector\Console\ExitCode;
+use Rector\Php85\Rector\FuncCall\OrdSingleByteRector;
+use Rector\Reporting\DeprecatedRulesReporter;
+use Rector\Reporting\MissConfigurationReporter;
+use Rector\Reporting\UnusedSkipResolver;
+use Rector\Skipper\SkipCriteriaResolver\SkippedClassResolver;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\Tests\Console\Command\Source\DeprecatedFixtureRule;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class ValidateConfigCommandTest extends AbstractLazyTestCase
+{
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $symfonyStyle = new SymfonyStyle(new ArrayInput([]), new BufferedOutput());
+
+        $validateConfigCommand = new ValidateConfigCommand(
+            $symfonyStyle,
+            new DeprecatedRulesReporter($symfonyStyle, []),
+            new MissConfigurationReporter(
+                $symfonyStyle,
+                new VendorMissAnalyseGuard(),
+                $this->make(UnusedSkipResolver::class),
+            ),
+            $this->make(SkippedClassResolver::class),
+        );
+
+        $this->commandTester = new CommandTester($validateConfigCommand);
+    }
+
+    protected function tearDown(): void
+    {
+        SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_RULES, []);
+    }
+
+    public function testFailsOnDeprecatedRegisteredRule(): void
+    {
+        SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_RULES, [DeprecatedFixtureRule::class]);
+
+        $this->assertSame(ExitCode::FAILURE, $this->commandTester->execute([]));
+    }
+
+    public function testSucceedsOnCleanConfig(): void
+    {
+        SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_RULES, [OrdSingleByteRector::class]);
+
+        $this->assertSame(ExitCode::SUCCESS, $this->commandTester->execute([]));
+    }
+}

--- a/tests/Console/Command/ValidateConfigCommandTest.php
+++ b/tests/Console/Command/ValidateConfigCommandTest.php
@@ -31,10 +31,20 @@ final class ValidateConfigCommandTest extends AbstractLazyTestCase
         parent::setUp();
 
         // clean baseline, so params leaked by other tests in the shared process do not count as issues
-        SimpleParameterProvider::setParameter(Option::SKIP, []);
-        SimpleParameterProvider::setParameter(Option::SKIPPED_NON_RECTOR_CLASSES, []);
-        SimpleParameterProvider::setParameter(Option::ROOT_STANDALONE_REGISTERED_RULES, []);
-        SimpleParameterProvider::setParameter(Option::SET_REGISTERED_RULES, []);
+        foreach ([
+            Option::SKIP,
+            Option::SKIPPED_NON_RECTOR_CLASSES,
+            Option::SKIPPED_RECTOR_RULES,
+            Option::SKIPPED_START_WITH_SHORT_OPEN_TAG_FILES,
+            Option::CACHE_META_EXTENSIONS,
+            Option::DEPRECATED_PHP_SETS_METHODS,
+            Option::DEPRECATED_ATTRIBUTES_SETS_ARGS,
+            Option::DEPRECATED_COMPOSER_BASED_ARGS,
+            Option::ROOT_STANDALONE_REGISTERED_RULES,
+            Option::SET_REGISTERED_RULES,
+        ] as $optionName) {
+            SimpleParameterProvider::setParameter($optionName, []);
+        }
 
         $symfonyStyle = new SymfonyStyle(new ArrayInput([]), new BufferedOutput());
 

--- a/tests/Console/Command/ValidateConfigCommandTest.php
+++ b/tests/Console/Command/ValidateConfigCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Console\Command;
 
+use Nette\Utils\Json;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Configuration\VendorMissAnalyseGuard;
@@ -62,5 +63,39 @@ final class ValidateConfigCommandTest extends AbstractLazyTestCase
         SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_RULES, [OrdSingleByteRector::class]);
 
         $this->assertSame(ExitCode::SUCCESS, $this->commandTester->execute([]));
+    }
+
+    public function testJsonOutputOnCleanConfig(): void
+    {
+        SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_RULES, [OrdSingleByteRector::class]);
+
+        ob_start();
+        $exitCode = $this->commandTester->execute([
+            '--output-format' => 'json',
+        ]);
+        $json = (string) ob_get_clean();
+
+        $this->assertSame(ExitCode::SUCCESS, $exitCode);
+        $this->assertSame([
+            'valid' => true,
+            'issue_count' => 0,
+        ], Json::decode($json, forceArrays: true));
+    }
+
+    public function testJsonOutputOnDeprecatedRegisteredRule(): void
+    {
+        SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_RULES, [DeprecatedFixtureRule::class]);
+
+        ob_start();
+        $exitCode = $this->commandTester->execute([
+            '--output-format' => 'json',
+        ]);
+        $json = (string) ob_get_clean();
+
+        $this->assertSame(ExitCode::FAILURE, $exitCode);
+        $this->assertSame([
+            'valid' => false,
+            'issue_count' => 1,
+        ], Json::decode($json, forceArrays: true));
     }
 }

--- a/tests/Console/Command/ValidateConfigCommandTest.php
+++ b/tests/Console/Command/ValidateConfigCommandTest.php
@@ -30,6 +30,12 @@ final class ValidateConfigCommandTest extends AbstractLazyTestCase
     {
         parent::setUp();
 
+        // clean baseline, so params leaked by other tests in the shared process do not count as issues
+        SimpleParameterProvider::setParameter(Option::SKIP, []);
+        SimpleParameterProvider::setParameter(Option::SKIPPED_NON_RECTOR_CLASSES, []);
+        SimpleParameterProvider::setParameter(Option::ROOT_STANDALONE_REGISTERED_RULES, []);
+        SimpleParameterProvider::setParameter(Option::SET_REGISTERED_RULES, []);
+
         $symfonyStyle = new SymfonyStyle(new ArrayInput([]), new BufferedOutput());
 
         $validateConfigCommand = new ValidateConfigCommand(


### PR DESCRIPTION
## Why

Agents and CI need a way to check a `rector.php` for hygiene problems without running a full refactor pass over the codebase. Until now these checks (deprecated rules, duplicate registrations, dead skips) only surfaced as warnings during a real `process` run, mixed in with the actual work.

## What

New `validate-config` command. It boots the config, runs the existing hygiene reporters without touching any files, and exits non-zero if anything is reported - so it can gate CI or an agent step.

```bash
rector validate-config
# > [OK] Config is valid, no issues found        (exit 0)
# or
# > [WARNING] Registered rule "FooRector" is deprecated ...
# > [ERROR] 1 config issue found                 (exit 1)
```

Checks (all reuse existing services, no new detection logic):
- deprecated registered rules, deprecated skipped rules
- deprecated cache-meta extensions, php-sets methods, attributes-sets and composer-based args
- rules using the deprecated `beforeTraverse` hook
- skipped rules that were never registered, skipped classes that are not Rector rules
- deprecated skipped classes
- rules registered in both a set and `withRules()`

## Implementation

- The `report*` methods on `DeprecatedRulesReporter` and the two static checks on `MissConfigurationReporter` now return the number of issues reported (were `void`). `ProcessCommand` calls them as before and ignores the return, so behavior there is unchanged.
- `ValidateConfigCommand` sums those counts plus the duplicate-registration and deprecated-skipped-class checks, and maps the total to `SUCCESS`/`FAILURE`.

## Tests

- `ValidateConfigCommandTest`: deprecated registered rule -> `FAILURE`; clean config -> `SUCCESS` (isolated reporters, exit code asserted via `CommandTester`).
- `composer check-cs`, `composer phpstan` clean; existing `MissConfigurationReporterTest` still green; verified on the CLI.