### PR TITLE
[ax] Deprecate --rules-summary, suggest --output-format=json

### DIFF
--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -98,6 +98,14 @@ EOF
             $this->symfonyStyle->setVerbosity(OutputInterface::VERBOSITY_QUIET);
         }
 
+        // "--rules-summary" is a human-only table; the JSON format carries richer per-rule data
+        if ($configuration->shouldShowRulesSummary()) {
+            $this->symfonyStyle->getErrorStyle()
+                ->warning(
+                    'The "--rules-summary" option is deprecated and will be removed. Use "--output-format=json" instead, which reports every applied rule with its file and line.'
+                );
+        }
+
         $this->additionalAutoloader->autoloadInput($input);
 
         $paths = $configuration->getPaths();


### PR DESCRIPTION
## Why

`--rules-summary` prints a human-only table of "which rule applied how many times". The JSON output format already carries strictly richer per-rule data - every applied rule with its file and line (`changes`, added in #8448). For agents the table is redundant noise.

Current `--rules-summary` output:

```
Rules Summary
-------------

 * SomeRector was applied 3 times
 * OtherRector was applied 1 time
```

## What

Deprecate `--rules-summary` without breaking it: when used, warn on stderr and point to the JSON format.

```
[WARNING] The "--rules-summary" option is deprecated and will be removed.
          Use "--output-format=json" instead, which reports every applied rule with its file and line.
```

- The option still works (summary still printed) - no behavior change, just a warning.
- Warning goes to **stderr** (`getErrorStyle`), so stdout / JSON stay clean.

## Verification

- `rector process --rules-summary` -> warning on stderr, summary still shown, stdout clean.
- without the option -> no warning.

https://claude.ai/code/session_01HpU9jWfDU9D81fTTh1symd
