### PR TITLE
[ax] Do not prompt or auto-create config on non-TTY

### DIFF
--- a/src/Configuration/ConfigInitializer.php
+++ b/src/Configuration/ConfigInitializer.php
@@ -52,6 +52,16 @@ final readonly class ConfigInitializer
             return;
         }
 
+        // non-interactive terminal, e.g. piped output, CI or an agent: never prompt or silently write a
+        // config, just say what to do - Symfony still treats a closed STDIN as interactive here
+        if (! (defined('STDIN') && stream_isatty(STDIN))) {
+            $this->symfonyStyle->warning(sprintf(
+                'No "%s" config found. Create one, or pass "--config <path>".',
+                RectorConfigsResolver::DEFAULT_CONFIG_FILE
+            ));
+            return;
+        }
+
         $response = $this->symfonyStyle->ask(
             'No "' . RectorConfigsResolver::DEFAULT_CONFIG_FILE . '" config found. Should we generate it for you?',
             'yes'

--- a/src/Configuration/ConfigInitializer.php
+++ b/src/Configuration/ConfigInitializer.php
@@ -54,7 +54,7 @@ final readonly class ConfigInitializer
 
         // non-interactive terminal, e.g. piped output, CI or an agent: never prompt or silently write a
         // config, just say what to do - Symfony still treats a closed STDIN as interactive here
-        if (! (defined('STDIN') && stream_isatty(STDIN))) {
+        if (!defined('STDIN') || !stream_isatty(STDIN)) {
             $this->symfonyStyle->warning(sprintf(
                 'No "%s" config found. Create one, or pass "--config <path>".',
                 RectorConfigsResolver::DEFAULT_CONFIG_FILE


### PR DESCRIPTION
## Why

Running `rector process` with no `rector.php` in a non-interactive context (piped, CI, an agent) currently:

- prints the interactive prompt `No "rector.php" config found. Should we generate it for you? [yes]:` into the output, then
- auto-answers the default `yes` and silently writes a `rector.php` into the project - a file the caller never asked for.

Symfony still treats a closed STDIN as interactive here, so the prompt is emitted and defaulted rather than skipped. For an agent this is a surprising side effect plus confusing prompt noise (and a hang risk when stdin is a pty with no human to answer).

## What

Guard the prompt on a non-TTY STDIN: emit a clear, actionable message and return - no prompt, no unrequested file.

```php
if (! (defined('STDIN') && stream_isatty(STDIN))) {
    $this->symfonyStyle->warning(sprintf(
        'No "%s" config found. Create one, or pass "--config <path>".',
        RectorConfigsResolver::DEFAULT_CONFIG_FILE
    ));
    return;
}
```

- **Agent / pipe / CI:** clear warning, no prompt, no `rector.php` written; the run falls through to the existing "no rules" handling.
- **Human terminal:** unchanged - prompt and generate as before.
- Same `stream_isatty` signal used in #8444 / #8453 (STDIN here, since the prompt reads stdin).

Trade-off: this drops the convenience of auto-scaffolding a config in non-interactive contexts. That silent write is the bug being fixed.

## Verification

`rector process src --dry-run < /dev/null` in a dir with no config:

- before: prompt printed, `rector.php` created
- after: `[WARNING] No "rector.php" config found. Create one, or pass "--config <path>."`, no file created

Env-dependent (reads the real STDIN stream), so verified via the CLI rather than a unit test.