### PR TITLE
[Parallel] Guard uninitialized encoder in ParallelProcess::quit()

### DIFF
--- a/src/Parallel/ValueObject/ParallelProcess.php
+++ b/src/Parallel/ValueObject/ParallelProcess.php
@@ -116,7 +116,11 @@ final class ParallelProcess
             $pipe->close();
         }
 
-        $this->encoder->end();
+        // the process can be quit before its connection is bound, e.g. on quitAll() after an error;
+        // in that case the encoder was never set
+        if (isset($this->encoder)) {
+            $this->encoder->end();
+        }
     }
 
     public function bindConnection(Decoder $decoder, Encoder $encoder): void


### PR DESCRIPTION
Fixes rectorphp/rector#9885

## Problem

Running with a high `withParallel()` worker count crashes near the end:

```
Fatal error: Uncaught Error: Typed property Rector\Parallel\ValueObject\ParallelProcess::$encoder must not be accessed before initialization
```

## Cause

A `ParallelProcess` is spawned via `start()` and attached to the pool immediately, but its `$encoder` is set only later in `bindConnection()`, once the child connects over TCP and sends `HELLO`.

When an error occurs (e.g. a job timeout), `handleErrorCallable` calls `ProcessPool::quitAll()`, which invokes `quit()` on **every** pooled process, including those spawned but not yet bound. Those have no `$encoder`, so `$this->encoder->end()` throws.

With many more workers than needed (the report uses `withParallel(360)`), plenty of processes sit in the pool unbound when `quitAll()` fires.

## Fix

Guard the encoder access in `quit()` with `isset()`, so an unbound process quits cleanly.

https://claude.ai/code/session_01BhpDMF7ffeFv6sjaPqEZzc