### PR TITLE
[ax] Deprecate -n shortcut for --dry-run

### DIFF
--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -82,6 +82,15 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        // "-n" is the "--dry-run" shortcut here, but means "--no-interaction" in most CLI tools;
+        // warn and steer to the explicit flag, to be removed in the next major version
+        if ($input->hasParameterOption('-n', true)) {
+            $this->symfonyStyle->getErrorStyle()
+                ->warning(
+                    'The "-n" shortcut for "--dry-run" is deprecated and will be removed, as it means "--no-interaction" in most CLI tools. Use "--dry-run" instead.'
+                );
+        }
+
         // missing config? add it :)
         if (! $this->configInitializer->areSomeRectorsLoaded()) {
             $this->configInitializer->createConfig(getcwd());


### PR DESCRIPTION
## Why

`-n` is registered as the short form of `--dry-run`. In almost every other CLI tool (Symfony Console included) `-n` means `--no-interaction`. An agent or user carrying that convention over silently triggers a dry-run when they meant something else - a quiet footgun.

## What

Deprecate the `-n` shortcut without breaking it: when `-n` is used, warn on stderr and point to the explicit flag.

```
[WARNING] The "-n" shortcut for "--dry-run" is deprecated and will be removed,
          as it means "--no-interaction" in most CLI tools. Use "--dry-run" instead.
```

- `-n` still works exactly as before (dry-run) - no behavior change, just a warning.
- The warning goes to **stderr** (`getErrorStyle`), so stdout / `--output-format=json` stay clean.
- `--dry-run` is unaffected (no warning).

Removal of the shortcut itself is left for the next major version.

## Verification

- `rector process -n` -> warning on stderr, still dry-runs, stdout clean.
- `rector process --dry-run` -> no warning.

## Note

Whole-repo `check-cs` is currently red on `ConfigInitializer.php` / `SymfonyStyleFactory.php` due to a merge-time rewrite; that is fixed in #8455. Once #8455 lands, rebasing this branch turns CI green. This PR touches only `ProcessCommand.php`.