### PR TITLE
[Testing] Use fresh single-file source locator under PHPUnit to avoid stale reflection

### DIFF
--- a/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
@@ -7,6 +7,7 @@ namespace Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvi
 use PHPStan\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 use PHPStan\Reflection\BetterReflection\SourceLocator\OptimizedDirectorySourceLocatorFactory;
+use PHPStan\Reflection\BetterReflection\SourceLocator\OptimizedSingleFileSourceLocatorFactory;
 use PHPStan\Reflection\BetterReflection\SourceLocator\OptimizedSingleFileSourceLocatorRepository;
 use Rector\Contract\DependencyInjection\ResettableInterface;
 use Rector\Testing\PHPUnit\StaticPHPUnitEnvironment;
@@ -30,7 +31,8 @@ final class DynamicSourceLocatorProvider implements ResettableInterface
 
     public function __construct(
         private readonly OptimizedDirectorySourceLocatorFactory $optimizedDirectorySourceLocatorFactory,
-        private readonly OptimizedSingleFileSourceLocatorRepository $optimizedSingleFileSourceLocatorRepository
+        private readonly OptimizedSingleFileSourceLocatorRepository $optimizedSingleFileSourceLocatorRepository,
+        private readonly OptimizedSingleFileSourceLocatorFactory $optimizedSingleFileSourceLocatorFactory
     ) {
     }
 
@@ -67,7 +69,12 @@ final class DynamicSourceLocatorProvider implements ResettableInterface
         $sourceLocators = [];
 
         foreach ($this->filePaths as $file) {
-            $sourceLocators[] = $this->optimizedSingleFileSourceLocatorRepository->getOrCreate($file);
+            // under PHPUnit each fixture is a throwaway temp file that is deleted after the test;
+            // the shared repository caches locators by path forever, so a stale locator for a since-deleted
+            // file can leak into a later test. build a fresh locator per run there, keep caching in production
+            $sourceLocators[] = $isPHPUnitRun
+                ? $this->optimizedSingleFileSourceLocatorFactory->create($file)
+                : $this->optimizedSingleFileSourceLocatorRepository->getOrCreate($file);
         }
 
         foreach ($this->directories as $directory) {


### PR DESCRIPTION
## Problem

Rule tests write each fixture to a throwaway temp file and delete it in `tearDown()`. The shared `OptimizedSingleFileSourceLocatorRepository` caches single-file locators by path for the whole worker and never evicts them. So a stale locator for a since-deleted fixture file can leak into a later test that runs in the same parallel worker.

Because `fastunit` groups tests into worker chunks by weight, whether this bites depends on how the chunks fall out - adding or removing test classes reshuffles the grouping. That makes it an intermittent, order-dependent failure: a test can go red not from its own change but from what it happens to share a worker with.

It reproduces reliably at a low worker count (matching CI's core count):

```
vendor/bin/fastunit -p 4 tests rules-tests utils/phpstan/tests
```

The symptom is a rule that resolves reflection (e.g. a parent property) suddenly seeing incomplete data - the parent property becomes invisible and the expected change is not applied - accompanied by `hash_file(... /Fixture/fixture.php): Failed to open stream: No such file` warnings from the stale locator.

## Fix

Under PHPUnit, build a fresh single-file locator via `OptimizedSingleFileSourceLocatorFactory::create()` instead of the cached `getOrCreate()`. Production keeps the cached repository, where files are stable and caching is a performance win. The `isPHPUnitRun` guard already exists in `provide()` for the aggregate locator; this extends the same reasoning to the single-file locators.

## Validation

Full suite green across worker counts that previously failed:

- `vendor/bin/fastunit -p 4 …` -> OK
- `vendor/bin/fastunit -p 3 …` -> OK

`composer check-cs`, `composer phpstan`, and `composer rector` pass on the changed file.