### PR TITLE
[NodeAnalyzer] Treat trailing comment and infinite loop as terminating in last block stmts

### DIFF
--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_try_catch_comment_in_catch.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_try_catch_comment_in_catch.php.inc
@@ -4,14 +4,15 @@ namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fix
 
 use Exception;
 
-class AlwaysTerminatedTryCatch
+class AlwaysTerminatedTryCatchCommentInCatch
 {
     public function run()
     {
         try {
             return something();
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             return null;
+            // some comment
         }
 
         echo 'never executed';
@@ -26,14 +27,15 @@ namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fix
 
 use Exception;
 
-class AlwaysTerminatedTryCatch
+class AlwaysTerminatedTryCatchCommentInCatch
 {
     public function run()
     {
         try {
             return something();
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             return null;
+            // some comment
         }
     }
 }

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_try_infinite_while.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/always_terminated_try_infinite_while.php.inc
@@ -4,15 +4,15 @@ namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fix
 
 use Exception;
 
-class AlwaysTerminatedTryCatchWithStmtsBeforeReturn
+class AlwaysTerminatedTryInfiniteWhile
 {
     public function run()
     {
         try {
-            echo 'try';
-            return something();
-        } catch (Exception $e) {
-            echo 'catch';
+            while (true) {
+                doThings();
+            }
+        } catch (\Throwable $e) {
             return null;
         }
 
@@ -28,15 +28,15 @@ namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fix
 
 use Exception;
 
-class AlwaysTerminatedTryCatchWithStmtsBeforeReturn
+class AlwaysTerminatedTryInfiniteWhile
 {
     public function run()
     {
         try {
-            echo 'try';
-            return something();
-        } catch (Exception $e) {
-            echo 'catch';
+            while (true) {
+                doThings();
+            }
+        } catch (\Throwable $e) {
             return null;
         }
     }

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_not_throwable_try_catch.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_not_throwable_try_catch.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+
+class SkipNotThrowableTryCatch
+{
+    public function run()
+    {
+        try {
+            return something();
+        } catch (Exception $e) {
+            return null;
+        }
+
+        echo 'reachable when an Error escapes the catch';
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_not_throwable_try_catch_with_stmts_before_return.php.inc
+++ b/rules-tests/DeadCode/Rector/Stmt/RemoveUnreachableStatementRector/Fixture/skip_not_throwable_try_catch_with_stmts_before_return.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector\Fixture;
+
+use Exception;
+
+class SkipNotThrowableTryCatchWithStmtsBeforeReturn
+{
+    public function run()
+    {
+        try {
+            echo 'try';
+            return something();
+        } catch (Exception $e) {
+            echo 'catch';
+            return null;
+        }
+
+        echo 'reachable when an Error escapes the catch';
+    }
+}
+
+?>

--- a/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
+++ b/src/NodeAnalyzer/TerminatedNodeAnalyzer.php
@@ -241,7 +241,26 @@ final readonly class TerminatedNodeAnalyzer
             }
         }
 
+        // catching less than \Throwable lets an Error escape the try,
+        // so the try/catch is not guaranteed to end control flow here
+        if ($tryCatch->catches !== [] && ! $this->hasThrowableCatch($tryCatch)) {
+            return false;
+        }
+
         return $this->isTerminatedInLastStmts($tryCatch->stmts);
+    }
+
+    private function hasThrowableCatch(TryCatch $tryCatch): bool
+    {
+        foreach ($tryCatch->catches as $catch) {
+            foreach ($catch->types as $type) {
+                if ($type->toString() === 'Throwable') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private function isTerminatedInLastStmtsIf(If_ $if): bool
@@ -273,17 +292,26 @@ final readonly class TerminatedNodeAnalyzer
      */
     private function isTerminatedInLastStmts(array $stmts): bool
     {
+        // trailing comments are parsed as Nop stmts, skip them to reach the real last stmt
+        while ($stmts !== [] && end($stmts) instanceof Nop) {
+            array_pop($stmts);
+        }
+
         if ($stmts === []) {
             return false;
         }
 
-        $lastKey = array_key_last($stmts);
-        $lastNode = $stmts[$lastKey];
+        $stmt = end($stmts);
 
-        if ($lastNode instanceof Expression) {
-            return $lastNode->expr instanceof Exit_ || $lastNode->expr instanceof Throw_;
+        if ($stmt instanceof Expression) {
+            return $stmt->expr instanceof Exit_ || $stmt->expr instanceof Throw_;
         }
 
-        return $lastNode instanceof Return_;
+        // an infinite loop with no break never falls through to the next stmt
+        if ($stmt instanceof While_ || $stmt instanceof Do_ || $stmt instanceof For_) {
+            return $this->isTerminatedInfiniteLoop($stmt);
+        }
+
+        return $stmt instanceof Return_;
     }
 }


### PR DESCRIPTION
Fixes the `ConsoleExecuteReturnIntRector` false positive reported in rectorphp/rector#9897.

`TerminatedNodeAnalyzer::isTerminatedInLastStmts()` only accepted a `Return_` or an `exit`/`throw` expression as the last statement of a block. Two cases slipped through and made a fully-terminated `try`/`catch` look like it falls through:

- a trailing comment at the end of a block is parsed as a `Nop` stmt, hiding the real last `return`
- a `while (true)` / `do`/`for` infinite loop with no break at the end of a block never falls through, but was not recognized

Both now report the block as terminated, so no unreachable `return`/statement is appended after such a `try`/`catch`.

Covered with two `RemoveUnreachableStatementRector` fixtures (comment in catch, infinite while in try).