### PR TITLE
[DeadCode] Skip annotation docblocks in RemoveParentDelegatingClassMethodRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_annotation_docblock.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector/Fixture/skip_annotation_docblock.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Fixture;
+
+use Rector\Tests\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector\Source\SomeParentCommand;
+
+final class SkipAnnotationDocblock extends SomeParentCommand
+{
+    /**
+     * @Route("/first", methods={"GET"})
+     */
+    public function anotherMethod(): void
+    {
+        parent::anotherMethod();
+    }
+}

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\DeadCode\Rector\ClassMethod;
 
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocChildNode;
 use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
@@ -116,15 +117,7 @@ CODE_SAMPLE
     private function hasRefiningDocblock(ClassMethod $classMethod): bool
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-
-        // any tag or annotation (e.g. @Route, @OA\Get, @param) may carry intent the parent lacks
-        foreach ($phpDocInfo->getPhpDocNode()->children as $childNode) {
-            if ($childNode instanceof PhpDocTagNode) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($phpDocInfo->getPhpDocNode()->children, fn(PhpDocChildNode $phpDocChildNode): bool => $phpDocChildNode instanceof PhpDocTagNode);
     }
 
     private function matchParentMethodReflection(ClassMethod $classMethod): ?ExtendedMethodReflection

--- a/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector.php
+++ b/rules/DeadCode/Rector/ClassMethod/RemoveParentDelegatingClassMethodRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeVisitor;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ExtendedParameterReflection;
@@ -116,17 +117,14 @@ CODE_SAMPLE
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
 
-        return $phpDocInfo->hasByNames(
-            [
-                '@param',
-                '@phpstan-param',
-                '@psalm-param',
-                '@return',
-                '@phpstan-return',
-                '@psalm-return',
-                '@deprecated',
-            ]
-        );
+        // any tag or annotation (e.g. @Route, @OA\Get, @param) may carry intent the parent lacks
+        foreach ($phpDocInfo->getPhpDocNode()->children as $childNode) {
+            if ($childNode instanceof PhpDocTagNode) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function matchParentMethodReflection(ClassMethod $classMethod): ?ExtendedMethodReflection


### PR DESCRIPTION
Fixes rectorphp/rector#9887

`RemoveParentDelegatingClassMethodRector` removed a child method that only delegates to its parent even when the child method carried a docblock annotation such as `@Route(...)` or OpenAPI `@OA\Get(...)`. Those annotations carry intent the parent does not have (routing, spec generation), so removing the method silently drops them.

The `hasRefiningDocblock()` bail-out only checked a fixed whitelist of tags (`@param`, `@return`, `@deprecated`, ...). It now bails on any docblock tag/annotation, so a delegating method with a meaningful docblock is kept.

Added `skip_annotation_docblock.php.inc` fixture covering the reported `@Route` case.