### PR TITLE
[ax] Never emit ANSI when output is not a TTY, even with --ansi

### DIFF
--- a/src/Console/Style/SymfonyStyleFactory.php
+++ b/src/Console/Style/SymfonyStyleFactory.php
@@ -41,7 +41,7 @@ final readonly class SymfonyStyleFactory
         }
 
         // no interactive terminal, e.g. piped output, CI or an agent - never emit ANSI, even if forced via --ansi
-        if (! (defined('STDOUT') && stream_isatty(STDOUT))) {
+        if (!defined('STDOUT') || !stream_isatty(STDOUT)) {
             $consoleOutput->setDecorated(false);
         }
 

--- a/src/Console/Style/SymfonyStyleFactory.php
+++ b/src/Console/Style/SymfonyStyleFactory.php
@@ -40,6 +40,11 @@ final readonly class SymfonyStyleFactory
             $consoleOutput->setVerbosity(OutputInterface::VERBOSITY_QUIET);
         }
 
+        // no interactive terminal, e.g. piped output, CI or an agent - never emit ANSI, even if forced via --ansi
+        if (! (defined('STDOUT') && stream_isatty(STDOUT))) {
+            $consoleOutput->setDecorated(false);
+        }
+
         return new RectorStyle($argvInput, $consoleOutput);
     }
 


### PR DESCRIPTION
## Why

When output is piped, redirected or captured by an agent, colored output is noise - ANSI escape bytes an agent has to strip. Symfony already drops color on a non-TTY by default, but an explicit `--ansi` overrides that detection and forces color even into a pipe:

```bash
rector process --dry-run --ansi | tee out.txt   # out.txt held raw escape codes
```

## What

Force console decoration off when STDOUT is not a TTY, regardless of `--ansi`. Real terminals are unaffected (they keep color); only non-interactive output is guaranteed clean.

```php
// SymfonyStyleFactory::create()
if (! (defined('STDOUT') && stream_isatty(STDOUT))) {
    $consoleOutput->setDecorated(false);
}
```

Same non-TTY detection used for the progress bar in #8444.

## Verification

Piping a run with `--ansi` (2 changed lines):

- before: 12 ANSI escape sequences in the captured output
- after: 0

Plain piped output was already clean (0) and stays 0; interactive terminal output keeps color.

This is env-dependent output plumbing that reads the real STDOUT stream, so it is verified via the CLI before/after rather than a unit test.