### PR TITLE
[ax] Fix missing space after negation in non-TTY guards

### DIFF
--- a/src/Configuration/ConfigInitializer.php
+++ b/src/Configuration/ConfigInitializer.php
@@ -54,7 +54,7 @@ final readonly class ConfigInitializer
 
         // non-interactive terminal, e.g. piped output, CI or an agent: never prompt or silently write a
         // config, just say what to do - Symfony still treats a closed STDIN as interactive here
-        if (!defined('STDIN') || !stream_isatty(STDIN)) {
+        if (! defined('STDIN') || ! stream_isatty(STDIN)) {
             $this->symfonyStyle->warning(sprintf(
                 'No "%s" config found. Create one, or pass "--config <path>".',
                 RectorConfigsResolver::DEFAULT_CONFIG_FILE

--- a/src/Console/Style/SymfonyStyleFactory.php
+++ b/src/Console/Style/SymfonyStyleFactory.php
@@ -41,7 +41,7 @@ final readonly class SymfonyStyleFactory
         }
 
         // no interactive terminal, e.g. piped output, CI or an agent - never emit ANSI, even if forced via --ansi
-        if (!defined('STDOUT') || !stream_isatty(STDOUT)) {
+        if (! defined('STDOUT') || ! stream_isatty(STDOUT)) {
             $consoleOutput->setDecorated(false);
         }
 


### PR DESCRIPTION
Follow-up to #8453 and #8454. During merge those two non-TTY guards were rewritten to `!x || !y` form, but without the space after `!` that ECS requires, so `composer check-cs` is currently red on main:

- `src/Configuration/ConfigInitializer.php`
- `src/Console/Style/SymfonyStyleFactory.php`

`!defined('STDIN') || !stream_isatty(STDIN)` -> `! defined('STDIN') || ! stream_isatty(STDIN)` (and the same in SymfonyStyleFactory).

Pure `composer fix-cs` output, no behavior change.