### PR TITLE
[CI] Tighten duplicated code gate from 400 to 150 tokens

### DIFF
--- a/.github/workflows/duplicated_code.yaml
+++ b/.github/workflows/duplicated_code.yaml
@@ -25,5 +25,5 @@ jobs:
 
             -   run: composer install --no-progress --ansi
 
-            # fails when a large copy-pasted block (>= 400 tokens) is added
+            # fails when a large copy-pasted block (>= 150 tokens) is added
             -   run: composer duplicated-code

--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
         "phpstan": "vendor/bin/phpstan analyse --ansi --memory-limit=512M",
         "rector": "bin/rector process --ansi",
-        "duplicated-code": "php utils/duplicates/bin/duplicates.php --min-lines 5 --min-tokens 400 src rules",
+        "duplicated-code": "php utils/duplicates/bin/duplicates.php --min-lines 5 --min-tokens 150 src rules",
         "preload": "php build/build-preload.php .",
         "release": "vendor/bin/rng --from-commit X --to-commit Y --remote-repository rectorphp/rector-symfony --remote-repository rectorphp/rector-doctrine --remote-repository rectorphp/rector-phpunit"
     },


### PR DESCRIPTION
Now that the sibling-rule de-duplication has landed, `src` and `rules` are clean down to 150 tokens, so the copy-paste gate can be tightened from 400 to 150. This catches much smaller copy-pasted blocks while staying green.

Verified locally: `composer duplicated-code` reports no duplicates at `--min-tokens 150`.