### PR TITLE
[Php84] Fix ForeachToArrayAnyRector dropping elseif/else branches

### DIFF
--- a/rules-tests/Php84/Rector/Foreach_/ForeachToArrayAnyRector/Fixture/early_return_skip_if_with_elseif_else.php.inc
+++ b/rules-tests/Php84/Rector/Foreach_/ForeachToArrayAnyRector/Fixture/early_return_skip_if_with_elseif_else.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\Php84\Rector\Foreach_\ForeachToArrayAnyRector\Fixture;
+
+class EarlyReturnSkipIfWithElseIfElse
+{
+    public function run($host, array $noProxyArray)
+    {
+        foreach ($noProxyArray as $area) {
+            if ($area === '*') {
+                return true;
+            } elseif (empty($area)) {
+                continue;
+            } elseif ($area === $host) {
+                return true;
+            } else {
+                $area = '.' . ltrim($area, '.');
+                if (substr($host, -(strlen($area))) === $area) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/rules-tests/Php84/Rector/Foreach_/ForeachToArrayAnyRector/Fixture/skip_boolean_if_with_else.php.inc
+++ b/rules-tests/Php84/Rector/Foreach_/ForeachToArrayAnyRector/Fixture/skip_boolean_if_with_else.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\Php84\Rector\Foreach_\ForeachToArrayAnyRector\Fixture;
+
+class SkipBooleanIfWithElse
+{
+    public function run(array $animals)
+    {
+        $found = false;
+        foreach ($animals as $animal) {
+            if (str_starts_with($animal, 'c')) {
+                $found = true;
+                break;
+            } else {
+                $found = false;
+            }
+        }
+        return $found;
+    }
+}

--- a/rules/Php84/Rector/Foreach_/ForeachToArrayAnyRector.php
+++ b/rules/Php84/Rector/Foreach_/ForeachToArrayAnyRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Break_;
+use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\If_;
@@ -277,6 +278,10 @@ CODE_SAMPLE
             return false;
         }
 
+        if ($firstStmt->elseifs !== [] || $firstStmt->else instanceof Else_) {
+            return false;
+        }
+
         $assignmentStmt = $firstStmt->stmts[0];
         $breakStmt = $firstStmt->stmts[1];
 
@@ -314,6 +319,10 @@ CODE_SAMPLE
         }
 
         $ifStmt = $foreach->stmts[0];
+
+        if ($ifStmt->elseifs !== [] || $ifStmt->else instanceof Else_) {
+            return false;
+        }
 
         if (count($ifStmt->stmts) !== 1) {
             return false;


### PR DESCRIPTION
Fixes [#9900](https://github.com/rectorphp/rector/issues/9900)

Reported via demo: https://getrector.com/demo/47467d38-e31b-478a-ac1e-de0ee5bda472

## Problem

`array_any()` takes a single predicate. When a foreach body is one `if` with `elseif`/`else` branches, the rule kept only the first `if` condition and silently discarded the rest.

The reported Guzzle `is_host_in_noproxy()` collapsed to:

```php
return array_any($noProxyArray, fn($area) => $area === '*');
```

dropping the exact-match, empty-value, and domain-suffix logic - broken output.

## Fix

Bail out in both structure validators when the `if` carries `elseifs` or an `else`, since those branches cannot be represented in a single `array_any` predicate.

Fixtures added for the early-return elseif/else case and the boolean-assignment else case.

https://claude.ai/code/session_01APZKnKT7DBy7AWZ7z3MGDa
