### PR TITLE
Add NarrowBoolDocblockReturnTypeRector to type-declaration-docblocks set

### DIFF
--- a/src/Config/Level/TypeDeclarationDocblocksLevel.php
+++ b/src/Config/Level/TypeDeclarationDocblocksLevel.php
@@ -7,6 +7,7 @@ namespace Rector\Config\Level;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddParamArrayDocblockBasedOnCallableNativeFuncCallRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnDocblockForScalarArrayFromAssignsRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\NarrowBoolDocblockReturnTypeRector;
 use Rector\TypeDeclarationDocblocks\Rector\Class_\AddVarArrayDocblockFromDimFetchAssignRector;
 use Rector\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector;
 use Rector\TypeDeclarationDocblocks\Rector\Class_\DocblockVarArrayFromGetterReturnRector;
@@ -53,5 +54,6 @@ final class TypeDeclarationDocblocksLevel
         // return
         DocblockGetterReturnArrayFromPropertyDocblockVarRector::class,
         NarrowArrayCollectionUnionReturnDocblockRector::class,
+        NarrowBoolDocblockReturnTypeRector::class,
     ];
 }


### PR DESCRIPTION
Registers `NarrowBoolDocblockReturnTypeRector` in the `type-declaration-docblocks` set (via `TypeDeclarationDocblocksLevel::RULES`), alongside the other return docblock narrowing rules.

https://claude.ai/code/session_01JJoiy9Q76AadRMLSz6Xfj3