### PR TITLE
[ax] Add --output-format=json to validate-config

### DIFF
--- a/src/Console/Command/ValidateConfigCommand.php
+++ b/src/Console/Command/ValidateConfigCommand.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\Console\Command;
 
+use Nette\Utils\Json;
+use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
+use Rector\ChangesReporting\Output\JsonOutputFormatter;
+use Rector\Configuration\Option;
 use Rector\Console\ExitCode;
 use Rector\Reporting\DeprecatedRulesReporter;
 use Rector\Reporting\MissConfigurationReporter;
@@ -11,6 +15,7 @@ use Rector\Skipper\SkipCriteriaResolver\SkippedClassResolver;
 use Rector\ValueObject\Configuration;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -32,10 +37,24 @@ final class ValidateConfigCommand extends Command
     {
         $this->setName('validate-config');
         $this->setDescription('Report config hygiene issues without processing any files');
+        $this->addOption(
+            Option::OUTPUT_FORMAT,
+            null,
+            InputOption::VALUE_REQUIRED,
+            sprintf('Output format: "%s" or "%s"', ConsoleOutputFormatter::NAME, JsonOutputFormatter::NAME),
+            ConsoleOutputFormatter::NAME
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $isJsonOutput = $input->getOption(Option::OUTPUT_FORMAT) === JsonOutputFormatter::NAME;
+
+        // silence the human-readable warnings, so only the JSON payload lands on stdout
+        if ($isJsonOutput) {
+            $this->symfonyStyle->setVerbosity(OutputInterface::VERBOSITY_QUIET);
+        }
+
         $issueCount = 0;
 
         $issueCount += $this->deprecatedRulesReporter->reportDeprecatedRules();
@@ -51,6 +70,14 @@ final class ValidateConfigCommand extends Command
 
         $issueCount += $this->reportDeprecatedSkippedClasses();
         $issueCount += $this->reportSetAndRulesDuplicatedRegistrations();
+
+        if ($isJsonOutput) {
+            echo Json::encode([
+                'valid' => $issueCount === 0,
+                'issue_count' => $issueCount,
+            ], pretty: true) . PHP_EOL;
+            return $issueCount === 0 ? ExitCode::SUCCESS : ExitCode::FAILURE;
+        }
 
         if ($issueCount === 0) {
             $this->symfonyStyle->success('Config is valid, no issues found');

--- a/tests/Console/Command/ValidateConfigCommandTest.php
+++ b/tests/Console/Command/ValidateConfigCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Tests\Console\Command;
 
+use Nette\Utils\Json;
 use Rector\Configuration\Option;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Configuration\VendorMissAnalyseGuard;
@@ -62,5 +63,39 @@ final class ValidateConfigCommandTest extends AbstractLazyTestCase
         SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_RULES, [OrdSingleByteRector::class]);
 
         $this->assertSame(ExitCode::SUCCESS, $this->commandTester->execute([]));
+    }
+
+    public function testJsonOutputOnCleanConfig(): void
+    {
+        SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_RULES, [OrdSingleByteRector::class]);
+
+        ob_start();
+        $exitCode = $this->commandTester->execute([
+            '--output-format' => 'json',
+        ]);
+        $json = (string) ob_get_clean();
+
+        $this->assertSame(ExitCode::SUCCESS, $exitCode);
+        $this->assertSame([
+            'valid' => true,
+            'issue_count' => 0,
+        ], Json::decode($json, forceArrays: true));
+    }
+
+    public function testJsonOutputOnDeprecatedRegisteredRule(): void
+    {
+        SimpleParameterProvider::setParameter(Option::REGISTERED_RECTOR_RULES, [DeprecatedFixtureRule::class]);
+
+        ob_start();
+        $exitCode = $this->commandTester->execute([
+            '--output-format' => 'json',
+        ]);
+        $json = (string) ob_get_clean();
+
+        $this->assertSame(ExitCode::FAILURE, $exitCode);
+        $this->assertSame([
+            'valid' => false,
+            'issue_count' => 1,
+        ], Json::decode($json, forceArrays: true));
     }
 }


### PR DESCRIPTION
Stacked on #8450 (base branch `tv-validate-config`); will retarget to `main` once #8450 merges.

## Why

`validate-config` (#8450) prints human warnings and sets an exit code. Agents and CI want a machine-readable result they can parse, not scrape from console text.

## What

`validate-config --output-format=json` emits a compact machine gate to stdout and suppresses the human warnings:

```json
{
    "valid": true,
    "issue_count": 0
}
```

- exit `0` when `valid` is true, `1` otherwise - same gate as console mode.
- default stays `console`.
- warnings are silenced in json mode (verbosity QUIET), so stdout is clean JSON only, matching how `process --output-format=json` behaves.

## Scope note

This v1 payload is the pass/fail gate (`valid` + `issue_count`). Per-finding detail (which rule/args are deprecated) would require the hygiene reporters to return structured findings instead of just counts - a larger change also touching `ProcessCommand` - so it is left as a follow-up.

## Tests

- `testJsonOutputOnCleanConfig` / `testJsonOutputOnDeprecatedRegisteredRule` assert both the payload and the exit code (output captured via `ob_*`).
- `composer check-cs`, `composer phpstan` clean; verified on the CLI.