### PR TITLE
[Arguments] Fix ReplaceArgumentDefaultValueRector re-applying already-migrated imported class constant

### DIFF
--- a/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Fixture/skip_imported_class_const_already_replaced.php.inc
+++ b/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/Fixture/skip_imported_class_const_already_replaced.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Fixture;
+
+use Rector\Tests\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector\Source\SomeSortableObject;
+
+class SkipImportedClassConstAlreadyReplaced
+{
+    public function run()
+    {
+        $object = new SomeSortableObject();
+        $object->sortBy(SomeSortableObject::SORT_ORDER_DESC);
+    }
+}

--- a/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/config/configured_rule.php
+++ b/rules-tests/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector/config/configured_rule.php
@@ -94,5 +94,13 @@ return static function (RectorConfig $rectorConfig): void {
                 'ASC',
                 'self::SORT_ORDER_DESC'
             ),
+
+            new ReplaceArgumentDefaultValue(
+                SomeSortableObject::class,
+                'sortBy',
+                0,
+                'DESC',
+                SomeSortableObject::class . '::SORT_ORDER_DESC'
+            ),
         ]);
 };

--- a/rules/Arguments/ArgumentDefaultValueReplacer.php
+++ b/rules/Arguments/ArgumentDefaultValueReplacer.php
@@ -165,7 +165,6 @@ final readonly class ArgumentDefaultValueReplacer
             $normalizedValueAfter = $this->normalizeValue($replaceArgumentDefaultValue->getValueAfter());
             if ($particularArg->value instanceof ClassConstFetch
                 && $particularArg->value->class instanceof Name
-                && $particularArg->value->class->isSpecialClassName()
                 && $normalizedValueAfter instanceof ClassConstFetch
                 && is_string($replaceArgumentDefaultValue->getValueAfter())
                 && str_contains($replaceArgumentDefaultValue->getValueAfter(), '::')) {

--- a/rules/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ReplaceArgumentDefaultValueRector.php
@@ -105,7 +105,7 @@ CODE_SAMPLE
                 $currentNode,
                 $replaceArgumentDefaultValue
             );
-            if ($replacedNode !== null && $replacedNode !== $currentNode) {
+            if ($replacedNode !== null) {
                 $currentNode = $replacedNode;
                 $hasChanged = true;
             }
@@ -142,7 +142,7 @@ CODE_SAMPLE
                 $currentNode,
                 $replaceArgumentDefaultValue
             );
-            if ($replacedNode !== null && $replacedNode !== $currentNode) {
+            if ($replacedNode !== null) {
                 $currentNode = $replacedNode;
                 $hasChanged = true;
             }


### PR DESCRIPTION
Fixes [#9898](https://github.com/rectorphp/rector/issues/9898)

## Problem

`ReplaceArgumentDefaultValueRector` had two related defects when a scalar `valueBefore` is migrated to a class constant `valueAfter` (e.g. `'lax'` -> `Cookie::SAMESITE_LAX`):

1. **Re-applies on already-migrated code.** After the first run the argument holds `Cookie::SAMESITE_LAX`, which resolves back to `'lax'`, so the rule matched it again and rewrote the constant to a fully qualified re-fetch on every run. The existing idempotency guard only covered `self::`/`static::`/`parent::` constants (`isSpecialClassName()`), not imported/FQ class constants.

2. **Change not reported in applied rules.** `processReplaces()` mutates the node in place and returns the same instance, but the caller checked `$replacedNode !== $currentNode` - always false - so valid migrations were applied to the AST without being attributed to the rule (diff shown, empty "Applied rules"). The sibling `FunctionArgumentDefaultValueReplacerRector` already uses the correct `instanceof Node` check.

## Fix

- Drop the `isSpecialClassName()` requirement from the already-at-target guard so imported class constants are skipped too.
- Report a change whenever `processReplaces()` returns a non-null node, matching the sibling rule.

## Test

Added `skip_imported_class_const_already_replaced` fixture asserting an argument already holding the target imported constant is left untouched.