### PR TITLE
[CI] Switch tests from fastunit to phpunit for stable runs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,4 +36,4 @@ jobs:
 
             -   uses: "ramsey/composer-install@v4"
 
-            -   run: vendor/bin/fastunit tests rules-tests utils/phpstan/tests
+            -   run: vendor/bin/phpunit tests rules-tests utils/phpstan/tests


### PR DESCRIPTION
fastunit test runs keep failing intermittently due to order-dependent shared source-locator reflection cache. Switch the tests workflow back to phpunit for stable, deterministic runs.

https://claude.ai/code/session_018nXn7xBmuX9jrY8zZqgAxp