### PR TITLE
 Give the worker the same NDJSON frame limit as the main process

### DIFF
--- a/src/Console/Command/WorkerCommand.php
+++ b/src/Console/Command/WorkerCommand.php
@@ -18,6 +18,7 @@ use Rector\Console\ProcessConfigureDecorator;
 use Rector\Parallel\Enum\Action;
 use Rector\Parallel\Enum\ReactCommand;
 use Rector\Parallel\Enum\ReactEvent;
+use Rector\Parallel\Enum\StreamFormat;
 use Rector\Parallel\ValueObject\Bridge;
 use Rector\StaticReflection\DynamicSourceLocatorDecorator;
 use Rector\Util\MemoryLimiter;
@@ -79,7 +80,7 @@ final class WorkerCommand extends Command
             $input,
             $output
         ): void {
-            $inDecoder = new Decoder($connection, true, 512, JSON_INVALID_UTF8_IGNORE);
+            $inDecoder = new Decoder($connection, true, StreamFormat::DEPTH, JSON_INVALID_UTF8_IGNORE, StreamFormat::MAX_LENGTH);
             $outEncoder = new Encoder($connection, JSON_INVALID_UTF8_IGNORE);
 
             $outEncoder->write([

--- a/src/Parallel/Application/ParallelFileProcessor.php
+++ b/src/Parallel/Application/ParallelFileProcessor.php
@@ -18,6 +18,7 @@ use Rector\Parallel\Enum\Action;
 use Rector\Parallel\Enum\Content;
 use Rector\Parallel\Enum\ReactCommand;
 use Rector\Parallel\Enum\ReactEvent;
+use Rector\Parallel\Enum\StreamFormat;
 use Rector\Parallel\ValueObject\Bridge;
 use Rector\Parallel\ValueObject\ParallelProcess;
 use Rector\Parallel\ValueObject\ProcessPool;
@@ -82,7 +83,7 @@ final class ParallelFileProcessor
         $this->processPool = new ProcessPool($tcpServer);
 
         $tcpServer->on(ReactEvent::CONNECTION, function (ConnectionInterface $connection) use (&$jobs): void {
-            $inDecoder = new Decoder($connection, true, 512, 0, 4 * 1024 * 1024);
+            $inDecoder = new Decoder($connection, true, StreamFormat::DEPTH, 0, StreamFormat::MAX_LENGTH);
             $outEncoder = new Encoder($connection);
 
             $inDecoder->on(ReactEvent::DATA, function (array $data) use (&$jobs, $inDecoder, $outEncoder): void {

--- a/src/Parallel/Enum/StreamFormat.php
+++ b/src/Parallel/Enum/StreamFormat.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Parallel\Enum;
+
+
+final class StreamFormat
+{
+    public const int DEPTH = 512;
+
+    public const int MAX_LENGTH = 4 * 1024 * 1024;
+}

--- a/src/Parallel/Enum/StreamFormat.php
+++ b/src/Parallel/Enum/StreamFormat.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Parallel\Enum;
 
-
 final class StreamFormat
 {
     public const int DEPTH = 512;


### PR DESCRIPTION
A job chunk larger than 64 KB is dropped on arrival at the worker. The run then reports success, having analysed almost nothing:

```
$ vendor/bin/rector process --dry-run   # withParallel(jobSize: 600)
 [OK] Rector is done!
$ echo $?
0
```

Nine seconds, empty stderr, exit code 0 - and **6 files analysed out of 12 492**. Counted by the entries written to the cache directory, because the console output gives no way to tell.

## Root cause

The two ends of the connection disagree about how large a frame may be.

`src/Parallel/Application/ParallelFileProcessor.php` (main process) asks for 4 MB:

```php
$inDecoder = new Decoder($connection, true, 512, 0, 4 * 1024 * 1024);
```

`src/Console/Command/WorkerCommand.php` (worker) omits `$maxlength` and gets the `clue/ndjson-react` default of 64 KB:

```php
$inDecoder = new Decoder($connection, true, 512, JSON_INVALID_UTF8_IGNORE);
```

A job frame carries one chunk of **absolute** file paths, so its size follows path length, not file count. The ceiling is therefore project-specific and moves on its own: a deeper directory tree, a longer checkout prefix (a git worktree sits some forty characters below the main clone) or simply more files per directory all lower it.

## Reproduction

12 762 files, 14 cores, PHP 8.5.10, average absolute path length 115 characters. Each timing repeated in both orders to rule out page-cache effects.

| `jobSize` | wall time | files actually analysed |
| --: | --: | --: |
| 16 (default) | 461 s / 468 s | 12 492 |
| 150 | 124 s / 134 s | 12 494 |
| 300 | 120 s / 116 s | 12 492 |
| **600** | **9 s, `[OK] Rector is done!`, exit 0** | **6** |

The cliff is arithmetic, not load-dependent. The worst 600-path window in this project encodes to **64 868 B** against the **65 536 B** default - 1.01×, right at the edge, which is why 300 passes and 600 does not. Raising `timeoutSeconds` to 900 changes nothing (still 6 files), so it is not the job timeout.

To reproduce on any project: pick `jobSize` such that `jobSize × (average absolute path length + 3)` exceeds 65 536, then compare the number of cache entries written against the file count.

## Why this is not just "pick a smaller jobSize"

Two reasons.

First, there is no signal. The run is green, stderr is empty, and the progress bar reaches 100%. [#8894](https://github.com/rectorphp/rector/issues/8894) reported this same symptom in 2024 - *"Rectorphp silently exits before completing the run"*, exit code 0, tied by the reporter to `jobSize` - and was closed the same day for lack of a reproducible case. The concern raised there still stands: a CI pipeline treats that exit code as proof the code was refactored.

Second, the default `jobSize` of 16 leaves a lot on the table - 461 s against 124 s in the table above, for identical work - so raising it is a reasonable thing for a user to try, and today that is a loaded gun.

## Precedent

Rector's parallel scheduling is derived from PHPStan (`ScheduleFactory` says so). PHPStan sets the limit on **both** ends from a single configurable value:

- `ParallelAnalyser` (main): `maxlength: $this->decoderBufferSize`
- `WorkerRunner` (worker): `maxlength: $this->decoderBufferSize`
- `conf/config.neon`: `parallel: buffer: 134217728  # 128 MB`

Rector's worker limit is currently 64× smaller than its own main process and 2048× smaller than PHPStan's default.