### PR TITLE
[Php80] Skip empty string needle in StrContainsRector

### DIFF
--- a/rules-tests/Php80/Rector/NotIdentical/StrContainsRector/Fixture/skip_empty_needle_strpos.php.inc
+++ b/rules-tests/Php80/Rector/NotIdentical/StrContainsRector/Fixture/skip_empty_needle_strpos.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\NotIdentical\StrContainsRector\Fixture;
+
+class SkipEmptyNeedleStrpos
+{
+    public function run()
+    {
+        return strpos('abc', '') !== false;
+    }
+}

--- a/rules-tests/Php80/Rector/NotIdentical/StrContainsRector/Fixture/skip_empty_needle_strstr.php.inc
+++ b/rules-tests/Php80/Rector/NotIdentical/StrContainsRector/Fixture/skip_empty_needle_strstr.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\NotIdentical\StrContainsRector\Fixture;
+
+class SkipEmptyNeedleStrstr
+{
+    public function run()
+    {
+        return strstr('abc', '') !== false;
+    }
+}

--- a/rules/Php80/Rector/NotIdentical/StrContainsRector.php
+++ b/rules/Php80/Rector/NotIdentical/StrContainsRector.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Scalar\String_;
 use Rector\Php80\NodeResolver\StrFalseComparisonResolver;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
@@ -97,6 +98,11 @@ CODE_SAMPLE
             return null;
         }
 
+        $args = $funcCall->getArgs();
+        if (isset($args[1]) && $this->isEmptyStringNeedle($args[1]->value)) {
+            return null;
+        }
+
         if (isset($funcCall->getArgs()[2])) {
             $secondArg = $funcCall->getArgs()[2];
 
@@ -131,5 +137,14 @@ CODE_SAMPLE
         }
 
         return $expr->value === 0;
+    }
+
+    private function isEmptyStringNeedle(Expr $expr): bool
+    {
+        if (! $expr instanceof String_) {
+            return false;
+        }
+
+        return $expr->value === '';
     }
 }


### PR DESCRIPTION
Fixes rectorphp/rector#9886

`StrContainsRector` rewrites `strpos()/strstr() !== false` to `str_contains()`. But with an empty string needle the two are not equivalent:

- On PHP < 8, `strpos($haystack, '')` returned `false`, so `strpos($haystack, '') !== false` was `false`.
- `str_contains($haystack, '')` returns `true`.

So the conversion silently changed behavior for empty needles. This skips the rule when the needle is an empty string literal.

Added two skip fixtures for `strpos` and `strstr`.

https://claude.ai/code/session_01Hczn76uiK4bDwdHM4rTMui