### PR TITLE
[ax] Extract TerminalDetector helper for TTY detection

### DIFF
--- a/src/Agentic/TerminalDetector.php
+++ b/src/Agentic/TerminalDetector.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Agentic;
+
+/**
+ * Detects whether Rector runs in an interactive terminal, so non-interactive callers - pipes, CI,
+ * agents - get clean machine output instead of human chrome (progress bar, ANSI, prompts).
+ */
+final class TerminalDetector
+{
+    public static function isOutputTty(): bool
+    {
+        return defined('STDOUT') && stream_isatty(STDOUT);
+    }
+
+    public static function isInputTty(): bool
+    {
+        return defined('STDIN') && stream_isatty(STDIN);
+    }
+}

--- a/src/Configuration/ConfigInitializer.php
+++ b/src/Configuration/ConfigInitializer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Configuration;
 
 use Nette\Utils\FileSystem;
+use Rector\Agentic\TerminalDetector;
 use Rector\Bootstrap\RectorConfigsResolver;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\FileSystem\InitFilePathsResolver;
@@ -54,7 +55,7 @@ final readonly class ConfigInitializer
 
         // non-interactive terminal, e.g. piped output, CI or an agent: never prompt or silently write a
         // config, just say what to do - Symfony still treats a closed STDIN as interactive here
-        if (! defined('STDIN') || ! stream_isatty(STDIN)) {
+        if (! TerminalDetector::isInputTty()) {
             $this->symfonyStyle->warning(sprintf(
                 'No "%s" config found. Create one, or pass "--config <path>".',
                 RectorConfigsResolver::DEFAULT_CONFIG_FILE

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Configuration;
 
+use Rector\Agentic\TerminalDetector;
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
 use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\FileSystem\FilePathFilter;
@@ -175,7 +176,7 @@ final readonly class ConfigurationFactory
         }
 
         // no interactive terminal, e.g. piped output, CI or an agent - the redraws are just noise
-        if (! $this->isTtyOutput()) {
+        if (! TerminalDetector::isOutputTty()) {
             return false;
         }
 
@@ -184,11 +185,6 @@ final readonly class ConfigurationFactory
         }
 
         return $outputFormat === ConsoleOutputFormatter::NAME;
-    }
-
-    private function isTtyOutput(): bool
-    {
-        return defined('STDOUT') && stream_isatty(STDOUT);
     }
 
     private function shouldShowDiffs(InputInterface $input): bool

--- a/src/Console/Style/SymfonyStyleFactory.php
+++ b/src/Console/Style/SymfonyStyleFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Console\Style;
 
+use Rector\Agentic\TerminalDetector;
 use Rector\Util\Reflection\PrivatesAccessor;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -41,7 +42,7 @@ final readonly class SymfonyStyleFactory
         }
 
         // no interactive terminal, e.g. piped output, CI or an agent - never emit ANSI, even if forced via --ansi
-        if (! defined('STDOUT') || ! stream_isatty(STDOUT)) {
+        if (! TerminalDetector::isOutputTty()) {
             $consoleOutput->setDecorated(false);
         }
 


### PR DESCRIPTION
## Why

TTY detection was inlined in three places, each hand-rolling `stream_isatty(...)`:

- `ConfigurationFactory` (progress bar off on non-TTY, #8444)
- `SymfonyStyleFactory` (no ANSI on non-TTY, #8453)
- `ConfigInitializer` (no config prompt on non-TTY, #8454)

As Rector grows more agent-aware, this check needs one home.

## What

New `Rector\Agentic\TerminalDetector` with two static checks:

```php
TerminalDetector::isOutputTty(); // STDOUT - progress bar, ANSI
TerminalDetector::isInputTty();  // STDIN  - interactive prompts
```

The three call sites now use it. Behavior is unchanged - static, matching the existing `StaticPHPUnitEnvironment` utility pattern, since `SymfonyStyleFactory` is built manually at bootstrap (no container).

New `src/Agentic/` namespace is the home for agent-oriented helpers going forward.

## Verification

- Piped `--ansi` run still emits 0 ANSI escapes; non-TTY still skips the config prompt.
- `composer check-cs`, `composer phpstan` clean.