### PR TITLE
Revert "[Testing] Use fresh single-file source locator under PHPUnit" (#8464)

### DIFF
--- a/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
+++ b/src/NodeTypeResolver/Reflection/BetterReflection/SourceLocatorProvider/DynamicSourceLocatorProvider.php
@@ -7,7 +7,6 @@ namespace Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvi
 use PHPStan\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 use PHPStan\Reflection\BetterReflection\SourceLocator\OptimizedDirectorySourceLocatorFactory;
-use PHPStan\Reflection\BetterReflection\SourceLocator\OptimizedSingleFileSourceLocatorFactory;
 use PHPStan\Reflection\BetterReflection\SourceLocator\OptimizedSingleFileSourceLocatorRepository;
 use Rector\Contract\DependencyInjection\ResettableInterface;
 use Rector\Testing\PHPUnit\StaticPHPUnitEnvironment;
@@ -31,8 +30,7 @@ final class DynamicSourceLocatorProvider implements ResettableInterface
 
     public function __construct(
         private readonly OptimizedDirectorySourceLocatorFactory $optimizedDirectorySourceLocatorFactory,
-        private readonly OptimizedSingleFileSourceLocatorRepository $optimizedSingleFileSourceLocatorRepository,
-        private readonly OptimizedSingleFileSourceLocatorFactory $optimizedSingleFileSourceLocatorFactory
+        private readonly OptimizedSingleFileSourceLocatorRepository $optimizedSingleFileSourceLocatorRepository
     ) {
     }
 
@@ -69,12 +67,7 @@ final class DynamicSourceLocatorProvider implements ResettableInterface
         $sourceLocators = [];
 
         foreach ($this->filePaths as $file) {
-            // under PHPUnit each fixture is a throwaway temp file that is deleted after the test;
-            // the shared repository caches locators by path forever, so a stale locator for a since-deleted
-            // file can leak into a later test. build a fresh locator per run there, keep caching in production
-            $sourceLocators[] = $isPHPUnitRun
-                ? $this->optimizedSingleFileSourceLocatorFactory->create($file)
-                : $this->optimizedSingleFileSourceLocatorRepository->getOrCreate($file);
+            $sourceLocators[] = $this->optimizedSingleFileSourceLocatorRepository->getOrCreate($file);
         }
 
         foreach ($this->directories as $directory) {


### PR DESCRIPTION
Reverts #8464.

That change did not actually fix the order-dependent reflection failure it targeted. It only appeared green on its own branch because that branch's `fastunit` chunk layout happened to avoid the failing test grouping - the same masking effect as adding or removing test classes. With a different chunk layout the original failure still reproduces, so the fresh-locator switch was not the real root cause.

Reverting to avoid carrying an ineffective change in the test harness. The underlying order-dependent reflection issue still needs a proper root-cause fix.