### PR TITLE
[ax] Allow --only to run several rules at once

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -57,7 +57,7 @@ final class ApplicationFileProcessor
     public function run(Configuration $configuration, InputInterface $input): ProcessResult
     {
         // scope the cache to this run's --only / --only-suffix selection before any cache read/write
-        $this->changedFilesDetector->setActiveScope($configuration->getOnlyRule(), $configuration->getOnlySuffix(), $configuration->getFilters());
+        $this->changedFilesDetector->setActiveScope($configuration->getOnlyRules(), $configuration->getOnlySuffix(), $configuration->getFilters());
 
         $filePaths = $this->filesFinder->findFilesInPaths($configuration->getPaths(), $configuration);
 
@@ -125,7 +125,7 @@ final class ApplicationFileProcessor
         ?callable $postFileCallback = null
     ): ProcessResult {
         // also set here: parallel workers reach processFiles() via WorkerCommand, bypassing run()
-        $this->changedFilesDetector->setActiveScope($configuration->getOnlyRule(), $configuration->getOnlySuffix(), $configuration->getFilters());
+        $this->changedFilesDetector->setActiveScope($configuration->getOnlyRules(), $configuration->getOnlySuffix(), $configuration->getFilters());
 
         /** @var SystemError[] $systemErrors */
         $systemErrors = [];

--- a/src/Caching/Detector/ChangedFilesDetector.php
+++ b/src/Caching/Detector/ChangedFilesDetector.php
@@ -33,14 +33,15 @@ final class ChangedFilesDetector
     }
 
     /**
+     * @param string[] $onlyRules
      * @param string[] $filters
      */
-    public function setActiveScope(?string $onlyRule, ?string $onlySuffix, array $filters = []): void
+    public function setActiveScope(array $onlyRules, ?string $onlySuffix, array $filters = []): void
     {
         // each selection gets its own cache key, so --only and full runs coexist without clearing or poisoning
-        $this->scopeSuffix = ($onlyRule === null && $onlySuffix === null && $filters === [])
+        $this->scopeSuffix = ($onlyRules === [] && $onlySuffix === null && $filters === [])
             ? ''
-            : '|only:' . ($onlyRule ?? '') . '|suffix:' . ($onlySuffix ?? '') . '|filter:' . implode(',', $filters);
+            : '|only:' . implode(',', $onlyRules) . '|suffix:' . ($onlySuffix ?? '') . '|filter:' . implode(',', $filters);
     }
 
     public function cacheFile(string $filePath): void

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -67,10 +67,12 @@ final readonly class ConfigurationFactory
         $fileExtensions = SimpleParameterProvider::provideArrayParameter(Option::FILE_EXTENSIONS);
 
         // filter rule and path
-        $onlyRule = $input->getOption(Option::ONLY);
-        if ($onlyRule !== null) {
-            $onlyRule = $this->onlyRuleResolver->resolve($onlyRule);
-        }
+        /** @var string[] $onlyRuleInputs */
+        $onlyRuleInputs = (array) $input->getOption(Option::ONLY);
+        $onlyRules = array_map(
+            $this->onlyRuleResolver->resolve(...),
+            $onlyRuleInputs
+        );
 
         $onlySuffix = $input->getOption(Option::ONLY_SUFFIX);
         if ($onlySuffix !== null) {
@@ -84,7 +86,7 @@ final readonly class ConfigurationFactory
 
         // "--only"/"--only-suffix"/"--filter" narrow the run, so skips outside the scope look falsely unused;
         // mark the run as narrowed to disable unused skip reporting and avoid false positives
-        if ($onlyRule !== null || $onlySuffix !== null || $filters !== []) {
+        if ($onlyRules !== [] || $onlySuffix !== null || $filters !== []) {
             SimpleParameterProvider::setParameter(Option::IS_RUN_NARROWED, true);
         }
 
@@ -141,7 +143,7 @@ final readonly class ConfigurationFactory
             $memoryLimit,
             $isDebug,
             $isReportingWithRealPath,
-            $onlyRule,
+            $onlyRules,
             $onlySuffix,
             $levelOverflows,
             $showRulesSummary,

--- a/src/Configuration/ConfigurationRuleFilter.php
+++ b/src/Configuration/ConfigurationRuleFilter.php
@@ -41,9 +41,9 @@ final class ConfigurationRuleFilter
             return $rectors;
         }
 
-        $onlyRule = $this->configuration->getOnlyRule();
-        if ($onlyRule !== null) {
-            return $this->filterOnlyRule($rectors, $onlyRule);
+        $onlyRules = $this->configuration->getOnlyRules();
+        if ($onlyRules !== []) {
+            return $this->filterOnlyRules($rectors, $onlyRules);
         }
 
         if ($this->configuration->isComposerBased()) {
@@ -59,14 +59,18 @@ final class ConfigurationRuleFilter
 
     /**
      * @param list<RectorInterface> $rectors
+     * @param string[] $onlyRules
      * @return list<RectorInterface>
      */
-    public function filterOnlyRule(array $rectors, string $onlyRule): array
+    public function filterOnlyRules(array $rectors, array $onlyRules): array
     {
         $activeRectors = [];
         foreach ($rectors as $rector) {
-            if ($rector instanceof $onlyRule) {
-                $activeRectors[] = $rector;
+            foreach ($onlyRules as $onlyRule) {
+                if ($rector instanceof $onlyRule) {
+                    $activeRectors[] = $rector;
+                    break;
+                }
             }
         }
 

--- a/src/Console/ProcessConfigureDecorator.php
+++ b/src/Console/ProcessConfigureDecorator.php
@@ -57,7 +57,12 @@ final class ProcessConfigureDecorator
         );
 
         // filter by rule and path
-        $command->addOption(Option::ONLY, null, InputOption::VALUE_REQUIRED, 'Fully qualified rule class name');
+        $command->addOption(
+            Option::ONLY,
+            null,
+            InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+            'Fully qualified rule class name; repeat to run several rules, e.g. --only=A --only=B'
+        );
 
         $command->addOption(
             Option::COMPOSER_BASED,

--- a/src/Parallel/Command/WorkerCommandLineFactory.php
+++ b/src/Parallel/Command/WorkerCommandLineFactory.php
@@ -127,11 +127,6 @@ final readonly class WorkerCommandLineFactory
             $workerCommandArray[] = self::OPTION_DASHES . Option::COMPOSER_BASED;
         }
 
-        if ($input->getOption(Option::ONLY) !== null) {
-            $workerCommandArray[] = self::OPTION_DASHES . Option::ONLY;
-            $workerCommandArray[] = escapeshellarg((string) $input->getOption(Option::ONLY));
-        }
-
         return implode(' ', $workerCommandArray);
     }
 
@@ -175,7 +170,7 @@ final readonly class WorkerCommandLineFactory
                 continue;
             }
 
-            /** @var bool|string|null $optionValue */
+            /** @var bool|string|string[]|null $optionValue */
             $optionValue = $input->getOption($mainCommandOptionName);
 
             // skip clutter
@@ -186,6 +181,16 @@ final readonly class WorkerCommandLineFactory
             if (is_bool($optionValue)) {
                 if ($optionValue) {
                     $workerCommandOptions[] = self::OPTION_DASHES . $mainCommandOptionName;
+                }
+
+                continue;
+            }
+
+            // array options (e.g. repeated --only) are mirrored one flag per value
+            if (is_array($optionValue)) {
+                foreach ($optionValue as $singleOptionValue) {
+                    $workerCommandOptions[] = self::OPTION_DASHES . $mainCommandOptionName;
+                    $workerCommandOptions[] = \escapeshellarg($singleOptionValue);
                 }
 
                 continue;

--- a/src/ValueObject/Configuration.php
+++ b/src/ValueObject/Configuration.php
@@ -15,6 +15,7 @@ final readonly class Configuration
     /**
      * @param string[] $fileExtensions
      * @param string[] $paths
+     * @param string[] $onlyRules
      * @param LevelOverflow[] $levelOverflows
      * @param string[] $filters
      */
@@ -32,7 +33,7 @@ final readonly class Configuration
         private string|null $memoryLimit = null,
         private bool $isDebug = false,
         private bool $reportingWithRealPath = false,
-        private ?string $onlyRule = null,
+        private array $onlyRules = [],
         private ?string $onlySuffix = null,
         private array $levelOverflows = [],
         private bool $showRulesSummary = false,
@@ -82,9 +83,12 @@ final readonly class Configuration
         return $this->fileExtensions;
     }
 
-    public function getOnlyRule(): ?string
+    /**
+     * @return string[]
+     */
+    public function getOnlyRules(): array
     {
-        return $this->onlyRule;
+        return $this->onlyRules;
     }
 
     /**

--- a/tests/Application/ApplicationFileProcessor/ApplicationFileProcessorTest.php
+++ b/tests/Application/ApplicationFileProcessor/ApplicationFileProcessorTest.php
@@ -49,15 +49,15 @@ final class ApplicationFileProcessorTest extends AbstractLazyTestCase
 
         $this->applicationFileProcessor->processFiles([$filePath], new Configuration(
             isDryRun: true,
-            onlyRule: RemoveEmptyClassMethodRector::class
+            onlyRules: [RemoveEmptyClassMethodRector::class]
         ));
 
         // a repeated --only run hits its own scoped cache entry
-        $this->changedFilesDetector->setActiveScope(RemoveEmptyClassMethodRector::class, null);
+        $this->changedFilesDetector->setActiveScope([RemoveEmptyClassMethodRector::class], null);
         $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
 
         // a full run uses a different scope key, so it is not poisoned
-        $this->changedFilesDetector->setActiveScope(null, null);
+        $this->changedFilesDetector->setActiveScope([], null);
         $this->assertTrue($this->changedFilesDetector->hasFileChanged($filePath));
     }
 
@@ -70,10 +70,10 @@ final class ApplicationFileProcessorTest extends AbstractLazyTestCase
             onlySuffix: 'Controller.php'
         ));
 
-        $this->changedFilesDetector->setActiveScope(null, 'Controller.php');
+        $this->changedFilesDetector->setActiveScope([], 'Controller.php');
         $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
 
-        $this->changedFilesDetector->setActiveScope(null, null);
+        $this->changedFilesDetector->setActiveScope([], null);
         $this->assertTrue($this->changedFilesDetector->hasFileChanged($filePath));
     }
 

--- a/tests/Caching/Detector/ChangedFilesDetectorTest.php
+++ b/tests/Caching/Detector/ChangedFilesDetectorTest.php
@@ -68,13 +68,13 @@ final class ChangedFilesDetectorTest extends AbstractLazyTestCase
         $filePath = __DIR__ . '/Source/file.php';
 
         // full run caches the file as clean
-        $this->changedFilesDetector->setActiveScope(null, null);
+        $this->changedFilesDetector->setActiveScope([], null);
         $this->changedFilesDetector->addCacheableFile($filePath);
         $this->changedFilesDetector->cacheFile($filePath);
         $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
 
         // an --only run reuses the full-run cache instead of re-analysing the file
-        $this->changedFilesDetector->setActiveScope('Rector\\SomeRule', null);
+        $this->changedFilesDetector->setActiveScope(['Rector\\SomeRule'], null);
         $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
     }
 
@@ -83,13 +83,13 @@ final class ChangedFilesDetectorTest extends AbstractLazyTestCase
         $filePath = __DIR__ . '/Source/file.php';
 
         // a scoped run only caches under its own key
-        $this->changedFilesDetector->setActiveScope('Rector\\SomeRule', null);
+        $this->changedFilesDetector->setActiveScope(['Rector\\SomeRule'], null);
         $this->changedFilesDetector->addCacheableFile($filePath);
         $this->changedFilesDetector->cacheFile($filePath);
         $this->assertFalse($this->changedFilesDetector->hasFileChanged($filePath));
 
         // a full run must not treat the file as cached, as only one rule ran
-        $this->changedFilesDetector->setActiveScope(null, null);
+        $this->changedFilesDetector->setActiveScope([], null);
         $this->assertTrue($this->changedFilesDetector->hasFileChanged($filePath));
     }
 

--- a/tests/Configuration/ConfigurationRuleFilterTest.php
+++ b/tests/Configuration/ConfigurationRuleFilterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Tests\Configuration;
 
 use Rector\Configuration\ConfigurationRuleFilter;
+use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
 use Rector\DeadCode\Rector\If_\RemoveDeadInstanceOfRector;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Testing\PHPUnit\AbstractLazyTestCase;
@@ -62,6 +63,24 @@ final class ConfigurationRuleFilterTest extends AbstractLazyTestCase
         );
 
         $this->assertSame([$removeDeadInstanceOfRector], $filteredRectors);
+    }
+
+    public function testOnlyRulesKeepsEveryListedRule(): void
+    {
+        $stringableForToStringRector = $this->make(StringableForToStringRector::class);
+        $removeDeadInstanceOfRector = $this->make(RemoveDeadInstanceOfRector::class);
+        $removeEmptyClassMethodRector = $this->make(RemoveEmptyClassMethodRector::class);
+
+        $this->configurationRuleFilter->setConfiguration(new Configuration(onlyRules: [
+            StringableForToStringRector::class,
+            RemoveEmptyClassMethodRector::class,
+        ]));
+
+        $filteredRectors = $this->configurationRuleFilter->filter(
+            [$stringableForToStringRector, $removeDeadInstanceOfRector, $removeEmptyClassMethodRector]
+        );
+
+        $this->assertSame([$stringableForToStringRector, $removeEmptyClassMethodRector], $filteredRectors);
     }
 
     private function createConfiguration(bool $isPhpOnly): Configuration

--- a/tests/Configuration/ConfigurationRuleFilterTest.php
+++ b/tests/Configuration/ConfigurationRuleFilterTest.php
@@ -23,6 +23,13 @@ final class ConfigurationRuleFilterTest extends AbstractLazyTestCase
         $this->configurationRuleFilter = $this->make(ConfigurationRuleFilter::class);
     }
 
+    protected function tearDown(): void
+    {
+        // the filter is a shared container service; reset it so a configured onlyRules/isPhpOnly
+        // does not leak into other tests in the same process
+        $this->configurationRuleFilter->setConfiguration(new Configuration());
+    }
+
     public function testPhpOnlyKeepsMinPhpVersionRules(): void
     {
         $stringableForToStringRector = $this->make(StringableForToStringRector::class);


### PR DESCRIPTION
## Why

`--only` accepted a single rule, so applying a curated subset of rules in one run was not possible - you had to run Rector once per rule. Agents and scripts that want to apply a specific set of rules (and nothing else) had no way to express it.

## What

`--only` now accepts multiple values by repeating the flag:

```bash
rector process --only=App\Rector\FooRector --only=App\Rector\BarRector
```

A rule runs if it matches any of the given `--only` values. A single `--only=Foo` behaves exactly as before, so this is backward compatible.

## Changes

- `--only` option is now `VALUE_REQUIRED | VALUE_IS_ARRAY`.
- `Configuration::getOnlyRule(): ?string` -> `getOnlyRules(): string[]`; each value is resolved through the existing `OnlyRuleResolver` (short names, ambiguity and not-found errors unchanged, per rule).
- `ConfigurationRuleFilter::filterOnlyRule()` -> `filterOnlyRules()`, keeping any rule that matches one of the listed classes.
- `ChangedFilesDetector::setActiveScope()` takes the rule list and builds the per-selection cache key from it, so different `--only` sets keep separate cache scopes.
- Parallel: the worker command line mirrors array options generically (one flag per value), which removes a now-redundant special-case block for `--only` and fixes passing several rules to workers.

## Tests

- `ConfigurationRuleFilterTest::testOnlyRulesKeepsEveryListedRule` - three rules in, two listed, only those two kept.
- Existing `--only` scope/cache tests updated to the array shape; all green.
- `composer check-cs`, `composer phpstan` clean; verified on the CLI in both parallel and single-process runs (two rules -> both applied; one rule -> BC).