### PR TITLE
Do not load both preload files when both conditions hold

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -116,10 +116,8 @@ final class AutoloadIncluder
 
 if (file_exists(__DIR__ . '/../preload.php') && is_dir(__DIR__ . '/../vendor')) {
     require_once __DIR__ . '/../preload.php';
-}
-
-// require rector-src on split packages
-if (file_exists(__DIR__ . '/../preload-split-package.php') && is_dir(__DIR__ . '/../../../../vendor')) {
+} elseif (file_exists(__DIR__ . '/../preload-split-package.php') && is_dir(__DIR__ . '/../../../../vendor')) {
+    // rector-src on split packages
     require_once __DIR__ . '/../preload-split-package.php';
 }
 

--- a/tests/Bin/PreloadTest.php
+++ b/tests/Bin/PreloadTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Bin;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+final class PreloadTest extends TestCase
+{
+    private string $rootDirectory;
+
+    protected function tearDown(): void
+    {
+        if (! isset($this->rootDirectory)) {
+            return;
+        }
+
+        $process = Process::fromShellCommandline('rm -rf ' . escapeshellarg($this->rootDirectory));
+        $process->run();
+    }
+
+    /**
+     * bin/rector.php picks a preload file from two conditions: "I have my own vendor/", so a
+     * monorepo checkout, and "I sit inside a project's vendor/". A checkout with its own vendor/
+     * that also happens to be three levels below another vendor/ answers yes to both. Both preload
+     * files declare isPHPStanTestPreloaded(), so loading both is a fatal error.
+     */
+    public function testPicksOnePreloadFileWhenBothConditionsHold(): void
+    {
+        $this->rootDirectory = sys_get_temp_dir() . '/rector-preload-test-' . uniqid();
+        $repositoryDirectory = $this->rootDirectory . '/a/b/c/repo';
+        mkdir($repositoryDirectory . '/bin', 0777, true);
+
+        $vendorDirectory = realpath(__DIR__ . '/../../vendor');
+        // the first condition, and the paths preload.php requires
+        symlink($vendorDirectory, $repositoryDirectory . '/vendor');
+        // the second condition, and the paths preload-split-package.php requires
+        symlink($vendorDirectory, $this->rootDirectory . '/a/vendor');
+
+        foreach (['bin/rector.php', 'preload.php', 'preload-split-package.php'] as $relativeFilePath) {
+            copy(__DIR__ . '/../../' . $relativeFilePath, $repositoryDirectory . '/' . $relativeFilePath);
+        }
+
+        $process = Process::fromShellCommandline(PHP_BINARY . ' bin/rector.php --version', $repositoryDirectory);
+        $process->run();
+
+        $this->assertStringNotContainsString('Cannot redeclare', $process->getErrorOutput());
+    }
+}


### PR DESCRIPTION
`bin/rector.php` picks a preload file from two conditions, written as two separate `if` statements:

```php
if (file_exists(__DIR__ . '/../preload.php') && is_dir(__DIR__ . '/../vendor')) {
    require_once __DIR__ . '/../preload.php';
}

// require rector-src on split packages
if (file_exists(__DIR__ . '/../preload-split-package.php') && is_dir(__DIR__ . '/../../../../vendor')) {
    require_once __DIR__ . '/../preload-split-package.php';
}
```

Each condition describes a layout, and they read as alternatives. The first is "I have my own `vendor/`", so
a monorepo checkout. The second is "I sit inside a project's `vendor/`". Because they are separate `if`
statements, a checkout that answers yes to both loads both files. Both declare
`isPHPStanTestPreloaded()`, so that is a fatal error.

Neither file's own `return` guard can stop it. A top-level function is declared when the file compiles,
before any of its statements run.

Both intended layouts are unaffected, which I checked by installing `rector/rector-src` as a dependency:

| | `is_dir(../vendor)` | `is_dir(../../../../vendor)` |
| --- | --- | --- |
| `vendor/rector/rector-src` install | false | **true** |
| monorepo checkout with local deps | **true** | false, normally |

The overlap needs a monorepo checkout that has its own `vendor/` **and** sits three levels below another
`vendor/`. phpstan/phpstan clones this repository into `e2e/integration/repo` for an integration test, so
four levels above `bin/` is phpstan's own `vendor/`. Every spawned `bin/rector` there writes nothing, and
`tests/Bin/RectorTest` fails with empty output. See phpstan/phpstan#15156, which works around it for now by
deleting the file after cloning.

`elseif` says what the two conditions already mean.

`tests/Bin/PreloadTest.php` builds the overlapping layout in a temp directory. It uses the real
`bin/rector.php` and both real preload files, and asserts the spawned run does not report
`Cannot redeclare`. It fails before the change and passes after. `vendor/` is symlinked twice so both preload files find the php-parser
paths they require, otherwise the run stops earlier for an unrelated reason.

Full suite: `OK (5273 tests, 6319 assertions)`. ECS is clean.
