### PR TITLE
[CI] Fix drupal-rector dev-main smoke test blocked by stopgap conflict

### DIFF
--- a/.github/workflows/rector_drupal_rector_dev.yaml
+++ b/.github/workflows/rector_drupal_rector_dev.yaml
@@ -25,5 +25,10 @@ jobs:
                     COMPOSER_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
             -   run: git clone https://github.com/palantirnet/drupal-rector.git
+
+                # drupal-rector pins a stopgap "conflict" against rector >=2.6.2 until it ports to composer-based sets;
+                # strip it so dev-main can be smoke-tested here
+            -   run: jq 'del(.conflict."rector/rector")' drupal-rector/composer.json > drupal-rector/composer.tmp.json && mv drupal-rector/composer.tmp.json drupal-rector/composer.json
+
             -   run: composer require rector/rector:dev-main --working-dir drupal-rector
             -   run: cd drupal-rector && vendor/bin/phpunit


### PR DESCRIPTION
The `Rector Drupal with dev-main` job fails at install:

```
palantirnet/drupal-rector dev-main conflicts with rector/rector dev-main
```

drupal-rector added a stopgap `conflict: rector/rector >=2.6.2` (their #420/#421) because rector 2.6.2 removed the version-specific set constants from extension packages in favor of composer-based sets. Their Drupal 8/9/10 configs still reference the old constants, so they pin the conflict until they finish porting (their #419).

That conflict blocks our downstream smoke test even though the actual test suite is compatible - stripping the conflict and running their phpunit gives `OK (695 tests, 954 assertions)` against rector dev-main.

This strips the conflict key before `composer require`, so the smoke test runs again. The one-liner is a no-op once drupal-rector lifts the conflict on their side.

https://claude.ai/code/session_01SETBUG7QqwFNJUXQ42dLf1